### PR TITLE
Add node info

### DIFF
--- a/data/git-log-tensorflow-stat-v2.csv
+++ b/data/git-log-tensorflow-stat-v2.csv
@@ -1,6 +1,4 @@
 Name,Quarter,File_Changed,Insertions,Deletions
-A. Unique TensorFlower,2021-Q4,0,0,0
-A. Unique TensorFlower,2021-Q3,0,0,0
 A. Unique TensorFlower,2021-Q2,1107,24570,21418
 A. Unique TensorFlower,2021-Q1,3035,54692,34926
 A. Unique TensorFlower,2020-Q4,2679,62249,39214
@@ -15,8 +13,6 @@ A. Unique TensorFlower,2018-Q4,4619,162192,77118
 A. Unique TensorFlower,2018-Q3,5540,173703,68318
 A. Unique TensorFlower,2018-Q2,6026,195958,101799
 A. Unique TensorFlower,2018-Q1,5482,290367,178443
-Jiri Simsa,2021-Q4,0,0,0
-Jiri Simsa,2021-Q3,0,0,0
 Jiri Simsa,2021-Q2,469,9030,10475
 Jiri Simsa,2021-Q1,383,5402,7636
 Jiri Simsa,2020-Q4,33,498,249
@@ -31,8 +27,6 @@ Jiri Simsa,2018-Q4,658,15284,12745
 Jiri Simsa,2018-Q3,505,12481,6380
 Jiri Simsa,2018-Q2,417,19484,5318
 Jiri Simsa,2018-Q1,6,69,25
-Chao Mei,2021-Q4,0,0,0
-Chao Mei,2021-Q3,0,0,0
 Chao Mei,2021-Q2,45,509,237
 Chao Mei,2021-Q1,46,786,206
 Chao Mei,2020-Q4,41,407,339
@@ -47,8 +41,6 @@ Chao Mei,2018-Q4,0,0,0
 Chao Mei,2018-Q3,0,0,0
 Chao Mei,2018-Q2,0,0,0
 Chao Mei,2018-Q1,0,0,0
-Isha Arkatkar,2021-Q4,0,0,0
-Isha Arkatkar,2021-Q3,0,0,0
 Isha Arkatkar,2021-Q2,7,163,12
 Isha Arkatkar,2021-Q1,52,2365,572
 Isha Arkatkar,2020-Q4,0,0,0
@@ -63,8 +55,6 @@ Isha Arkatkar,2018-Q4,0,0,0
 Isha Arkatkar,2018-Q3,0,0,0
 Isha Arkatkar,2018-Q2,0,0,0
 Isha Arkatkar,2018-Q1,0,0,0
-Shivani Agrawal,2021-Q4,0,0,0
-Shivani Agrawal,2021-Q3,0,0,0
 Shivani Agrawal,2021-Q2,3,82,2
 Shivani Agrawal,2021-Q1,2,2,0
 Shivani Agrawal,2020-Q4,0,0,0
@@ -79,8 +69,6 @@ Shivani Agrawal,2018-Q4,204,6980,7304
 Shivani Agrawal,2018-Q3,95,2986,660
 Shivani Agrawal,2018-Q2,38,952,355
 Shivani Agrawal,2018-Q1,34,672,883
-HanBin Yoon,2021-Q4,0,0,0
-HanBin Yoon,2021-Q3,0,0,0
 HanBin Yoon,2021-Q2,10,438,22
 HanBin Yoon,2021-Q1,1,0,2
 HanBin Yoon,2020-Q4,0,0,0
@@ -95,8 +83,6 @@ HanBin Yoon,2018-Q4,0,0,0
 HanBin Yoon,2018-Q3,0,0,0
 HanBin Yoon,2018-Q2,0,0,0
 HanBin Yoon,2018-Q1,0,0,0
-Robert David,2021-Q4,0,0,0
-Robert David,2021-Q3,0,0,0
 Robert David,2021-Q2,14,166,10
 Robert David,2021-Q1,53,908,379
 Robert David,2020-Q4,24,144,147
@@ -111,8 +97,6 @@ Robert David,2018-Q4,0,0,0
 Robert David,2018-Q3,0,0,0
 Robert David,2018-Q2,0,0,0
 Robert David,2018-Q1,0,0,0
-Meghna Natraj,2021-Q4,0,0,0
-Meghna Natraj,2021-Q3,0,0,0
 Meghna Natraj,2021-Q2,23,355,650
 Meghna Natraj,2021-Q1,29,341,329
 Meghna Natraj,2020-Q4,88,3186,2682
@@ -127,8 +111,6 @@ Meghna Natraj,2018-Q4,0,0,0
 Meghna Natraj,2018-Q3,0,0,0
 Meghna Natraj,2018-Q2,0,0,0
 Meghna Natraj,2018-Q1,0,0,0
-Geoffrey Martin-Noble,2021-Q4,0,0,0
-Geoffrey Martin-Noble,2021-Q3,0,0,0
 Geoffrey Martin-Noble,2021-Q2,24,147,39
 Geoffrey Martin-Noble,2021-Q1,43,1838,927
 Geoffrey Martin-Noble,2020-Q4,11,32,67
@@ -143,8 +125,6 @@ Geoffrey Martin-Noble,2018-Q4,0,0,0
 Geoffrey Martin-Noble,2018-Q3,0,0,0
 Geoffrey Martin-Noble,2018-Q2,0,0,0
 Geoffrey Martin-Noble,2018-Q1,0,0,0
-Xiao Yu,2021-Q4,0,0,0
-Xiao Yu,2021-Q3,0,0,0
 Xiao Yu,2021-Q2,17,28,46
 Xiao Yu,2021-Q1,83,1171,625
 Xiao Yu,2020-Q4,26,112,73
@@ -159,8 +139,6 @@ Xiao Yu,2018-Q4,0,0,0
 Xiao Yu,2018-Q3,0,0,0
 Xiao Yu,2018-Q2,0,0,0
 Xiao Yu,2018-Q1,0,0,0
-Tomer Kaftan,2021-Q4,0,0,0
-Tomer Kaftan,2021-Q3,0,0,0
 Tomer Kaftan,2021-Q2,17,103,916
 Tomer Kaftan,2021-Q1,30,479,452
 Tomer Kaftan,2020-Q4,72,2756,728
@@ -175,8 +153,6 @@ Tomer Kaftan,2018-Q4,0,0,0
 Tomer Kaftan,2018-Q3,0,0,0
 Tomer Kaftan,2018-Q2,0,0,0
 Tomer Kaftan,2018-Q1,0,0,0
-Li Lao,2021-Q4,0,0,0
-Li Lao,2021-Q3,0,0,0
 Li Lao,2021-Q2,2,0,37
 Li Lao,2021-Q1,0,0,0
 Li Lao,2020-Q4,0,0,0
@@ -191,8 +167,6 @@ Li Lao,2018-Q4,0,0,0
 Li Lao,2018-Q3,0,0,0
 Li Lao,2018-Q2,0,0,0
 Li Lao,2018-Q1,0,0,0
-Yash Katariya,2021-Q4,0,0,0
-Yash Katariya,2021-Q3,0,0,0
 Yash Katariya,2021-Q2,28,1242,1078
 Yash Katariya,2021-Q1,2,43,0
 Yash Katariya,2020-Q4,8,192,48
@@ -207,8 +181,6 @@ Yash Katariya,2018-Q4,0,0,0
 Yash Katariya,2018-Q3,28,2105,716
 Yash Katariya,2018-Q2,15,2232,56
 Yash Katariya,2018-Q1,0,0,0
-George Karpenkov,2021-Q4,0,0,0
-George Karpenkov,2021-Q3,0,0,0
 George Karpenkov,2021-Q2,95,1813,3532
 George Karpenkov,2021-Q1,178,1751,681
 George Karpenkov,2020-Q4,238,3292,1359
@@ -223,8 +195,6 @@ George Karpenkov,2018-Q4,0,0,0
 George Karpenkov,2018-Q3,0,0,0
 George Karpenkov,2018-Q2,0,0,0
 George Karpenkov,2018-Q1,0,0,0
-Alexander Belyaev,2021-Q4,0,0,0
-Alexander Belyaev,2021-Q3,0,0,0
 Alexander Belyaev,2021-Q2,12,28,23
 Alexander Belyaev,2021-Q1,301,3895,2307
 Alexander Belyaev,2020-Q4,342,2650,3117
@@ -239,8 +209,6 @@ Alexander Belyaev,2018-Q4,0,0,0
 Alexander Belyaev,2018-Q3,0,0,0
 Alexander Belyaev,2018-Q2,0,0,0
 Alexander Belyaev,2018-Q1,0,0,0
-Peter Hawkins,2021-Q4,0,0,0
-Peter Hawkins,2021-Q3,0,0,0
 Peter Hawkins,2021-Q2,129,9706,1233
 Peter Hawkins,2021-Q1,339,4783,3118
 Peter Hawkins,2020-Q4,117,3605,3087
@@ -255,8 +223,6 @@ Peter Hawkins,2018-Q4,1131,9609,8841
 Peter Hawkins,2018-Q3,193,5136,1959
 Peter Hawkins,2018-Q2,737,19985,14844
 Peter Hawkins,2018-Q1,109,4066,1259
-Saurabh Saxena,2021-Q4,0,0,0
-Saurabh Saxena,2021-Q3,0,0,0
 Saurabh Saxena,2021-Q2,25,490,66
 Saurabh Saxena,2021-Q1,0,0,0
 Saurabh Saxena,2020-Q4,64,2222,1327
@@ -271,8 +237,6 @@ Saurabh Saxena,2018-Q4,102,3530,961
 Saurabh Saxena,2018-Q3,60,2839,357
 Saurabh Saxena,2018-Q2,31,2776,353
 Saurabh Saxena,2018-Q1,21,591,83
-Feng Liu,2021-Q4,0,0,0
-Feng Liu,2021-Q3,0,0,0
 Feng Liu,2021-Q2,60,1719,1098
 Feng Liu,2021-Q1,81,1462,566
 Feng Liu,2020-Q4,152,5848,706
@@ -287,8 +251,6 @@ Feng Liu,2018-Q4,96,2544,675
 Feng Liu,2018-Q3,35,306,77
 Feng Liu,2018-Q2,0,0,0
 Feng Liu,2018-Q1,0,0,0
-Berkin Ilbeyi,2021-Q4,0,0,0
-Berkin Ilbeyi,2021-Q3,0,0,0
 Berkin Ilbeyi,2021-Q2,24,855,145
 Berkin Ilbeyi,2021-Q1,17,744,110
 Berkin Ilbeyi,2020-Q4,21,643,194
@@ -303,8 +265,6 @@ Berkin Ilbeyi,2018-Q4,0,0,0
 Berkin Ilbeyi,2018-Q3,0,0,0
 Berkin Ilbeyi,2018-Q2,0,0,0
 Berkin Ilbeyi,2018-Q1,0,0,0
-Mingming Liu,2021-Q4,0,0,0
-Mingming Liu,2021-Q3,0,0,0
 Mingming Liu,2021-Q2,2,25,7
 Mingming Liu,2021-Q1,12,395,24
 Mingming Liu,2020-Q4,10,272,41
@@ -319,8 +279,6 @@ Mingming Liu,2018-Q4,0,0,0
 Mingming Liu,2018-Q3,0,0,0
 Mingming Liu,2018-Q2,0,0,0
 Mingming Liu,2018-Q1,0,0,0
-Rajkumar Samuel,2021-Q4,0,0,0
-Rajkumar Samuel,2021-Q3,0,0,0
 Rajkumar Samuel,2021-Q2,27,564,76
 Rajkumar Samuel,2021-Q1,0,0,0
 Rajkumar Samuel,2020-Q4,0,0,0
@@ -335,8 +293,6 @@ Rajkumar Samuel,2018-Q4,0,0,0
 Rajkumar Samuel,2018-Q3,0,0,0
 Rajkumar Samuel,2018-Q2,0,0,0
 Rajkumar Samuel,2018-Q1,0,0,0
-Roman Dzhabarov,2021-Q4,0,0,0
-Roman Dzhabarov,2021-Q3,0,0,0
 Roman Dzhabarov,2021-Q2,11,67,89
 Roman Dzhabarov,2021-Q1,48,688,309
 Roman Dzhabarov,2020-Q4,16,396,149
@@ -351,8 +307,6 @@ Roman Dzhabarov,2018-Q4,0,0,0
 Roman Dzhabarov,2018-Q3,0,0,0
 Roman Dzhabarov,2018-Q2,0,0,0
 Roman Dzhabarov,2018-Q1,0,0,0
-Tatiana Shpeisman,2021-Q4,0,0,0
-Tatiana Shpeisman,2021-Q3,0,0,0
 Tatiana Shpeisman,2021-Q2,1,20,17
 Tatiana Shpeisman,2021-Q1,5,322,0
 Tatiana Shpeisman,2020-Q4,0,0,0
@@ -367,8 +321,6 @@ Tatiana Shpeisman,2018-Q4,3,14,13
 Tatiana Shpeisman,2018-Q3,161,4013,1024
 Tatiana Shpeisman,2018-Q2,11,250,15
 Tatiana Shpeisman,2018-Q1,12,62,28
-Rahul Joshi,2021-Q4,0,0,0
-Rahul Joshi,2021-Q3,0,0,0
 Rahul Joshi,2021-Q2,113,2188,1282
 Rahul Joshi,2021-Q1,363,6668,3236
 Rahul Joshi,2020-Q4,302,5778,2800
@@ -383,8 +335,6 @@ Rahul Joshi,2018-Q4,0,0,0
 Rahul Joshi,2018-Q3,0,0,0
 Rahul Joshi,2018-Q2,0,0,0
 Rahul Joshi,2018-Q1,0,0,0
-Dan Moldovan,2021-Q4,0,0,0
-Dan Moldovan,2021-Q3,0,0,0
 Dan Moldovan,2021-Q2,103,3756,1228
 Dan Moldovan,2021-Q1,33,303,199
 Dan Moldovan,2020-Q4,61,1137,679
@@ -399,8 +349,6 @@ Dan Moldovan,2018-Q4,312,6549,2967
 Dan Moldovan,2018-Q3,324,8942,5164
 Dan Moldovan,2018-Q2,138,5230,1945
 Dan Moldovan,2018-Q1,2,1974,0
-Smit Hinsu,2021-Q4,0,0,0
-Smit Hinsu,2021-Q3,0,0,0
 Smit Hinsu,2021-Q2,47,707,793
 Smit Hinsu,2021-Q1,125,1830,470
 Smit Hinsu,2020-Q4,217,2963,979
@@ -415,8 +363,6 @@ Smit Hinsu,2018-Q4,43,303,330
 Smit Hinsu,2018-Q3,32,243,331
 Smit Hinsu,2018-Q2,39,734,346
 Smit Hinsu,2018-Q1,6,233,30
-Benjamin Kramer,2021-Q4,0,0,0
-Benjamin Kramer,2021-Q3,0,0,0
 Benjamin Kramer,2021-Q2,19,629,194
 Benjamin Kramer,2021-Q1,166,2403,1325
 Benjamin Kramer,2020-Q4,99,1338,867
@@ -431,8 +377,6 @@ Benjamin Kramer,2018-Q4,237,1676,707
 Benjamin Kramer,2018-Q3,299,3237,6148
 Benjamin Kramer,2018-Q2,100,1378,671
 Benjamin Kramer,2018-Q1,25,222,108
-Stephan Herhut,2021-Q4,0,0,0
-Stephan Herhut,2021-Q3,0,0,0
 Stephan Herhut,2021-Q2,10,50,48
 Stephan Herhut,2021-Q1,301,1859,2124
 Stephan Herhut,2020-Q4,243,3771,5280
@@ -447,8 +391,6 @@ Stephan Herhut,2018-Q4,0,0,0
 Stephan Herhut,2018-Q3,0,0,0
 Stephan Herhut,2018-Q2,0,0,0
 Stephan Herhut,2018-Q1,0,0,0
-Marvin Kim,2021-Q4,0,0,0
-Marvin Kim,2021-Q3,0,0,0
 Marvin Kim,2021-Q2,10,156,69
 Marvin Kim,2021-Q1,4,566,11
 Marvin Kim,2020-Q4,0,0,0
@@ -463,8 +405,6 @@ Marvin Kim,2018-Q4,0,0,0
 Marvin Kim,2018-Q3,0,0,0
 Marvin Kim,2018-Q2,0,0,0
 Marvin Kim,2018-Q1,0,0,0
-Tian Lin,2021-Q4,0,0,0
-Tian Lin,2021-Q3,0,0,0
 Tian Lin,2021-Q2,7,46,35
 Tian Lin,2021-Q1,4,12,2
 Tian Lin,2020-Q4,5,7,7
@@ -479,8 +419,6 @@ Tian Lin,2018-Q4,0,0,0
 Tian Lin,2018-Q3,0,0,0
 Tian Lin,2018-Q2,0,0,0
 Tian Lin,2018-Q1,0,0,0
-Alex Zinenko,2021-Q4,0,0,0
-Alex Zinenko,2021-Q3,0,0,0
 Alex Zinenko,2021-Q2,6,356,141
 Alex Zinenko,2021-Q1,0,0,0
 Alex Zinenko,2020-Q4,11,171,173
@@ -495,8 +433,6 @@ Alex Zinenko,2018-Q4,191,10521,1942
 Alex Zinenko,2018-Q3,0,0,0
 Alex Zinenko,2018-Q2,0,0,0
 Alex Zinenko,2018-Q1,0,0,0
-Jinliang Wei,2021-Q4,0,0,0
-Jinliang Wei,2021-Q3,0,0,0
 Jinliang Wei,2021-Q2,13,495,168
 Jinliang Wei,2021-Q1,0,0,0
 Jinliang Wei,2020-Q4,18,2806,34
@@ -511,8 +447,6 @@ Jinliang Wei,2018-Q4,0,0,0
 Jinliang Wei,2018-Q3,0,0,0
 Jinliang Wei,2018-Q2,0,0,0
 Jinliang Wei,2018-Q1,0,0,0
-Raman Sarokin,2021-Q4,0,0,0
-Raman Sarokin,2021-Q3,0,0,0
 Raman Sarokin,2021-Q2,66,924,244
 Raman Sarokin,2021-Q1,1184,24075,21888
 Raman Sarokin,2020-Q4,1691,24338,19952
@@ -527,8 +461,6 @@ Raman Sarokin,2018-Q4,0,0,0
 Raman Sarokin,2018-Q3,0,0,0
 Raman Sarokin,2018-Q2,0,0,0
 Raman Sarokin,2018-Q1,0,0,0
-Thai Nguyen,2021-Q4,0,0,0
-Thai Nguyen,2021-Q3,0,0,0
 Thai Nguyen,2021-Q2,86,1551,617
 Thai Nguyen,2021-Q1,144,5556,873
 Thai Nguyen,2020-Q4,111,3285,308
@@ -543,8 +475,6 @@ Thai Nguyen,2018-Q4,0,0,0
 Thai Nguyen,2018-Q3,0,0,0
 Thai Nguyen,2018-Q2,0,0,0
 Thai Nguyen,2018-Q1,0,0,0
-Terry Heo,2021-Q4,0,0,0
-Terry Heo,2021-Q3,0,0,0
 Terry Heo,2021-Q2,30,232,213
 Terry Heo,2021-Q1,58,987,396
 Terry Heo,2020-Q4,51,3929,138
@@ -559,8 +489,6 @@ Terry Heo,2018-Q4,0,0,0
 Terry Heo,2018-Q3,0,0,0
 Terry Heo,2018-Q2,0,0,0
 Terry Heo,2018-Q1,0,0,0
-Marat Dukhan,2021-Q4,0,0,0
-Marat Dukhan,2021-Q3,0,0,0
 Marat Dukhan,2021-Q2,34,4787,145
 Marat Dukhan,2021-Q1,9,191,95
 Marat Dukhan,2020-Q4,33,1183,169
@@ -575,8 +503,6 @@ Marat Dukhan,2018-Q4,0,0,0
 Marat Dukhan,2018-Q3,0,0,0
 Marat Dukhan,2018-Q2,0,0,0
 Marat Dukhan,2018-Q1,0,0,0
-Mihai Maruseac,2021-Q4,0,0,0
-Mihai Maruseac,2021-Q3,0,0,0
 Mihai Maruseac,2021-Q2,87,896,545
 Mihai Maruseac,2021-Q1,330,3742,7244
 Mihai Maruseac,2020-Q4,286,1868,8133
@@ -591,8 +517,6 @@ Mihai Maruseac,2018-Q4,522,5569,3462
 Mihai Maruseac,2018-Q3,5,43,4
 Mihai Maruseac,2018-Q2,0,0,0
 Mihai Maruseac,2018-Q1,0,0,0
-Qiao Zhang,2021-Q4,0,0,0
-Qiao Zhang,2021-Q3,0,0,0
 Qiao Zhang,2021-Q2,67,3279,479
 Qiao Zhang,2021-Q1,29,204,54
 Qiao Zhang,2020-Q4,133,3979,2885
@@ -607,8 +531,6 @@ Qiao Zhang,2018-Q4,0,0,0
 Qiao Zhang,2018-Q3,0,0,0
 Qiao Zhang,2018-Q2,0,0,0
 Qiao Zhang,2018-Q1,0,0,0
-Haoliang Zhang,2021-Q4,0,0,0
-Haoliang Zhang,2021-Q3,0,0,0
 Haoliang Zhang,2021-Q2,51,1612,291
 Haoliang Zhang,2021-Q1,40,846,235
 Haoliang Zhang,2020-Q4,3,3,2
@@ -623,8 +545,6 @@ Haoliang Zhang,2018-Q4,0,0,0
 Haoliang Zhang,2018-Q3,0,0,0
 Haoliang Zhang,2018-Q2,0,0,0
 Haoliang Zhang,2018-Q1,0,0,0
-Jing Pu,2021-Q4,0,0,0
-Jing Pu,2021-Q3,0,0,0
 Jing Pu,2021-Q2,4,53,16
 Jing Pu,2021-Q1,3,146,0
 Jing Pu,2020-Q4,6,125,75
@@ -639,8 +559,6 @@ Jing Pu,2018-Q4,0,0,0
 Jing Pu,2018-Q3,0,0,0
 Jing Pu,2018-Q2,0,0,0
 Jing Pu,2018-Q1,0,0,0
-Allen Lavoie,2021-Q4,0,0,0
-Allen Lavoie,2021-Q3,0,0,0
 Allen Lavoie,2021-Q2,14,157,20
 Allen Lavoie,2021-Q1,147,2820,1413
 Allen Lavoie,2020-Q4,119,3198,928
@@ -655,8 +573,6 @@ Allen Lavoie,2018-Q4,225,6553,1847
 Allen Lavoie,2018-Q3,185,4615,1627
 Allen Lavoie,2018-Q2,485,9621,4269
 Allen Lavoie,2018-Q1,335,7141,3328
-Reed Wanderman-Milne,2021-Q4,0,0,0
-Reed Wanderman-Milne,2021-Q3,0,0,0
 Reed Wanderman-Milne,2021-Q2,26,311,308
 Reed Wanderman-Milne,2021-Q1,60,686,159
 Reed Wanderman-Milne,2020-Q4,572,8086,1082
@@ -671,8 +587,6 @@ Reed Wanderman-Milne,2018-Q4,9,206,46
 Reed Wanderman-Milne,2018-Q3,36,290,263
 Reed Wanderman-Milne,2018-Q2,14,331,348
 Reed Wanderman-Milne,2018-Q1,5,24,23
-Yang Chen,2021-Q4,0,0,0
-Yang Chen,2021-Q3,0,0,0
 Yang Chen,2021-Q2,29,521,133
 Yang Chen,2021-Q1,0,0,0
 Yang Chen,2020-Q4,0,0,0
@@ -687,8 +601,6 @@ Yang Chen,2018-Q4,0,0,0
 Yang Chen,2018-Q3,0,0,0
 Yang Chen,2018-Q2,0,0,0
 Yang Chen,2018-Q1,0,0,0
-Daniel Speckhard,2021-Q4,0,0,0
-Daniel Speckhard,2021-Q3,0,0,0
 Daniel Speckhard,2021-Q2,2,2,2
 Daniel Speckhard,2021-Q1,0,0,0
 Daniel Speckhard,2020-Q4,0,0,0
@@ -703,8 +615,6 @@ Daniel Speckhard,2018-Q4,0,0,0
 Daniel Speckhard,2018-Q3,0,0,0
 Daniel Speckhard,2018-Q2,0,0,0
 Daniel Speckhard,2018-Q1,0,0,0
-Prakalp Srivastava,2021-Q4,0,0,0
-Prakalp Srivastava,2021-Q3,0,0,0
 Prakalp Srivastava,2021-Q2,28,833,336
 Prakalp Srivastava,2021-Q1,35,865,137
 Prakalp Srivastava,2020-Q4,60,2109,155
@@ -719,8 +629,6 @@ Prakalp Srivastava,2018-Q4,0,0,0
 Prakalp Srivastava,2018-Q3,0,0,0
 Prakalp Srivastava,2018-Q2,0,0,0
 Prakalp Srivastava,2018-Q1,0,0,0
-Michael Delorimier,2021-Q4,0,0,0
-Michael Delorimier,2021-Q3,0,0,0
 Michael Delorimier,2021-Q2,25,228,182
 Michael Delorimier,2021-Q1,48,1412,70
 Michael Delorimier,2020-Q4,14,495,116
@@ -735,8 +643,6 @@ Michael Delorimier,2018-Q4,0,0,0
 Michael Delorimier,2018-Q3,0,0,0
 Michael Delorimier,2018-Q2,0,0,0
 Michael Delorimier,2018-Q1,0,0,0
-Adrian Kuegel,2021-Q4,0,0,0
-Adrian Kuegel,2021-Q3,0,0,0
 Adrian Kuegel,2021-Q2,79,1495,585
 Adrian Kuegel,2021-Q1,402,3997,2519
 Adrian Kuegel,2020-Q4,173,3467,2212
@@ -751,8 +657,6 @@ Adrian Kuegel,2018-Q4,98,2777,1377
 Adrian Kuegel,2018-Q3,176,3461,1105
 Adrian Kuegel,2018-Q2,34,418,669
 Adrian Kuegel,2018-Q1,0,0,0
-Eugene Zhulenev,2021-Q4,0,0,0
-Eugene Zhulenev,2021-Q3,0,0,0
 Eugene Zhulenev,2021-Q2,11,1058,30
 Eugene Zhulenev,2021-Q1,29,671,374
 Eugene Zhulenev,2020-Q4,14,296,262
@@ -767,8 +671,6 @@ Eugene Zhulenev,2018-Q4,309,12536,4248
 Eugene Zhulenev,2018-Q3,44,4885,1380
 Eugene Zhulenev,2018-Q2,24,2066,361
 Eugene Zhulenev,2018-Q1,0,0,0
-Amit Patankar,2021-Q4,0,0,0
-Amit Patankar,2021-Q3,0,0,0
 Amit Patankar,2021-Q2,63,578,147
 Amit Patankar,2021-Q1,106,923,1490
 Amit Patankar,2020-Q4,130,1576,1367
@@ -783,8 +685,6 @@ Amit Patankar,2018-Q4,117,498,3611
 Amit Patankar,2018-Q3,81,313,228
 Amit Patankar,2018-Q2,75,233,127
 Amit Patankar,2018-Q1,144,775,391
-Hyeonjong Ryu,2021-Q4,0,0,0
-Hyeonjong Ryu,2021-Q3,0,0,0
 Hyeonjong Ryu,2021-Q2,1,2,3
 Hyeonjong Ryu,2021-Q1,31,514,59
 Hyeonjong Ryu,2020-Q4,24,135,315
@@ -799,8 +699,6 @@ Hyeonjong Ryu,2018-Q4,0,0,0
 Hyeonjong Ryu,2018-Q3,0,0,0
 Hyeonjong Ryu,2018-Q2,0,0,0
 Hyeonjong Ryu,2018-Q1,0,0,0
-Jaesung Chung,2021-Q4,0,0,0
-Jaesung Chung,2021-Q3,0,0,0
 Jaesung Chung,2021-Q2,53,740,176
 Jaesung Chung,2021-Q1,219,6011,2339
 Jaesung Chung,2020-Q4,359,7026,942
@@ -815,8 +713,6 @@ Jaesung Chung,2018-Q4,0,0,0
 Jaesung Chung,2018-Q3,0,0,0
 Jaesung Chung,2018-Q2,0,0,0
 Jaesung Chung,2018-Q1,0,0,0
-Shlomi Regev,2021-Q4,0,0,0
-Shlomi Regev,2021-Q3,0,0,0
 Shlomi Regev,2021-Q2,1,4,0
 Shlomi Regev,2021-Q1,46,313,64
 Shlomi Regev,2020-Q4,2,0,0
@@ -831,8 +727,6 @@ Shlomi Regev,2018-Q4,0,0,0
 Shlomi Regev,2018-Q3,0,0,0
 Shlomi Regev,2018-Q2,0,0,0
 Shlomi Regev,2018-Q1,0,0,0
-Renjie Liu,2021-Q4,0,0,0
-Renjie Liu,2021-Q3,0,0,0
 Renjie Liu,2021-Q2,52,258,3540
 Renjie Liu,2021-Q1,37,753,285
 Renjie Liu,2020-Q4,61,1136,1396
@@ -847,8 +741,6 @@ Renjie Liu,2018-Q4,0,0,0
 Renjie Liu,2018-Q3,0,0,0
 Renjie Liu,2018-Q2,0,0,0
 Renjie Liu,2018-Q1,0,0,0
-David Majnemer,2021-Q4,0,0,0
-David Majnemer,2021-Q3,0,0,0
 David Majnemer,2021-Q2,22,479,124
 David Majnemer,2021-Q1,78,1123,378
 David Majnemer,2020-Q4,20,286,85
@@ -863,8 +755,6 @@ David Majnemer,2018-Q4,42,622,322
 David Majnemer,2018-Q3,155,1996,917
 David Majnemer,2018-Q2,54,772,200
 David Majnemer,2018-Q1,23,322,183
-Marcello Maggioni,2021-Q4,0,0,0
-Marcello Maggioni,2021-Q3,0,0,0
 Marcello Maggioni,2021-Q2,3,19,7
 Marcello Maggioni,2021-Q1,96,6382,2198
 Marcello Maggioni,2020-Q4,15,596,117
@@ -879,8 +769,6 @@ Marcello Maggioni,2018-Q4,0,0,0
 Marcello Maggioni,2018-Q3,0,0,0
 Marcello Maggioni,2018-Q2,0,0,0
 Marcello Maggioni,2018-Q1,0,0,0
-T.J. Alumbaugh,2021-Q4,0,0,0
-T.J. Alumbaugh,2021-Q3,0,0,0
 T.J. Alumbaugh,2021-Q2,13,9,14
 T.J. Alumbaugh,2021-Q1,10,124,16
 T.J. Alumbaugh,2020-Q4,40,446,85
@@ -895,8 +783,6 @@ T.J. Alumbaugh,2018-Q4,0,0,0
 T.J. Alumbaugh,2018-Q3,0,0,0
 T.J. Alumbaugh,2018-Q2,0,0,0
 T.J. Alumbaugh,2018-Q1,0,0,0
-Katherine Wu,2021-Q4,0,0,0
-Katherine Wu,2021-Q3,0,0,0
 Katherine Wu,2021-Q2,24,513,88
 Katherine Wu,2021-Q1,59,1825,232
 Katherine Wu,2020-Q4,140,2965,1314
@@ -911,8 +797,6 @@ Katherine Wu,2018-Q4,132,4649,981
 Katherine Wu,2018-Q3,82,4293,2363
 Katherine Wu,2018-Q2,9,765,410
 Katherine Wu,2018-Q1,8,321,41
-Suraj Sudhir,2021-Q4,0,0,0
-Suraj Sudhir,2021-Q3,0,0,0
 Suraj Sudhir,2021-Q2,15,194,770
 Suraj Sudhir,2021-Q1,15,1517,368
 Suraj Sudhir,2020-Q4,41,16405,682
@@ -927,8 +811,6 @@ Suraj Sudhir,2018-Q4,0,0,0
 Suraj Sudhir,2018-Q3,0,0,0
 Suraj Sudhir,2018-Q2,0,0,0
 Suraj Sudhir,2018-Q1,0,0,0
-Monica Song,2021-Q4,0,0,0
-Monica Song,2021-Q3,0,0,0
 Monica Song,2021-Q2,6,221,8
 Monica Song,2021-Q1,34,794,113
 Monica Song,2020-Q4,32,489,458
@@ -943,8 +825,6 @@ Monica Song,2018-Q4,0,0,0
 Monica Song,2018-Q3,0,0,0
 Monica Song,2018-Q2,0,0,0
 Monica Song,2018-Q1,0,0,0
-Edward Loper,2021-Q4,0,0,0
-Edward Loper,2021-Q3,0,0,0
 Edward Loper,2021-Q2,54,4403,449
 Edward Loper,2021-Q1,67,184,160
 Edward Loper,2020-Q4,78,5306,701
@@ -959,8 +839,6 @@ Edward Loper,2018-Q4,0,0,0
 Edward Loper,2018-Q3,0,0,0
 Edward Loper,2018-Q2,0,0,0
 Edward Loper,2018-Q1,0,0,0
-Wenhao Jia,2021-Q4,0,0,0
-Wenhao Jia,2021-Q3,0,0,0
 Wenhao Jia,2021-Q2,1,2,0
 Wenhao Jia,2021-Q1,8,39,17
 Wenhao Jia,2020-Q4,2,73,0
@@ -975,8 +853,6 @@ Wenhao Jia,2018-Q4,0,0,0
 Wenhao Jia,2018-Q3,0,0,0
 Wenhao Jia,2018-Q2,0,0,0
 Wenhao Jia,2018-Q1,0,0,0
-Yunxing Dai,2021-Q4,0,0,0
-Yunxing Dai,2021-Q3,0,0,0
 Yunxing Dai,2021-Q2,58,2787,901
 Yunxing Dai,2021-Q1,112,4021,1020
 Yunxing Dai,2020-Q4,108,2667,376
@@ -991,8 +867,6 @@ Yunxing Dai,2018-Q4,81,4214,205
 Yunxing Dai,2018-Q3,108,855,420
 Yunxing Dai,2018-Q2,30,531,219
 Yunxing Dai,2018-Q1,24,705,384
-Nat Jeffries,2021-Q4,0,0,0
-Nat Jeffries,2021-Q3,0,0,0
 Nat Jeffries,2021-Q2,4,77,120
 Nat Jeffries,2021-Q1,150,4443,2625
 Nat Jeffries,2020-Q4,151,4335,9053
@@ -1007,8 +881,6 @@ Nat Jeffries,2018-Q4,0,0,0
 Nat Jeffries,2018-Q3,0,0,0
 Nat Jeffries,2018-Q2,0,0,0
 Nat Jeffries,2018-Q1,0,0,0
-Tim Shen,2021-Q4,0,0,0
-Tim Shen,2021-Q3,0,0,0
 Tim Shen,2021-Q2,28,333,478
 Tim Shen,2021-Q1,202,7097,3035
 Tim Shen,2020-Q4,299,13891,6119
@@ -1023,8 +895,6 @@ Tim Shen,2018-Q4,98,1522,956
 Tim Shen,2018-Q3,536,5664,5471
 Tim Shen,2018-Q2,0,0,0
 Tim Shen,2018-Q1,0,0,0
-Laura Pak,2021-Q4,0,0,0
-Laura Pak,2021-Q3,0,0,0
 Laura Pak,2021-Q2,6,167,7
 Laura Pak,2021-Q1,55,879,41
 Laura Pak,2020-Q4,0,0,0
@@ -1039,8 +909,6 @@ Laura Pak,2018-Q4,0,0,0
 Laura Pak,2018-Q3,0,0,0
 Laura Pak,2018-Q2,0,0,0
 Laura Pak,2018-Q1,0,0,0
-Amogh Joshi,2021-Q4,0,0,0
-Amogh Joshi,2021-Q3,0,0,0
 Amogh Joshi,2021-Q2,5,42,13
 Amogh Joshi,2021-Q1,7,103,45
 Amogh Joshi,2020-Q4,0,0,0
@@ -1055,8 +923,6 @@ Amogh Joshi,2018-Q4,0,0,0
 Amogh Joshi,2018-Q3,0,0,0
 Amogh Joshi,2018-Q2,0,0,0
 Amogh Joshi,2018-Q1,0,0,0
-Rohan Jain,2021-Q4,0,0,0
-Rohan Jain,2021-Q3,0,0,0
 Rohan Jain,2021-Q2,23,1171,847
 Rohan Jain,2021-Q1,1,0,0
 Rohan Jain,2020-Q4,50,3038,1836
@@ -1071,8 +937,6 @@ Rohan Jain,2018-Q4,258,11429,7546
 Rohan Jain,2018-Q3,221,24098,11844
 Rohan Jain,2018-Q2,53,3157,932
 Rohan Jain,2018-Q1,75,1200,587
-David Pal,2021-Q4,0,0,0
-David Pal,2021-Q3,0,0,0
 David Pal,2021-Q2,2,26,0
 David Pal,2021-Q1,0,0,0
 David Pal,2020-Q4,0,0,0
@@ -1087,8 +951,6 @@ David Pal,2018-Q4,0,0,0
 David Pal,2018-Q3,0,0,0
 David Pal,2018-Q2,0,0,0
 David Pal,2018-Q1,0,0,0
-Matt Watson,2021-Q4,0,0,0
-Matt Watson,2021-Q3,0,0,0
 Matt Watson,2021-Q2,545,2890,2799
 Matt Watson,2021-Q1,190,3036,4893
 Matt Watson,2020-Q4,0,0,0
@@ -1103,8 +965,6 @@ Matt Watson,2018-Q4,0,0,0
 Matt Watson,2018-Q3,0,0,0
 Matt Watson,2018-Q2,0,0,0
 Matt Watson,2018-Q1,0,0,0
-Haitang Hu,2021-Q4,0,0,0
-Haitang Hu,2021-Q3,0,0,0
 Haitang Hu,2021-Q2,4,60,46
 Haitang Hu,2021-Q1,3,23,0
 Haitang Hu,2020-Q4,9,337,44
@@ -1119,8 +979,6 @@ Haitang Hu,2018-Q4,0,0,0
 Haitang Hu,2018-Q3,0,0,0
 Haitang Hu,2018-Q2,0,0,0
 Haitang Hu,2018-Q1,0,0,0
-Ken Franko,2021-Q4,0,0,0
-Ken Franko,2021-Q3,0,0,0
 Ken Franko,2021-Q2,51,1444,273
 Ken Franko,2021-Q1,90,3926,4172
 Ken Franko,2020-Q4,44,1782,186
@@ -1135,8 +993,6 @@ Ken Franko,2018-Q4,0,0,0
 Ken Franko,2018-Q3,0,0,0
 Ken Franko,2018-Q2,0,0,0
 Ken Franko,2018-Q1,0,0,0
-Sanjoy Das,2021-Q4,0,0,0
-Sanjoy Das,2021-Q3,0,0,0
 Sanjoy Das,2021-Q2,29,2436,221
 Sanjoy Das,2021-Q1,239,2821,1509
 Sanjoy Das,2020-Q4,54,391,281
@@ -1151,8 +1007,6 @@ Sanjoy Das,2018-Q4,273,4511,1371
 Sanjoy Das,2018-Q3,502,17853,7540
 Sanjoy Das,2018-Q2,304,10479,4194
 Sanjoy Das,2018-Q1,803,11673,4269
-Yi Situ,2021-Q4,0,0,0
-Yi Situ,2021-Q3,0,0,0
 Yi Situ,2021-Q2,9,115,45
 Yi Situ,2021-Q1,26,202,100
 Yi Situ,2020-Q4,97,2415,1436
@@ -1167,8 +1021,6 @@ Yi Situ,2018-Q4,0,0,0
 Yi Situ,2018-Q3,0,0,0
 Yi Situ,2018-Q2,0,0,0
 Yi Situ,2018-Q1,0,0,0
-Rick Chao,2021-Q4,0,0,0
-Rick Chao,2021-Q3,0,0,0
 Rick Chao,2021-Q2,51,1660,455
 Rick Chao,2021-Q1,90,1265,643
 Rick Chao,2020-Q4,137,3025,1130
@@ -1183,8 +1035,6 @@ Rick Chao,2018-Q4,110,1331,256
 Rick Chao,2018-Q3,0,0,0
 Rick Chao,2018-Q2,0,0,0
 Rick Chao,2018-Q1,0,0,0
-Scott Zhu,2021-Q4,0,0,0
-Scott Zhu,2021-Q3,0,0,0
 Scott Zhu,2021-Q2,111,7512,121
 Scott Zhu,2021-Q1,367,2459,1330
 Scott Zhu,2020-Q4,322,2701,1202
@@ -1199,8 +1049,6 @@ Scott Zhu,2018-Q4,168,7130,4778
 Scott Zhu,2018-Q3,128,2586,1312
 Scott Zhu,2018-Q2,75,1797,402
 Scott Zhu,2018-Q1,0,0,0
-Advait Jain,2021-Q4,0,0,0
-Advait Jain,2021-Q3,0,0,0
 Advait Jain,2021-Q2,34,2567,3199
 Advait Jain,2021-Q1,377,4786,7854
 Advait Jain,2020-Q4,412,6783,11544
@@ -1215,8 +1063,6 @@ Advait Jain,2018-Q4,0,0,0
 Advait Jain,2018-Q3,0,0,0
 Advait Jain,2018-Q2,0,0,0
 Advait Jain,2018-Q1,0,0,0
-Mark Daoust,2021-Q4,0,0,0
-Mark Daoust,2021-Q3,0,0,0
 Mark Daoust,2021-Q2,7,37,10
 Mark Daoust,2021-Q1,16,201,688
 Mark Daoust,2020-Q4,57,1983,3536
@@ -1231,8 +1077,6 @@ Mark Daoust,2018-Q4,61,2836,340
 Mark Daoust,2018-Q3,585,4987,38410
 Mark Daoust,2018-Q2,81,697,304
 Mark Daoust,2018-Q1,108,994,3807
-Tres Popp,2021-Q4,0,0,0
-Tres Popp,2021-Q3,0,0,0
 Tres Popp,2021-Q2,37,1013,553
 Tres Popp,2021-Q1,78,645,599
 Tres Popp,2020-Q4,132,2266,1196
@@ -1247,8 +1091,6 @@ Tres Popp,2018-Q4,0,0,0
 Tres Popp,2018-Q3,0,0,0
 Tres Popp,2018-Q2,0,0,0
 Tres Popp,2018-Q1,0,0,0
-Julian Gross,2021-Q4,0,0,0
-Julian Gross,2021-Q3,0,0,0
 Julian Gross,2021-Q2,4,84,5
 Julian Gross,2021-Q1,0,0,0
 Julian Gross,2020-Q4,0,0,0
@@ -1263,8 +1105,6 @@ Julian Gross,2018-Q4,0,0,0
 Julian Gross,2018-Q3,0,0,0
 Julian Gross,2018-Q2,0,0,0
 Julian Gross,2018-Q1,0,0,0
-Jian Li,2021-Q4,0,0,0
-Jian Li,2021-Q3,0,0,0
 Jian Li,2021-Q2,17,127,43
 Jian Li,2021-Q1,61,1633,153
 Jian Li,2020-Q4,110,3817,19
@@ -1279,8 +1119,6 @@ Jian Li,2018-Q4,114,6772,288
 Jian Li,2018-Q3,18,2360,2
 Jian Li,2018-Q2,0,0,0
 Jian Li,2018-Q1,0,0,0
-Måns Nilsson,2021-Q4,0,0,0
-Måns Nilsson,2021-Q3,0,0,0
 Måns Nilsson,2021-Q2,21,385,261
 Måns Nilsson,2021-Q1,76,1071,348
 Måns Nilsson,2020-Q4,116,1959,1294
@@ -1295,8 +1133,6 @@ Måns Nilsson,2018-Q4,0,0,0
 Måns Nilsson,2018-Q3,0,0,0
 Måns Nilsson,2018-Q2,0,0,0
 Måns Nilsson,2018-Q1,0,0,0
-Christian Sigg,2021-Q4,0,0,0
-Christian Sigg,2021-Q3,0,0,0
 Christian Sigg,2021-Q2,13,56,35
 Christian Sigg,2021-Q1,447,5058,4869
 Christian Sigg,2020-Q4,138,529,540
@@ -1311,8 +1147,6 @@ Christian Sigg,2018-Q4,0,0,0
 Christian Sigg,2018-Q3,0,0,0
 Christian Sigg,2018-Q2,0,0,0
 Christian Sigg,2018-Q1,0,0,0
-Tianrun Li,2021-Q4,0,0,0
-Tianrun Li,2021-Q3,0,0,0
 Tianrun Li,2021-Q2,2,23,13
 Tianrun Li,2021-Q1,23,252,187
 Tianrun Li,2020-Q4,13,134,37
@@ -1327,8 +1161,6 @@ Tianrun Li,2018-Q4,0,0,0
 Tianrun Li,2018-Q3,0,0,0
 Tianrun Li,2018-Q2,0,0,0
 Tianrun Li,2018-Q1,0,0,0
-Kaixi Hou,2021-Q4,0,0,0
-Kaixi Hou,2021-Q3,0,0,0
 Kaixi Hou,2021-Q2,16,235,234
 Kaixi Hou,2021-Q1,188,8265,4371
 Kaixi Hou,2020-Q4,22,994,290
@@ -1343,8 +1175,6 @@ Kaixi Hou,2018-Q4,0,0,0
 Kaixi Hou,2018-Q3,0,0,0
 Kaixi Hou,2018-Q2,0,0,0
 Kaixi Hou,2018-Q1,0,0,0
-Dave Moore,2021-Q4,0,0,0
-Dave Moore,2021-Q3,0,0,0
 Dave Moore,2021-Q2,4,55,16
 Dave Moore,2021-Q1,6,47,8
 Dave Moore,2020-Q4,4,250,38
@@ -1359,8 +1189,6 @@ Dave Moore,2018-Q4,0,0,0
 Dave Moore,2018-Q3,0,0,0
 Dave Moore,2018-Q2,0,0,0
 Dave Moore,2018-Q1,0,0,0
-Andrew Audibert,2021-Q4,0,0,0
-Andrew Audibert,2021-Q3,0,0,0
 Andrew Audibert,2021-Q2,37,868,572
 Andrew Audibert,2021-Q1,238,4729,1837
 Andrew Audibert,2020-Q4,109,1472,496
@@ -1375,8 +1203,6 @@ Andrew Audibert,2018-Q4,0,0,0
 Andrew Audibert,2018-Q3,0,0,0
 Andrew Audibert,2018-Q2,0,0,0
 Andrew Audibert,2018-Q1,0,0,0
-Bixia Zheng,2021-Q4,0,0,0
-Bixia Zheng,2021-Q3,0,0,0
 Bixia Zheng,2021-Q2,7,148,5
 Bixia Zheng,2021-Q1,61,830,542
 Bixia Zheng,2020-Q4,48,918,759
@@ -1391,8 +1217,6 @@ Bixia Zheng,2018-Q4,67,3273,3149
 Bixia Zheng,2018-Q3,57,2041,838
 Bixia Zheng,2018-Q2,56,1515,795
 Bixia Zheng,2018-Q1,94,2913,1758
-Abdurrahman Akkas,2021-Q4,0,0,0
-Abdurrahman Akkas,2021-Q3,0,0,0
 Abdurrahman Akkas,2021-Q2,4,214,10
 Abdurrahman Akkas,2021-Q1,2,10,3
 Abdurrahman Akkas,2020-Q4,10,137,45
@@ -1407,8 +1231,6 @@ Abdurrahman Akkas,2018-Q4,0,0,0
 Abdurrahman Akkas,2018-Q3,0,0,0
 Abdurrahman Akkas,2018-Q2,0,0,0
 Abdurrahman Akkas,2018-Q1,0,0,0
-Russell Power,2021-Q4,0,0,0
-Russell Power,2021-Q3,0,0,0
 Russell Power,2021-Q2,116,403,1025
 Russell Power,2021-Q1,612,1416,12912
 Russell Power,2020-Q4,21,94,149
@@ -1423,8 +1245,6 @@ Russell Power,2018-Q4,57,1891,1310
 Russell Power,2018-Q3,67,2385,755
 Russell Power,2018-Q2,29,1705,552
 Russell Power,2018-Q1,28,803,417
-Kuangyuan Chen,2021-Q4,0,0,0
-Kuangyuan Chen,2021-Q3,0,0,0
 Kuangyuan Chen,2021-Q2,9,95,40
 Kuangyuan Chen,2021-Q1,23,447,169
 Kuangyuan Chen,2020-Q4,49,940,262
@@ -1439,8 +1259,6 @@ Kuangyuan Chen,2018-Q4,0,0,0
 Kuangyuan Chen,2018-Q3,0,0,0
 Kuangyuan Chen,2018-Q2,0,0,0
 Kuangyuan Chen,2018-Q1,0,0,0
-Michael Banfield,2021-Q4,0,0,0
-Michael Banfield,2021-Q3,0,0,0
 Michael Banfield,2021-Q2,2,10,5
 Michael Banfield,2021-Q1,8,23,2
 Michael Banfield,2020-Q4,10,296,50
@@ -1455,8 +1273,6 @@ Michael Banfield,2018-Q4,2,21,12
 Michael Banfield,2018-Q3,21,1537,715
 Michael Banfield,2018-Q2,0,0,0
 Michael Banfield,2018-Q1,0,0,0
-Yu-Cheng Ling,2021-Q4,0,0,0
-Yu-Cheng Ling,2021-Q3,0,0,0
 Yu-Cheng Ling,2021-Q2,17,75,26
 Yu-Cheng Ling,2021-Q1,5,28,17
 Yu-Cheng Ling,2020-Q4,0,0,0
@@ -1471,8 +1287,6 @@ Yu-Cheng Ling,2018-Q4,203,2918,1322
 Yu-Cheng Ling,2018-Q3,183,1506,785
 Yu-Cheng Ling,2018-Q2,131,2449,780
 Yu-Cheng Ling,2018-Q1,126,3200,478
-Austin Anderson,2021-Q4,0,0,0
-Austin Anderson,2021-Q3,0,0,0
 Austin Anderson,2021-Q2,6,5,23
 Austin Anderson,2021-Q1,92,1430,1150
 Austin Anderson,2020-Q4,187,1148,3247
@@ -1487,8 +1301,6 @@ Austin Anderson,2018-Q4,2095,190705,190334
 Austin Anderson,2018-Q3,181,3819,1681
 Austin Anderson,2018-Q2,13,208,351
 Austin Anderson,2018-Q1,114,2660,3991
-Ran Chen,2021-Q4,0,0,0
-Ran Chen,2021-Q3,0,0,0
 Ran Chen,2021-Q2,3,24,21
 Ran Chen,2021-Q1,58,740,811
 Ran Chen,2020-Q4,366,6343,3994
@@ -1503,8 +1315,6 @@ Ran Chen,2018-Q4,0,0,0
 Ran Chen,2018-Q3,0,0,0
 Ran Chen,2018-Q2,0,0,0
 Ran Chen,2018-Q1,0,0,0
-Frank Chen,2021-Q4,0,0,0
-Frank Chen,2021-Q3,0,0,0
 Frank Chen,2021-Q2,4,252,31
 Frank Chen,2021-Q1,124,2214,430
 Frank Chen,2020-Q4,125,1694,1347
@@ -1519,8 +1329,6 @@ Frank Chen,2018-Q4,91,4171,1958
 Frank Chen,2018-Q3,17,107,40
 Frank Chen,2018-Q2,25,416,38
 Frank Chen,2018-Q1,74,850,332
-Jacques Pienaar,2021-Q4,0,0,0
-Jacques Pienaar,2021-Q3,0,0,0
 Jacques Pienaar,2021-Q2,54,620,239
 Jacques Pienaar,2021-Q1,141,1723,1597
 Jacques Pienaar,2020-Q4,67,1337,850
@@ -1535,8 +1343,6 @@ Jacques Pienaar,2018-Q4,181,4682,1590
 Jacques Pienaar,2018-Q3,126,4572,2585
 Jacques Pienaar,2018-Q2,86,1531,243
 Jacques Pienaar,2018-Q1,476,10899,3375
-Jing Dong,2021-Q4,0,0,0
-Jing Dong,2021-Q3,0,0,0
 Jing Dong,2021-Q2,1,0,4
 Jing Dong,2021-Q1,0,0,0
 Jing Dong,2020-Q4,17,132,81
@@ -1551,8 +1357,6 @@ Jing Dong,2018-Q4,0,0,0
 Jing Dong,2018-Q3,0,0,0
 Jing Dong,2018-Q2,0,0,0
 Jing Dong,2018-Q1,0,0,0
-nammbash,2021-Q4,0,0,0
-nammbash,2021-Q3,0,0,0
 nammbash,2021-Q2,2,6,4
 nammbash,2021-Q1,3,13,2
 nammbash,2020-Q4,0,0,0
@@ -1567,8 +1371,6 @@ nammbash,2018-Q4,79,22774,21130
 nammbash,2018-Q3,0,0,0
 nammbash,2018-Q2,0,0,0
 nammbash,2018-Q1,0,0,0
-Michael Gester,2021-Q4,0,0,0
-Michael Gester,2021-Q3,0,0,0
 Michael Gester,2021-Q2,18,1573,1109
 Michael Gester,2021-Q1,30,3199,1318
 Michael Gester,2020-Q4,37,1041,199
@@ -1583,8 +1385,6 @@ Michael Gester,2018-Q4,0,0,0
 Michael Gester,2018-Q3,0,0,0
 Michael Gester,2018-Q2,0,0,0
 Michael Gester,2018-Q1,0,0,0
-Eirikur Agustsson,2021-Q4,0,0,0
-Eirikur Agustsson,2021-Q3,0,0,0
 Eirikur Agustsson,2021-Q2,2,14,6
 Eirikur Agustsson,2021-Q1,0,0,0
 Eirikur Agustsson,2020-Q4,0,0,0
@@ -1599,8 +1399,6 @@ Eirikur Agustsson,2018-Q4,0,0,0
 Eirikur Agustsson,2018-Q3,0,0,0
 Eirikur Agustsson,2018-Q2,0,0,0
 Eirikur Agustsson,2018-Q1,0,0,0
-Stefano Galarraga,2021-Q4,0,0,0
-Stefano Galarraga,2021-Q3,0,0,0
 Stefano Galarraga,2021-Q2,6,126,0
 Stefano Galarraga,2021-Q1,3,8,2
 Stefano Galarraga,2020-Q4,3,168,0
@@ -1615,8 +1413,6 @@ Stefano Galarraga,2018-Q4,0,0,0
 Stefano Galarraga,2018-Q3,0,0,0
 Stefano Galarraga,2018-Q2,0,0,0
 Stefano Galarraga,2018-Q1,0,0,0
-Lu Wang,2021-Q4,0,0,0
-Lu Wang,2021-Q3,0,0,0
 Lu Wang,2021-Q2,7,24,7
 Lu Wang,2021-Q1,20,250,181
 Lu Wang,2020-Q4,14,164,51
@@ -1631,8 +1427,6 @@ Lu Wang,2018-Q4,0,0,0
 Lu Wang,2018-Q3,0,0,0
 Lu Wang,2018-Q2,0,0,0
 Lu Wang,2018-Q1,0,0,0
-wamuir,2021-Q4,0,0,0
-wamuir,2021-Q3,0,0,0
 wamuir,2021-Q2,5,9,0
 wamuir,2021-Q1,1,2,0
 wamuir,2020-Q4,0,0,0
@@ -1647,8 +1441,6 @@ wamuir,2018-Q4,0,0,0
 wamuir,2018-Q3,0,0,0
 wamuir,2018-Q2,0,0,0
 wamuir,2018-Q1,0,0,0
-Loren Maggiore,2021-Q4,0,0,0
-Loren Maggiore,2021-Q3,0,0,0
 Loren Maggiore,2021-Q2,6,78,0
 Loren Maggiore,2021-Q1,6,57,97
 Loren Maggiore,2020-Q4,0,0,0
@@ -1663,8 +1455,6 @@ Loren Maggiore,2018-Q4,0,0,0
 Loren Maggiore,2018-Q3,0,0,0
 Loren Maggiore,2018-Q2,0,0,0
 Loren Maggiore,2018-Q1,0,0,0
-Henri Woodcock,2021-Q4,0,0,0
-Henri Woodcock,2021-Q3,0,0,0
 Henri Woodcock,2021-Q2,1,2,2
 Henri Woodcock,2021-Q1,3,3,4
 Henri Woodcock,2020-Q4,0,0,0
@@ -1679,8 +1469,6 @@ Henri Woodcock,2018-Q4,0,0,0
 Henri Woodcock,2018-Q3,0,0,0
 Henri Woodcock,2018-Q2,0,0,0
 Henri Woodcock,2018-Q1,0,0,0
-Fredrik Knutsson,2021-Q4,0,0,0
-Fredrik Knutsson,2021-Q3,0,0,0
 Fredrik Knutsson,2021-Q2,1,2,2
 Fredrik Knutsson,2021-Q1,5,77,44
 Fredrik Knutsson,2020-Q4,4,38,112
@@ -1695,8 +1483,6 @@ Fredrik Knutsson,2018-Q4,0,0,0
 Fredrik Knutsson,2018-Q3,0,0,0
 Fredrik Knutsson,2018-Q2,0,0,0
 Fredrik Knutsson,2018-Q1,0,0,0
-Vignesh Kothapalli,2021-Q4,0,0,0
-Vignesh Kothapalli,2021-Q3,0,0,0
 Vignesh Kothapalli,2021-Q2,95,911,415
 Vignesh Kothapalli,2021-Q1,415,7712,8994
 Vignesh Kothapalli,2020-Q4,7,54,37
@@ -1711,8 +1497,6 @@ Vignesh Kothapalli,2018-Q4,0,0,0
 Vignesh Kothapalli,2018-Q3,0,0,0
 Vignesh Kothapalli,2018-Q2,0,0,0
 Vignesh Kothapalli,2018-Q1,0,0,0
-Taehee Jeong,2021-Q4,0,0,0
-Taehee Jeong,2021-Q3,0,0,0
 Taehee Jeong,2021-Q2,15,81,26
 Taehee Jeong,2021-Q1,88,2658,942
 Taehee Jeong,2020-Q4,114,2348,860
@@ -1727,8 +1511,6 @@ Taehee Jeong,2018-Q4,0,0,0
 Taehee Jeong,2018-Q3,0,0,0
 Taehee Jeong,2018-Q2,0,0,0
 Taehee Jeong,2018-Q1,0,0,0
-Ian Langmore,2021-Q4,0,0,0
-Ian Langmore,2021-Q3,0,0,0
 Ian Langmore,2021-Q2,2,51,15
 Ian Langmore,2021-Q1,0,0,0
 Ian Langmore,2020-Q4,0,0,0
@@ -1743,8 +1525,6 @@ Ian Langmore,2018-Q4,11,814,32
 Ian Langmore,2018-Q3,22,893,1007
 Ian Langmore,2018-Q2,16,2549,19
 Ian Langmore,2018-Q1,18,1411,330
-Daniel Ellis,2021-Q4,0,0,0
-Daniel Ellis,2021-Q3,0,0,0
 Daniel Ellis,2021-Q2,10,71,2
 Daniel Ellis,2021-Q1,65,2049,245
 Daniel Ellis,2020-Q4,2,5,10
@@ -1759,8 +1539,6 @@ Daniel Ellis,2018-Q4,0,0,0
 Daniel Ellis,2018-Q3,0,0,0
 Daniel Ellis,2018-Q2,0,0,0
 Daniel Ellis,2018-Q1,0,0,0
-Hongmin Fan,2021-Q4,0,0,0
-Hongmin Fan,2021-Q3,0,0,0
 Hongmin Fan,2021-Q2,1,16,0
 Hongmin Fan,2021-Q1,10,378,61
 Hongmin Fan,2020-Q4,4,217,279
@@ -1775,8 +1553,6 @@ Hongmin Fan,2018-Q4,0,0,0
 Hongmin Fan,2018-Q3,0,0,0
 Hongmin Fan,2018-Q2,0,0,0
 Hongmin Fan,2018-Q1,0,0,0
-vishakha.agrawal,2021-Q4,0,0,0
-vishakha.agrawal,2021-Q3,0,0,0
 vishakha.agrawal,2021-Q2,5,44,11
 vishakha.agrawal,2021-Q1,8,31,33
 vishakha.agrawal,2020-Q4,18,471,116
@@ -1791,8 +1567,6 @@ vishakha.agrawal,2018-Q4,0,0,0
 vishakha.agrawal,2018-Q3,0,0,0
 vishakha.agrawal,2018-Q2,0,0,0
 vishakha.agrawal,2018-Q1,0,0,0
-Chris Jones,2021-Q4,0,0,0
-Chris Jones,2021-Q3,0,0,0
 Chris Jones,2021-Q2,14,940,336
 Chris Jones,2021-Q1,14,74,39
 Chris Jones,2020-Q4,106,3088,1679
@@ -1807,8 +1581,6 @@ Chris Jones,2018-Q4,21,123,175
 Chris Jones,2018-Q3,0,0,0
 Chris Jones,2018-Q2,0,0,0
 Chris Jones,2018-Q1,0,0,0
-Yuefeng Zhou,2021-Q4,0,0,0
-Yuefeng Zhou,2021-Q3,0,0,0
 Yuefeng Zhou,2021-Q2,6,328,29
 Yuefeng Zhou,2021-Q1,14,179,37
 Yuefeng Zhou,2020-Q4,26,1366,1283
@@ -1823,8 +1595,6 @@ Yuefeng Zhou,2018-Q4,105,2558,715
 Yuefeng Zhou,2018-Q3,142,8523,1857
 Yuefeng Zhou,2018-Q2,46,1358,201
 Yuefeng Zhou,2018-Q1,84,1556,669
-rsun,2021-Q4,0,0,0
-rsun,2021-Q3,0,0,0
 rsun,2021-Q2,7,526,0
 rsun,2021-Q1,100,2227,1056
 rsun,2020-Q4,22,646,304
@@ -1839,8 +1609,6 @@ rsun,2018-Q4,0,0,0
 rsun,2018-Q3,0,0,0
 rsun,2018-Q2,0,0,0
 rsun,2018-Q1,0,0,0
-Zhuo Peng,2021-Q4,0,0,0
-Zhuo Peng,2021-Q3,0,0,0
 Zhuo Peng,2021-Q2,5,2,18
 Zhuo Peng,2021-Q1,3,16,2
 Zhuo Peng,2020-Q4,8,125,5
@@ -1855,8 +1623,6 @@ Zhuo Peng,2018-Q4,0,0,0
 Zhuo Peng,2018-Q3,0,0,0
 Zhuo Peng,2018-Q2,0,0,0
 Zhuo Peng,2018-Q1,0,0,0
-George Necula,2021-Q4,0,0,0
-George Necula,2021-Q3,0,0,0
 George Necula,2021-Q2,3,8,0
 George Necula,2021-Q1,2,9,3
 George Necula,2020-Q4,0,0,0
@@ -1871,8 +1637,6 @@ George Necula,2018-Q4,0,0,0
 George Necula,2018-Q3,0,0,0
 George Necula,2018-Q2,0,0,0
 George Necula,2018-Q1,0,0,0
-Chenkai Kuang,2021-Q4,0,0,0
-Chenkai Kuang,2021-Q3,0,0,0
 Chenkai Kuang,2021-Q2,20,205,754
 Chenkai Kuang,2021-Q1,41,1186,383
 Chenkai Kuang,2020-Q4,73,2025,658
@@ -1887,8 +1651,6 @@ Chenkai Kuang,2018-Q4,0,0,0
 Chenkai Kuang,2018-Q3,0,0,0
 Chenkai Kuang,2018-Q2,0,0,0
 Chenkai Kuang,2018-Q1,0,0,0
-Nick Kreeger,2021-Q4,0,0,0
-Nick Kreeger,2021-Q3,0,0,0
 Nick Kreeger,2021-Q2,2,71,5
 Nick Kreeger,2021-Q1,0,0,0
 Nick Kreeger,2020-Q4,132,1085,1217
@@ -1903,8 +1665,6 @@ Nick Kreeger,2018-Q4,0,0,0
 Nick Kreeger,2018-Q3,11,686,80
 Nick Kreeger,2018-Q2,0,0,0
 Nick Kreeger,2018-Q1,4,18,3
-bhanu prakash bandaru venkata,2021-Q4,0,0,0
-bhanu prakash bandaru venkata,2021-Q3,0,0,0
 bhanu prakash bandaru venkata,2021-Q2,10,135,24
 bhanu prakash bandaru venkata,2021-Q1,0,0,0
 bhanu prakash bandaru venkata,2020-Q4,0,0,0
@@ -1919,8 +1679,6 @@ bhanu prakash bandaru venkata,2018-Q4,0,0,0
 bhanu prakash bandaru venkata,2018-Q3,0,0,0
 bhanu prakash bandaru venkata,2018-Q2,0,0,0
 bhanu prakash bandaru venkata,2018-Q1,0,0,0
-Yuqi Li,2021-Q4,0,0,0
-Yuqi Li,2021-Q3,0,0,0
 Yuqi Li,2021-Q2,7,82,64
 Yuqi Li,2021-Q1,3,10,8
 Yuqi Li,2020-Q4,1,0,0
@@ -1935,8 +1693,6 @@ Yuqi Li,2018-Q4,0,0,0
 Yuqi Li,2018-Q3,0,0,0
 Yuqi Li,2018-Q2,0,0,0
 Yuqi Li,2018-Q1,0,0,0
-Sean Morgan,2021-Q4,0,0,0
-Sean Morgan,2021-Q3,0,0,0
 Sean Morgan,2021-Q2,1,2,0
 Sean Morgan,2021-Q1,0,0,0
 Sean Morgan,2020-Q4,0,0,0
@@ -1951,8 +1707,6 @@ Sean Morgan,2018-Q4,0,0,0
 Sean Morgan,2018-Q3,0,0,0
 Sean Morgan,2018-Q2,0,0,0
 Sean Morgan,2018-Q1,0,0,0
-Skye Wanderman-Milne,2021-Q4,0,0,0
-Skye Wanderman-Milne,2021-Q3,0,0,0
 Skye Wanderman-Milne,2021-Q2,18,97,80
 Skye Wanderman-Milne,2021-Q1,32,192,102
 Skye Wanderman-Milne,2020-Q4,22,736,21
@@ -1967,8 +1721,6 @@ Skye Wanderman-Milne,2018-Q4,157,4153,2647
 Skye Wanderman-Milne,2018-Q3,60,788,613
 Skye Wanderman-Milne,2018-Q2,181,2589,2600
 Skye Wanderman-Milne,2018-Q1,219,4844,3032
-Lisa Wang,2021-Q4,0,0,0
-Lisa Wang,2021-Q3,0,0,0
 Lisa Wang,2021-Q2,1,7,7
 Lisa Wang,2021-Q1,0,0,0
 Lisa Wang,2020-Q4,0,0,0
@@ -1983,8 +1735,6 @@ Lisa Wang,2018-Q4,0,0,0
 Lisa Wang,2018-Q3,0,0,0
 Lisa Wang,2018-Q2,0,0,0
 Lisa Wang,2018-Q1,0,0,0
-Karim Nosir,2021-Q4,0,0,0
-Karim Nosir,2021-Q3,0,0,0
 Karim Nosir,2021-Q2,53,1219,184
 Karim Nosir,2021-Q1,65,1431,200
 Karim Nosir,2020-Q4,125,3070,358
@@ -1999,8 +1749,6 @@ Karim Nosir,2018-Q4,40,1187,39
 Karim Nosir,2018-Q3,0,0,0
 Karim Nosir,2018-Q2,0,0,0
 Karim Nosir,2018-Q1,0,0,0
-Chuanhao Zhuge,2021-Q4,0,0,0
-Chuanhao Zhuge,2021-Q3,0,0,0
 Chuanhao Zhuge,2021-Q2,34,298,72
 Chuanhao Zhuge,2021-Q1,49,359,68
 Chuanhao Zhuge,2020-Q4,47,320,142
@@ -2015,8 +1763,6 @@ Chuanhao Zhuge,2018-Q4,0,0,0
 Chuanhao Zhuge,2018-Q3,0,0,0
 Chuanhao Zhuge,2018-Q2,0,0,0
 Chuanhao Zhuge,2018-Q1,0,0,0
-Andy Ly,2021-Q4,0,0,0
-Andy Ly,2021-Q3,0,0,0
 Andy Ly,2021-Q2,1,0,0
 Andy Ly,2021-Q1,44,3807,1049
 Andy Ly,2020-Q4,256,8559,3566
@@ -2031,8 +1777,6 @@ Andy Ly,2018-Q4,30,1562,529
 Andy Ly,2018-Q3,0,0,0
 Andy Ly,2018-Q2,0,0,0
 Andy Ly,2018-Q1,0,0,0
-Yong Tang,2021-Q4,0,0,0
-Yong Tang,2021-Q3,0,0,0
 Yong Tang,2021-Q2,8,15,35
 Yong Tang,2021-Q1,38,227,51
 Yong Tang,2020-Q4,17,99,41
@@ -2047,8 +1791,6 @@ Yong Tang,2018-Q4,107,546,283
 Yong Tang,2018-Q3,219,3075,884
 Yong Tang,2018-Q2,395,3815,780
 Yong Tang,2018-Q1,233,3538,838
-Joshua Maynez,2021-Q4,0,0,0
-Joshua Maynez,2021-Q3,0,0,0
 Joshua Maynez,2021-Q2,1,5,0
 Joshua Maynez,2021-Q1,0,0,0
 Joshua Maynez,2020-Q4,0,0,0
@@ -2063,8 +1805,6 @@ Joshua Maynez,2018-Q4,0,0,0
 Joshua Maynez,2018-Q3,0,0,0
 Joshua Maynez,2018-Q2,0,0,0
 Joshua Maynez,2018-Q1,0,0,0
-Jay Shi,2021-Q4,0,0,0
-Jay Shi,2021-Q3,0,0,0
 Jay Shi,2021-Q2,18,384,415
 Jay Shi,2021-Q1,132,3386,543
 Jay Shi,2020-Q4,62,1065,549
@@ -2079,8 +1819,6 @@ Jay Shi,2018-Q4,0,0,0
 Jay Shi,2018-Q3,0,0,0
 Jay Shi,2018-Q2,0,0,0
 Jay Shi,2018-Q1,0,0,0
-Gaurav Jain,2021-Q4,0,0,0
-Gaurav Jain,2021-Q3,0,0,0
 Gaurav Jain,2021-Q2,1,26,2
 Gaurav Jain,2021-Q1,0,0,0
 Gaurav Jain,2020-Q4,1,0,0
@@ -2095,8 +1833,6 @@ Gaurav Jain,2018-Q4,1457,17087,11190
 Gaurav Jain,2018-Q3,0,0,0
 Gaurav Jain,2018-Q2,0,0,0
 Gaurav Jain,2018-Q1,0,0,0
-River Riddle,2021-Q4,0,0,0
-River Riddle,2021-Q3,0,0,0
 River Riddle,2021-Q2,1,300,169
 River Riddle,2021-Q1,2,23,35
 River Riddle,2020-Q4,358,374,546
@@ -2111,8 +1847,6 @@ River Riddle,2018-Q4,212,4971,3405
 River Riddle,2018-Q3,0,0,0
 River Riddle,2018-Q2,0,0,0
 River Riddle,2018-Q1,0,0,0
-YoungSeok Yoon,2021-Q4,0,0,0
-YoungSeok Yoon,2021-Q3,0,0,0
 YoungSeok Yoon,2021-Q2,7,28,12
 YoungSeok Yoon,2021-Q1,24,406,2
 YoungSeok Yoon,2020-Q4,155,276,325
@@ -2127,8 +1861,6 @@ YoungSeok Yoon,2018-Q4,0,0,0
 YoungSeok Yoon,2018-Q3,0,0,0
 YoungSeok Yoon,2018-Q2,0,0,0
 YoungSeok Yoon,2018-Q1,0,0,0
-Jean-Baptiste Lespiau,2021-Q4,0,0,0
-Jean-Baptiste Lespiau,2021-Q3,0,0,0
 Jean-Baptiste Lespiau,2021-Q2,3,56,40
 Jean-Baptiste Lespiau,2021-Q1,49,1531,449
 Jean-Baptiste Lespiau,2020-Q4,41,1267,851
@@ -2143,8 +1875,6 @@ Jean-Baptiste Lespiau,2018-Q4,0,0,0
 Jean-Baptiste Lespiau,2018-Q3,0,0,0
 Jean-Baptiste Lespiau,2018-Q2,0,0,0
 Jean-Baptiste Lespiau,2018-Q1,0,0,0
-Ilya Tokar,2021-Q4,0,0,0
-Ilya Tokar,2021-Q3,0,0,0
 Ilya Tokar,2021-Q2,1,42,0
 Ilya Tokar,2021-Q1,0,0,0
 Ilya Tokar,2020-Q4,1,115,57
@@ -2159,8 +1889,6 @@ Ilya Tokar,2018-Q4,0,0,0
 Ilya Tokar,2018-Q3,0,0,0
 Ilya Tokar,2018-Q2,0,0,0
 Ilya Tokar,2018-Q1,0,0,0
-Williard Joshua Jose,2021-Q4,0,0,0
-Williard Joshua Jose,2021-Q3,0,0,0
 Williard Joshua Jose,2021-Q2,6,30,17
 Williard Joshua Jose,2021-Q1,0,0,0
 Williard Joshua Jose,2020-Q4,0,0,0
@@ -2175,8 +1903,6 @@ Williard Joshua Jose,2018-Q4,0,0,0
 Williard Joshua Jose,2018-Q3,0,0,0
 Williard Joshua Jose,2018-Q2,0,0,0
 Williard Joshua Jose,2018-Q1,0,0,0
-Ben Barsdell,2021-Q4,0,0,0
-Ben Barsdell,2021-Q3,0,0,0
 Ben Barsdell,2021-Q2,11,163,144
 Ben Barsdell,2021-Q1,93,3166,1005
 Ben Barsdell,2020-Q4,47,2733,1277
@@ -2191,8 +1917,6 @@ Ben Barsdell,2018-Q4,2,2,4
 Ben Barsdell,2018-Q3,0,0,0
 Ben Barsdell,2018-Q2,7,262,22
 Ben Barsdell,2018-Q1,5,139,9
-Jiri Podivin,2021-Q4,0,0,0
-Jiri Podivin,2021-Q3,0,0,0
 Jiri Podivin,2021-Q2,1,3,4
 Jiri Podivin,2021-Q1,0,0,0
 Jiri Podivin,2020-Q4,0,0,0
@@ -2207,8 +1931,6 @@ Jiri Podivin,2018-Q4,0,0,0
 Jiri Podivin,2018-Q3,0,0,0
 Jiri Podivin,2018-Q2,0,0,0
 Jiri Podivin,2018-Q1,0,0,0
-Geeta Chavan,2021-Q4,0,0,0
-Geeta Chavan,2021-Q3,0,0,0
 Geeta Chavan,2021-Q2,3,0,0
 Geeta Chavan,2021-Q1,14,29,29
 Geeta Chavan,2020-Q4,59,483,492
@@ -2223,8 +1945,6 @@ Geeta Chavan,2018-Q4,0,0,0
 Geeta Chavan,2018-Q3,0,0,0
 Geeta Chavan,2018-Q2,0,0,0
 Geeta Chavan,2018-Q1,0,0,0
-Fergus Henderson,2021-Q4,0,0,0
-Fergus Henderson,2021-Q3,0,0,0
 Fergus Henderson,2021-Q2,31,1289,56
 Fergus Henderson,2021-Q1,101,2496,545
 Fergus Henderson,2020-Q4,110,2182,1118
@@ -2239,8 +1959,6 @@ Fergus Henderson,2018-Q4,0,0,0
 Fergus Henderson,2018-Q3,0,0,0
 Fergus Henderson,2018-Q2,0,0,0
 Fergus Henderson,2018-Q1,0,0,0
-Sachin Joglekar,2021-Q4,0,0,0
-Sachin Joglekar,2021-Q3,0,0,0
 Sachin Joglekar,2021-Q2,9,692,12
 Sachin Joglekar,2021-Q1,19,299,151
 Sachin Joglekar,2020-Q4,58,3690,1227
@@ -2255,8 +1973,6 @@ Sachin Joglekar,2018-Q4,37,951,112
 Sachin Joglekar,2018-Q3,0,0,0
 Sachin Joglekar,2018-Q2,0,0,0
 Sachin Joglekar,2018-Q1,0,0,0
-Jared Duke,2021-Q4,0,0,0
-Jared Duke,2021-Q3,0,0,0
 Jared Duke,2021-Q2,30,146,1306
 Jared Duke,2021-Q1,77,1100,682
 Jared Duke,2020-Q4,41,255,283
@@ -2271,8 +1987,6 @@ Jared Duke,2018-Q4,183,3654,728
 Jared Duke,2018-Q3,316,7178,1761
 Jared Duke,2018-Q2,26,734,25
 Jared Duke,2018-Q1,0,0,0
-Haoyu Zhang,2021-Q4,0,0,0
-Haoyu Zhang,2021-Q3,0,0,0
 Haoyu Zhang,2021-Q2,3,172,0
 Haoyu Zhang,2021-Q1,9,53,77
 Haoyu Zhang,2020-Q4,50,1225,1053
@@ -2287,8 +2001,6 @@ Haoyu Zhang,2018-Q4,0,0,0
 Haoyu Zhang,2018-Q3,0,0,0
 Haoyu Zhang,2018-Q2,0,0,0
 Haoyu Zhang,2018-Q1,0,0,0
-Dero Gharibian,2021-Q4,0,0,0
-Dero Gharibian,2021-Q3,0,0,0
 Dero Gharibian,2021-Q2,3,23,32
 Dero Gharibian,2021-Q1,0,0,0
 Dero Gharibian,2020-Q4,0,0,0
@@ -2303,8 +2015,6 @@ Dero Gharibian,2018-Q4,0,0,0
 Dero Gharibian,2018-Q3,0,0,0
 Dero Gharibian,2018-Q2,0,0,0
 Dero Gharibian,2018-Q1,0,0,0
-Thomas Köppe,2021-Q4,0,0,0
-Thomas Köppe,2021-Q3,0,0,0
 Thomas Köppe,2021-Q2,1,11,0
 Thomas Köppe,2021-Q1,1,0,0
 Thomas Köppe,2020-Q4,0,0,0
@@ -2319,8 +2029,6 @@ Thomas Köppe,2018-Q4,0,0,0
 Thomas Köppe,2018-Q3,0,0,0
 Thomas Köppe,2018-Q2,0,0,0
 Thomas Köppe,2018-Q1,0,0,0
-Robert Kalmar,2021-Q4,0,0,0
-Robert Kalmar,2021-Q3,0,0,0
 Robert Kalmar,2021-Q2,2,22,2
 Robert Kalmar,2021-Q1,0,0,0
 Robert Kalmar,2020-Q4,0,0,0
@@ -2335,8 +2043,6 @@ Robert Kalmar,2018-Q4,0,0,0
 Robert Kalmar,2018-Q3,0,0,0
 Robert Kalmar,2018-Q2,0,0,0
 Robert Kalmar,2018-Q1,0,0,0
-Hengwen Tong,2021-Q4,0,0,0
-Hengwen Tong,2021-Q3,0,0,0
 Hengwen Tong,2021-Q2,1,0,0
 Hengwen Tong,2021-Q1,0,0,0
 Hengwen Tong,2020-Q4,0,0,0
@@ -2351,8 +2057,6 @@ Hengwen Tong,2018-Q4,0,0,0
 Hengwen Tong,2018-Q3,0,0,0
 Hengwen Tong,2018-Q2,0,0,0
 Hengwen Tong,2018-Q1,0,0,0
-Soojeong,2021-Q4,0,0,0
-Soojeong,2021-Q3,0,0,0
 Soojeong,2021-Q2,2,38,7
 Soojeong,2021-Q1,0,0,0
 Soojeong,2020-Q4,0,0,0
@@ -2367,8 +2071,6 @@ Soojeong,2018-Q4,0,0,0
 Soojeong,2018-Q3,0,0,0
 Soojeong,2018-Q2,0,0,0
 Soojeong,2018-Q1,0,0,0
-Juanli Shen,2021-Q4,0,0,0
-Juanli Shen,2021-Q3,0,0,0
 Juanli Shen,2021-Q2,6,36,20
 Juanli Shen,2021-Q1,2,5,7
 Juanli Shen,2020-Q4,0,0,0
@@ -2383,8 +2085,6 @@ Juanli Shen,2018-Q4,0,0,0
 Juanli Shen,2018-Q3,0,0,0
 Juanli Shen,2018-Q2,0,0,0
 Juanli Shen,2018-Q1,0,0,0
-Trent Lo,2021-Q4,0,0,0
-Trent Lo,2021-Q3,0,0,0
 Trent Lo,2021-Q2,9,115,107
 Trent Lo,2021-Q1,23,1002,143
 Trent Lo,2020-Q4,28,508,117
@@ -2399,8 +2099,6 @@ Trent Lo,2018-Q4,0,0,0
 Trent Lo,2018-Q3,0,0,0
 Trent Lo,2018-Q2,0,0,0
 Trent Lo,2018-Q1,0,0,0
-Ruoxin Sang,2021-Q4,0,0,0
-Ruoxin Sang,2021-Q3,0,0,0
 Ruoxin Sang,2021-Q2,10,61,126
 Ruoxin Sang,2021-Q1,70,772,514
 Ruoxin Sang,2020-Q4,21,185,114
@@ -2415,8 +2113,6 @@ Ruoxin Sang,2018-Q4,13,136,76
 Ruoxin Sang,2018-Q3,4,8,11
 Ruoxin Sang,2018-Q2,28,820,344
 Ruoxin Sang,2018-Q1,0,0,0
-Mehdi Amini,2021-Q4,0,0,0
-Mehdi Amini,2021-Q3,0,0,0
 Mehdi Amini,2021-Q2,33,507,367
 Mehdi Amini,2021-Q1,61,824,276
 Mehdi Amini,2020-Q4,12,92,26
@@ -2431,8 +2127,6 @@ Mehdi Amini,2018-Q4,3,63,36
 Mehdi Amini,2018-Q3,0,0,0
 Mehdi Amini,2018-Q2,0,0,0
 Mehdi Amini,2018-Q1,0,0,0
-Andrew Selle,2021-Q4,0,0,0
-Andrew Selle,2021-Q3,0,0,0
 Andrew Selle,2021-Q2,7,36,33
 Andrew Selle,2021-Q1,18,437,64
 Andrew Selle,2020-Q4,0,0,0
@@ -2447,8 +2141,6 @@ Andrew Selle,2018-Q4,149,5382,3048
 Andrew Selle,2018-Q3,66,4411,2361
 Andrew Selle,2018-Q2,36,1339,134
 Andrew Selle,2018-Q1,55,2974,129
-wcn,2021-Q4,0,0,0
-wcn,2021-Q3,0,0,0
 wcn,2021-Q2,1,3,4
 wcn,2021-Q1,0,0,0
 wcn,2020-Q4,0,0,0
@@ -2463,8 +2155,6 @@ wcn,2018-Q4,0,0,0
 wcn,2018-Q3,0,0,0
 wcn,2018-Q2,0,0,0
 wcn,2018-Q1,0,0,0
-evelynmitchell,2021-Q4,0,0,0
-evelynmitchell,2021-Q3,0,0,0
 evelynmitchell,2021-Q2,2,3,0
 evelynmitchell,2021-Q1,0,0,0
 evelynmitchell,2020-Q4,0,0,0
@@ -2479,8 +2169,6 @@ evelynmitchell,2018-Q4,0,0,0
 evelynmitchell,2018-Q3,0,0,0
 evelynmitchell,2018-Q2,0,0,0
 evelynmitchell,2018-Q1,0,0,0
-Bruce Fontaine,2021-Q4,0,0,0
-Bruce Fontaine,2021-Q3,0,0,0
 Bruce Fontaine,2021-Q2,2,69,2
 Bruce Fontaine,2021-Q1,17,305,37
 Bruce Fontaine,2020-Q4,17,1010,552
@@ -2495,8 +2183,6 @@ Bruce Fontaine,2018-Q4,0,0,0
 Bruce Fontaine,2018-Q3,0,0,0
 Bruce Fontaine,2018-Q2,0,0,0
 Bruce Fontaine,2018-Q1,0,0,0
-Lukas Geiger,2021-Q4,0,0,0
-Lukas Geiger,2021-Q3,0,0,0
 Lukas Geiger,2021-Q2,26,139,282
 Lukas Geiger,2021-Q1,61,467,520
 Lukas Geiger,2020-Q4,27,257,159
@@ -2511,8 +2197,6 @@ Lukas Geiger,2018-Q4,0,0,0
 Lukas Geiger,2018-Q3,5,11,12
 Lukas Geiger,2018-Q2,14,121,24
 Lukas Geiger,2018-Q1,4,58,5
-Hanhan Wang,2021-Q4,0,0,0
-Hanhan Wang,2021-Q3,0,0,0
 Hanhan Wang,2021-Q2,15,403,41
 Hanhan Wang,2021-Q1,24,1841,161
 Hanhan Wang,2020-Q4,2,256,253
@@ -2527,8 +2211,6 @@ Hanhan Wang,2018-Q4,0,0,0
 Hanhan Wang,2018-Q3,0,0,0
 Hanhan Wang,2018-Q2,0,0,0
 Hanhan Wang,2018-Q1,0,0,0
-William Chargin,2021-Q4,0,0,0
-William Chargin,2021-Q3,0,0,0
 William Chargin,2021-Q2,2,0,0
 William Chargin,2021-Q1,3,2,2
 William Chargin,2020-Q4,1,0,0
@@ -2543,8 +2225,6 @@ William Chargin,2018-Q4,0,0,0
 William Chargin,2018-Q3,0,0,0
 William Chargin,2018-Q2,0,0,0
 William Chargin,2018-Q1,0,0,0
-Khanh LeViet,2021-Q4,0,0,0
-Khanh LeViet,2021-Q3,0,0,0
 Khanh LeViet,2021-Q2,1,4,4
 Khanh LeViet,2021-Q1,6,240,183
 Khanh LeViet,2020-Q4,1,4,4
@@ -2559,8 +2239,6 @@ Khanh LeViet,2018-Q4,0,0,0
 Khanh LeViet,2018-Q3,0,0,0
 Khanh LeViet,2018-Q2,0,0,0
 Khanh LeViet,2018-Q1,0,0,0
-Hyeonji Lee,2021-Q4,0,0,0
-Hyeonji Lee,2021-Q3,0,0,0
 Hyeonji Lee,2021-Q2,2,5,5
 Hyeonji Lee,2021-Q1,0,0,0
 Hyeonji Lee,2020-Q4,0,0,0
@@ -2575,8 +2253,6 @@ Hyeonji Lee,2018-Q4,0,0,0
 Hyeonji Lee,2018-Q3,0,0,0
 Hyeonji Lee,2018-Q2,0,0,0
 Hyeonji Lee,2018-Q1,0,0,0
-Patrik Laurell,2021-Q4,0,0,0
-Patrik Laurell,2021-Q3,0,0,0
 Patrik Laurell,2021-Q2,37,738,1006
 Patrik Laurell,2021-Q1,23,176,115
 Patrik Laurell,2020-Q4,15,343,171
@@ -2591,8 +2267,6 @@ Patrik Laurell,2018-Q4,0,0,0
 Patrik Laurell,2018-Q3,0,0,0
 Patrik Laurell,2018-Q2,0,0,0
 Patrik Laurell,2018-Q1,0,0,0
-Duncan Riach,2021-Q4,0,0,0
-Duncan Riach,2021-Q3,0,0,0
 Duncan Riach,2021-Q2,3,148,2
 Duncan Riach,2021-Q1,26,544,66
 Duncan Riach,2020-Q4,0,0,0
@@ -2607,8 +2281,6 @@ Duncan Riach,2018-Q4,1,40,0
 Duncan Riach,2018-Q3,0,0,0
 Duncan Riach,2018-Q2,0,0,0
 Duncan Riach,2018-Q1,0,0,0
-Rajeshwar Reddy T,2021-Q4,0,0,0
-Rajeshwar Reddy T,2021-Q3,0,0,0
 Rajeshwar Reddy T,2021-Q2,2,6,3
 Rajeshwar Reddy T,2021-Q1,0,0,0
 Rajeshwar Reddy T,2020-Q4,0,0,0
@@ -2623,8 +2295,6 @@ Rajeshwar Reddy T,2018-Q4,0,0,0
 Rajeshwar Reddy T,2018-Q3,0,0,0
 Rajeshwar Reddy T,2018-Q2,0,0,0
 Rajeshwar Reddy T,2018-Q1,0,0,0
-Artem Belevich,2021-Q4,0,0,0
-Artem Belevich,2021-Q3,0,0,0
 Artem Belevich,2021-Q2,2,6,5
 Artem Belevich,2021-Q1,1,0,0
 Artem Belevich,2020-Q4,0,0,0
@@ -2639,8 +2309,6 @@ Artem Belevich,2018-Q4,20,1315,144
 Artem Belevich,2018-Q3,0,0,0
 Artem Belevich,2018-Q2,0,0,0
 Artem Belevich,2018-Q1,0,0,0
-Jun Xu,2021-Q4,0,0,0
-Jun Xu,2021-Q3,0,0,0
 Jun Xu,2021-Q2,52,2888,2494
 Jun Xu,2021-Q1,2,56,22
 Jun Xu,2020-Q4,0,0,0
@@ -2655,8 +2323,6 @@ Jun Xu,2018-Q4,0,0,0
 Jun Xu,2018-Q3,0,0,0
 Jun Xu,2018-Q2,0,0,0
 Jun Xu,2018-Q1,0,0,0
-Mahmoud Abuzaina,2021-Q4,0,0,0
-Mahmoud Abuzaina,2021-Q3,0,0,0
 Mahmoud Abuzaina,2021-Q2,5,25,12
 Mahmoud Abuzaina,2021-Q1,49,1451,260
 Mahmoud Abuzaina,2020-Q4,26,285,338
@@ -2671,8 +2337,6 @@ Mahmoud Abuzaina,2018-Q4,25,769,403
 Mahmoud Abuzaina,2018-Q3,36,2756,147
 Mahmoud Abuzaina,2018-Q2,2,17,24
 Mahmoud Abuzaina,2018-Q1,3,64,18
-Thibaut Goetghebuer-Planchon,2021-Q4,0,0,0
-Thibaut Goetghebuer-Planchon,2021-Q3,0,0,0
 Thibaut Goetghebuer-Planchon,2021-Q2,9,336,225
 Thibaut Goetghebuer-Planchon,2021-Q1,1,3,3
 Thibaut Goetghebuer-Planchon,2020-Q4,25,249,69
@@ -2687,8 +2351,6 @@ Thibaut Goetghebuer-Planchon,2018-Q4,0,0,0
 Thibaut Goetghebuer-Planchon,2018-Q3,0,0,0
 Thibaut Goetghebuer-Planchon,2018-Q2,0,0,0
 Thibaut Goetghebuer-Planchon,2018-Q1,0,0,0
-Pedro Marques,2021-Q4,0,0,0
-Pedro Marques,2021-Q3,0,0,0
 Pedro Marques,2021-Q2,2,24,0
 Pedro Marques,2021-Q1,16,332,16
 Pedro Marques,2020-Q4,5,148,5
@@ -2703,8 +2365,6 @@ Pedro Marques,2018-Q4,0,0,0
 Pedro Marques,2018-Q3,0,0,0
 Pedro Marques,2018-Q2,0,0,0
 Pedro Marques,2018-Q1,0,0,0
-MH Kwon,2021-Q4,0,0,0
-MH Kwon,2021-Q3,0,0,0
 MH Kwon,2021-Q2,1,2,2
 MH Kwon,2021-Q1,0,0,0
 MH Kwon,2020-Q4,0,0,0
@@ -2719,8 +2379,6 @@ MH Kwon,2018-Q4,0,0,0
 MH Kwon,2018-Q3,0,0,0
 MH Kwon,2018-Q2,0,0,0
 MH Kwon,2018-Q1,0,0,0
-Hiran Sarkar,2021-Q4,0,0,0
-Hiran Sarkar,2021-Q3,0,0,0
 Hiran Sarkar,2021-Q2,9,60,25
 Hiran Sarkar,2021-Q1,7,35,50
 Hiran Sarkar,2020-Q4,0,0,0
@@ -2735,8 +2393,6 @@ Hiran Sarkar,2018-Q4,0,0,0
 Hiran Sarkar,2018-Q3,0,0,0
 Hiran Sarkar,2018-Q2,0,0,0
 Hiran Sarkar,2018-Q1,0,0,0
-wenwu,2021-Q4,0,0,0
-wenwu,2021-Q3,0,0,0
 wenwu,2021-Q2,1,0,0
 wenwu,2021-Q1,0,0,0
 wenwu,2020-Q4,0,0,0
@@ -2751,8 +2407,6 @@ wenwu,2018-Q4,0,0,0
 wenwu,2018-Q3,0,0,0
 wenwu,2018-Q2,0,0,0
 wenwu,2018-Q1,0,0,0
-Kevin Cheng,2021-Q4,0,0,0
-Kevin Cheng,2021-Q3,0,0,0
 Kevin Cheng,2021-Q2,4,985,1009
 Kevin Cheng,2021-Q1,1,1651,650
 Kevin Cheng,2020-Q4,0,0,0
@@ -2767,8 +2421,6 @@ Kevin Cheng,2018-Q4,0,0,0
 Kevin Cheng,2018-Q3,0,0,0
 Kevin Cheng,2018-Q2,0,0,0
 Kevin Cheng,2018-Q1,0,0,0
-Frederic Bastien,2021-Q4,0,0,0
-Frederic Bastien,2021-Q3,0,0,0
 Frederic Bastien,2021-Q2,71,1164,1120
 Frederic Bastien,2021-Q1,163,2787,1416
 Frederic Bastien,2020-Q4,15,148,66
@@ -2783,8 +2435,6 @@ Frederic Bastien,2018-Q4,0,0,0
 Frederic Bastien,2018-Q3,0,0,0
 Frederic Bastien,2018-Q2,0,0,0
 Frederic Bastien,2018-Q1,0,0,0
-Markus Kunesch,2021-Q4,0,0,0
-Markus Kunesch,2021-Q3,0,0,0
 Markus Kunesch,2021-Q2,2,42,25
 Markus Kunesch,2021-Q1,0,0,0
 Markus Kunesch,2020-Q4,0,0,0
@@ -2799,8 +2449,6 @@ Markus Kunesch,2018-Q4,0,0,0
 Markus Kunesch,2018-Q3,0,0,0
 Markus Kunesch,2018-Q2,0,0,0
 Markus Kunesch,2018-Q1,0,0,0
-Robert Neale,2021-Q4,0,0,0
-Robert Neale,2021-Q3,0,0,0
 Robert Neale,2021-Q2,2,30,19
 Robert Neale,2021-Q1,1,4,4
 Robert Neale,2020-Q4,0,0,0
@@ -2815,8 +2463,6 @@ Robert Neale,2018-Q4,13,702,32
 Robert Neale,2018-Q3,0,0,0
 Robert Neale,2018-Q2,0,0,0
 Robert Neale,2018-Q1,0,0,0
-Cesar Crusius,2021-Q4,0,0,0
-Cesar Crusius,2021-Q3,0,0,0
 Cesar Crusius,2021-Q2,11,377,30
 Cesar Crusius,2021-Q1,2,36,20
 Cesar Crusius,2020-Q4,28,311,118
@@ -2831,8 +2477,6 @@ Cesar Crusius,2018-Q4,0,0,0
 Cesar Crusius,2018-Q3,0,0,0
 Cesar Crusius,2018-Q2,0,0,0
 Cesar Crusius,2018-Q1,0,0,0
-xiaohong1031,2021-Q4,0,0,0
-xiaohong1031,2021-Q3,0,0,0
 xiaohong1031,2021-Q2,3,28,9
 xiaohong1031,2021-Q1,75,272,616
 xiaohong1031,2020-Q4,26,733,1378
@@ -2847,8 +2491,6 @@ xiaohong1031,2018-Q4,0,0,0
 xiaohong1031,2018-Q3,0,0,0
 xiaohong1031,2018-Q2,0,0,0
 xiaohong1031,2018-Q1,0,0,0
-Zachary Garrett,2021-Q4,0,0,0
-Zachary Garrett,2021-Q3,0,0,0
 Zachary Garrett,2021-Q2,2,16,0
 Zachary Garrett,2021-Q1,0,0,0
 Zachary Garrett,2020-Q4,0,0,0
@@ -2863,8 +2505,6 @@ Zachary Garrett,2018-Q4,0,0,0
 Zachary Garrett,2018-Q3,0,0,0
 Zachary Garrett,2018-Q2,0,0,0
 Zachary Garrett,2018-Q1,0,0,0
-Liubov Batanina,2021-Q4,0,0,0
-Liubov Batanina,2021-Q3,0,0,0
 Liubov Batanina,2021-Q2,2,14,8
 Liubov Batanina,2021-Q1,0,0,0
 Liubov Batanina,2020-Q4,0,0,0
@@ -2879,8 +2519,6 @@ Liubov Batanina,2018-Q4,0,0,0
 Liubov Batanina,2018-Q3,0,0,0
 Liubov Batanina,2018-Q2,0,0,0
 Liubov Batanina,2018-Q1,0,0,0
-Alan Green,2021-Q4,0,0,0
-Alan Green,2021-Q3,0,0,0
 Alan Green,2021-Q2,2,3,0
 Alan Green,2021-Q1,0,0,0
 Alan Green,2020-Q4,0,0,0
@@ -2895,8 +2533,6 @@ Alan Green,2018-Q4,0,0,0
 Alan Green,2018-Q3,0,0,0
 Alan Green,2018-Q2,0,0,0
 Alan Green,2018-Q1,0,0,0
-bhack,2021-Q4,0,0,0
-bhack,2021-Q3,0,0,0
 bhack,2021-Q2,4,11,3
 bhack,2021-Q1,26,52,19
 bhack,2020-Q4,142,3078,2096
@@ -2911,8 +2547,6 @@ bhack,2018-Q4,0,0,0
 bhack,2018-Q3,0,0,0
 bhack,2018-Q2,1,3,0
 bhack,2018-Q1,0,0,0
-Aleksandr Nikolaev,2021-Q4,0,0,0
-Aleksandr Nikolaev,2021-Q3,0,0,0
 Aleksandr Nikolaev,2021-Q2,3,24,13
 Aleksandr Nikolaev,2021-Q1,20,241,39
 Aleksandr Nikolaev,2020-Q4,0,0,0
@@ -2927,8 +2561,6 @@ Aleksandr Nikolaev,2018-Q4,0,0,0
 Aleksandr Nikolaev,2018-Q3,0,0,0
 Aleksandr Nikolaev,2018-Q2,0,0,0
 Aleksandr Nikolaev,2018-Q1,0,0,0
-Jose Baiocchi,2021-Q4,0,0,0
-Jose Baiocchi,2021-Q3,0,0,0
 Jose Baiocchi,2021-Q2,3,8,0
 Jose Baiocchi,2021-Q1,11,134,17
 Jose Baiocchi,2020-Q4,205,1855,1335
@@ -2943,8 +2575,6 @@ Jose Baiocchi,2018-Q4,0,0,0
 Jose Baiocchi,2018-Q3,0,0,0
 Jose Baiocchi,2018-Q2,0,0,0
 Jose Baiocchi,2018-Q1,0,0,0
-Yuanzhong Xu,2021-Q4,0,0,0
-Yuanzhong Xu,2021-Q3,0,0,0
 Yuanzhong Xu,2021-Q2,33,1072,354
 Yuanzhong Xu,2021-Q1,35,2165,178
 Yuanzhong Xu,2020-Q4,59,954,371
@@ -2959,8 +2589,6 @@ Yuanzhong Xu,2018-Q4,18,105,106
 Yuanzhong Xu,2018-Q3,20,886,251
 Yuanzhong Xu,2018-Q2,18,654,226
 Yuanzhong Xu,2018-Q1,56,4021,497
-Koan-Sin Tan,2021-Q4,0,0,0
-Koan-Sin Tan,2021-Q3,0,0,0
 Koan-Sin Tan,2021-Q2,3,29,3
 Koan-Sin Tan,2021-Q1,15,37,152
 Koan-Sin Tan,2020-Q4,9,116,14
@@ -2975,8 +2603,6 @@ Koan-Sin Tan,2018-Q4,2,9,0
 Koan-Sin Tan,2018-Q3,9,44,24
 Koan-Sin Tan,2018-Q2,25,308,110
 Koan-Sin Tan,2018-Q1,9,106,61
-Billy Lamberta,2021-Q4,0,0,0
-Billy Lamberta,2021-Q3,0,0,0
 Billy Lamberta,2021-Q2,4,6,6
 Billy Lamberta,2021-Q1,2,2,868
 Billy Lamberta,2020-Q4,0,0,0
@@ -2991,8 +2617,6 @@ Billy Lamberta,2018-Q4,83,4076,2720
 Billy Lamberta,2018-Q3,258,3791,10778
 Billy Lamberta,2018-Q2,305,3602,4474
 Billy Lamberta,2018-Q1,42,3108,3043
-Jeremy Meredith,2021-Q4,0,0,0
-Jeremy Meredith,2021-Q3,0,0,0
 Jeremy Meredith,2021-Q2,51,955,756
 Jeremy Meredith,2021-Q1,3,4,6
 Jeremy Meredith,2020-Q4,0,0,0
@@ -3007,8 +2631,6 @@ Jeremy Meredith,2018-Q4,0,0,0
 Jeremy Meredith,2018-Q3,0,0,0
 Jeremy Meredith,2018-Q2,0,0,0
 Jeremy Meredith,2018-Q1,0,0,0
-Kibeom Kim,2021-Q4,0,0,0
-Kibeom Kim,2021-Q3,0,0,0
 Kibeom Kim,2021-Q2,3,0,0
 Kibeom Kim,2021-Q1,16,28,91
 Kibeom Kim,2020-Q4,102,190,657
@@ -3023,8 +2645,6 @@ Kibeom Kim,2018-Q4,0,0,0
 Kibeom Kim,2018-Q3,0,0,0
 Kibeom Kim,2018-Q2,0,0,0
 Kibeom Kim,2018-Q1,0,0,0
-Richard Uhler,2021-Q4,0,0,0
-Richard Uhler,2021-Q3,0,0,0
 Richard Uhler,2021-Q2,2,88,9
 Richard Uhler,2021-Q1,52,877,392
 Richard Uhler,2020-Q4,30,628,227
@@ -3039,8 +2659,6 @@ Richard Uhler,2018-Q4,0,0,0
 Richard Uhler,2018-Q3,0,0,0
 Richard Uhler,2018-Q2,0,0,0
 Richard Uhler,2018-Q1,0,0,0
-Saduf2019,2021-Q4,0,0,0
-Saduf2019,2021-Q3,0,0,0
 Saduf2019,2021-Q2,3,0,0
 Saduf2019,2021-Q1,2,2,2
 Saduf2019,2020-Q4,0,0,0
@@ -3055,8 +2673,6 @@ Saduf2019,2018-Q4,0,0,0
 Saduf2019,2018-Q3,0,0,0
 Saduf2019,2018-Q2,0,0,0
 Saduf2019,2018-Q1,0,0,0
-François Chollet,2021-Q4,0,0,0
-François Chollet,2021-Q3,0,0,0
 François Chollet,2021-Q2,1,4,3
 François Chollet,2021-Q1,2,0,2
 François Chollet,2020-Q4,0,0,0
@@ -3071,8 +2687,6 @@ François Chollet,2018-Q4,0,0,0
 François Chollet,2018-Q3,0,0,0
 François Chollet,2018-Q2,0,0,0
 François Chollet,2018-Q1,0,0,0
-Yujing Zhang,2021-Q4,0,0,0
-Yujing Zhang,2021-Q3,0,0,0
 Yujing Zhang,2021-Q2,8,207,142
 Yujing Zhang,2021-Q1,57,194,1134
 Yujing Zhang,2020-Q4,80,739,16333
@@ -3087,8 +2701,6 @@ Yujing Zhang,2018-Q4,0,0,0
 Yujing Zhang,2018-Q3,0,0,0
 Yujing Zhang,2018-Q2,0,0,0
 Yujing Zhang,2018-Q1,0,0,0
-Nick Felt,2021-Q4,0,0,0
-Nick Felt,2021-Q3,0,0,0
 Nick Felt,2021-Q2,15,342,57
 Nick Felt,2021-Q1,13,146,442
 Nick Felt,2020-Q4,1,0,54
@@ -3103,8 +2715,6 @@ Nick Felt,2018-Q4,29,691,388
 Nick Felt,2018-Q3,46,1218,1598
 Nick Felt,2018-Q2,32,998,311
 Nick Felt,2018-Q1,11,7,2
-Adam Hillier,2021-Q4,0,0,0
-Adam Hillier,2021-Q3,0,0,0
 Adam Hillier,2021-Q2,2,2,8
 Adam Hillier,2021-Q1,2,0,0
 Adam Hillier,2020-Q4,0,0,0
@@ -3119,8 +2729,6 @@ Adam Hillier,2018-Q4,0,0,0
 Adam Hillier,2018-Q3,0,0,0
 Adam Hillier,2018-Q2,0,0,0
 Adam Hillier,2018-Q1,0,0,0
-Justin Lebar,2021-Q4,0,0,0
-Justin Lebar,2021-Q3,0,0,0
 Justin Lebar,2021-Q2,2,17,29
 Justin Lebar,2021-Q1,2,35,0
 Justin Lebar,2020-Q4,1,4,3
@@ -3135,8 +2743,6 @@ Justin Lebar,2018-Q4,546,8382,5907
 Justin Lebar,2018-Q3,1065,11232,9564
 Justin Lebar,2018-Q2,737,8046,7550
 Justin Lebar,2018-Q1,187,4607,2591
-Brian Patton,2021-Q4,0,0,0
-Brian Patton,2021-Q3,0,0,0
 Brian Patton,2021-Q2,25,754,259
 Brian Patton,2021-Q1,0,0,0
 Brian Patton,2020-Q4,9,187,15
@@ -3151,8 +2757,6 @@ Brian Patton,2018-Q4,17,62,9
 Brian Patton,2018-Q3,52,347,177
 Brian Patton,2018-Q2,26,367,148
 Brian Patton,2018-Q1,41,1378,487
-Ian Kivlichan,2021-Q4,0,0,0
-Ian Kivlichan,2021-Q3,0,0,0
 Ian Kivlichan,2021-Q2,3,51,44
 Ian Kivlichan,2021-Q1,0,0,0
 Ian Kivlichan,2020-Q4,0,0,0
@@ -3167,8 +2771,6 @@ Ian Kivlichan,2018-Q4,0,0,0
 Ian Kivlichan,2018-Q3,0,0,0
 Ian Kivlichan,2018-Q2,0,0,0
 Ian Kivlichan,2018-Q1,0,0,0
-Johannes Ballé,2021-Q4,0,0,0
-Johannes Ballé,2021-Q3,0,0,0
 Johannes Ballé,2021-Q2,4,22,9
 Johannes Ballé,2021-Q1,0,0,0
 Johannes Ballé,2020-Q4,0,0,0
@@ -3183,8 +2785,6 @@ Johannes Ballé,2018-Q4,0,0,0
 Johannes Ballé,2018-Q3,0,0,0
 Johannes Ballé,2018-Q2,0,0,0
 Johannes Ballé,2018-Q1,0,0,0
-ddavis-2015,2021-Q4,0,0,0
-ddavis-2015,2021-Q3,0,0,0
 ddavis-2015,2021-Q2,15,777,255
 ddavis-2015,2021-Q1,175,7682,4815
 ddavis-2015,2020-Q4,17,523,244
@@ -3199,8 +2799,6 @@ ddavis-2015,2018-Q4,0,0,0
 ddavis-2015,2018-Q3,0,0,0
 ddavis-2015,2018-Q2,0,0,0
 ddavis-2015,2018-Q1,0,0,0
-Ihor Indyk,2021-Q4,0,0,0
-Ihor Indyk,2021-Q3,0,0,0
 Ihor Indyk,2021-Q2,1,6,6
 Ihor Indyk,2021-Q1,20,1050,460
 Ihor Indyk,2020-Q4,2,20,8
@@ -3215,8 +2813,6 @@ Ihor Indyk,2018-Q4,0,0,0
 Ihor Indyk,2018-Q3,0,0,0
 Ihor Indyk,2018-Q2,0,0,0
 Ihor Indyk,2018-Q1,0,0,0
-Jake VanderPlas,2021-Q4,0,0,0
-Jake VanderPlas,2021-Q3,0,0,0
 Jake VanderPlas,2021-Q2,3,28,0
 Jake VanderPlas,2021-Q1,0,0,0
 Jake VanderPlas,2020-Q4,0,0,0
@@ -3231,8 +2827,6 @@ Jake VanderPlas,2018-Q4,0,0,0
 Jake VanderPlas,2018-Q3,0,0,0
 Jake VanderPlas,2018-Q2,0,0,0
 Jake VanderPlas,2018-Q1,0,0,0
-Jim Fisher,2021-Q4,0,0,0
-Jim Fisher,2021-Q3,0,0,0
 Jim Fisher,2021-Q2,1,0,0
 Jim Fisher,2021-Q1,2,3,3
 Jim Fisher,2020-Q4,0,0,0
@@ -3247,8 +2841,6 @@ Jim Fisher,2018-Q4,0,0,0
 Jim Fisher,2018-Q3,0,0,0
 Jim Fisher,2018-Q2,0,0,0
 Jim Fisher,2018-Q1,0,0,0
-Chuan He,2021-Q4,0,0,0
-Chuan He,2021-Q3,0,0,0
 Chuan He,2021-Q2,4,102,0
 Chuan He,2021-Q1,3,63,14
 Chuan He,2020-Q4,14,241,68
@@ -3263,8 +2855,6 @@ Chuan He,2018-Q4,0,0,0
 Chuan He,2018-Q3,0,0,0
 Chuan He,2018-Q2,0,0,0
 Chuan He,2018-Q1,0,0,0
-Aditya Kane,2021-Q4,0,0,0
-Aditya Kane,2021-Q3,0,0,0
 Aditya Kane,2021-Q2,1,0,0
 Aditya Kane,2021-Q1,17,34,15
 Aditya Kane,2020-Q4,0,0,0
@@ -3279,8 +2869,6 @@ Aditya Kane,2018-Q4,0,0,0
 Aditya Kane,2018-Q3,0,0,0
 Aditya Kane,2018-Q2,0,0,0
 Aditya Kane,2018-Q1,0,0,0
-Deven Desai,2021-Q4,0,0,0
-Deven Desai,2021-Q3,0,0,0
 Deven Desai,2021-Q2,30,805,732
 Deven Desai,2021-Q1,117,3219,767
 Deven Desai,2020-Q4,130,1752,1106
@@ -3295,8 +2883,6 @@ Deven Desai,2018-Q4,0,0,0
 Deven Desai,2018-Q3,0,0,0
 Deven Desai,2018-Q2,0,0,0
 Deven Desai,2018-Q1,0,0,0
-Cheng Ren,2021-Q4,0,0,0
-Cheng Ren,2021-Q3,0,0,0
 Cheng Ren,2021-Q2,1,0,0
 Cheng Ren,2021-Q1,1,0,0
 Cheng Ren,2020-Q4,0,0,0
@@ -3311,8 +2897,6 @@ Cheng Ren,2018-Q4,0,0,0
 Cheng Ren,2018-Q3,0,0,0
 Cheng Ren,2018-Q2,0,0,0
 Cheng Ren,2018-Q1,0,0,0
-Aadhitya A,2021-Q4,0,0,0
-Aadhitya A,2021-Q3,0,0,0
 Aadhitya A,2021-Q2,6,2,6
 Aadhitya A,2021-Q1,0,0,0
 Aadhitya A,2020-Q4,0,0,0
@@ -3327,8 +2911,6 @@ Aadhitya A,2018-Q4,0,0,0
 Aadhitya A,2018-Q3,0,0,0
 Aadhitya A,2018-Q2,0,0,0
 Aadhitya A,2018-Q1,0,0,0
-stevenireeves,2021-Q4,0,0,0
-stevenireeves,2021-Q3,0,0,0
 stevenireeves,2021-Q2,1,0,3
 stevenireeves,2021-Q1,11,136,109
 stevenireeves,2020-Q4,0,0,0
@@ -3343,8 +2925,6 @@ stevenireeves,2018-Q4,0,0,0
 stevenireeves,2018-Q3,0,0,0
 stevenireeves,2018-Q2,0,0,0
 stevenireeves,2018-Q1,0,0,0
-root,2021-Q4,0,0,0
-root,2021-Q3,0,0,0
 root,2021-Q2,1,7,0
 root,2021-Q1,0,0,0
 root,2020-Q4,0,0,0
@@ -3359,8 +2939,6 @@ root,2018-Q4,0,0,0
 root,2018-Q3,0,0,0
 root,2018-Q2,0,0,0
 root,2018-Q1,0,0,0
-Daniel Situnayake,2021-Q4,0,0,0
-Daniel Situnayake,2021-Q3,0,0,0
 Daniel Situnayake,2021-Q2,6,43,20
 Daniel Situnayake,2021-Q1,2,141,3
 Daniel Situnayake,2020-Q4,0,0,0
@@ -3375,8 +2953,6 @@ Daniel Situnayake,2018-Q4,0,0,0
 Daniel Situnayake,2018-Q3,0,0,0
 Daniel Situnayake,2018-Q2,0,0,0
 Daniel Situnayake,2018-Q1,0,0,0
-Neil Girdhar,2021-Q4,0,0,0
-Neil Girdhar,2021-Q3,0,0,0
 Neil Girdhar,2021-Q2,3,6,6
 Neil Girdhar,2021-Q1,0,0,0
 Neil Girdhar,2020-Q4,0,0,0
@@ -3391,8 +2967,6 @@ Neil Girdhar,2018-Q4,0,0,0
 Neil Girdhar,2018-Q3,0,0,0
 Neil Girdhar,2018-Q2,0,0,0
 Neil Girdhar,2018-Q1,0,0,0
-Gabriele Macchi,2021-Q4,0,0,0
-Gabriele Macchi,2021-Q3,0,0,0
 Gabriele Macchi,2021-Q2,2,3,4
 Gabriele Macchi,2021-Q1,0,0,0
 Gabriele Macchi,2020-Q4,0,0,0
@@ -3407,8 +2981,6 @@ Gabriele Macchi,2018-Q4,0,0,0
 Gabriele Macchi,2018-Q3,0,0,0
 Gabriele Macchi,2018-Q2,0,0,0
 Gabriele Macchi,2018-Q1,0,0,0
-Yasir Modak,2021-Q4,0,0,0
-Yasir Modak,2021-Q3,0,0,0
 Yasir Modak,2021-Q2,2,5,0
 Yasir Modak,2021-Q1,3,8,4
 Yasir Modak,2020-Q4,1,2,2
@@ -3423,8 +2995,6 @@ Yasir Modak,2018-Q4,0,0,0
 Yasir Modak,2018-Q3,0,0,0
 Yasir Modak,2018-Q2,0,0,0
 Yasir Modak,2018-Q1,0,0,0
-Ce Zheng,2021-Q4,0,0,0
-Ce Zheng,2021-Q3,0,0,0
 Ce Zheng,2021-Q2,14,291,89
 Ce Zheng,2021-Q1,8,1244,4
 Ce Zheng,2020-Q4,63,1508,443
@@ -3439,8 +3009,6 @@ Ce Zheng,2018-Q4,0,0,0
 Ce Zheng,2018-Q3,0,0,0
 Ce Zheng,2018-Q2,0,0,0
 Ce Zheng,2018-Q1,0,0,0
-Pankaj Kanwar,2021-Q4,0,0,0
-Pankaj Kanwar,2021-Q3,0,0,0
 Pankaj Kanwar,2021-Q2,1,0,0
 Pankaj Kanwar,2021-Q1,73,3403,2696
 Pankaj Kanwar,2020-Q4,46,674,110
@@ -3455,8 +3023,6 @@ Pankaj Kanwar,2018-Q4,0,0,0
 Pankaj Kanwar,2018-Q3,0,0,0
 Pankaj Kanwar,2018-Q2,0,0,0
 Pankaj Kanwar,2018-Q1,0,0,0
-Prashant Kumar,2021-Q4,0,0,0
-Prashant Kumar,2021-Q3,0,0,0
 Prashant Kumar,2021-Q2,0,0,0
 Prashant Kumar,2021-Q1,4,224,0
 Prashant Kumar,2020-Q4,0,0,0
@@ -3471,8 +3037,6 @@ Prashant Kumar,2018-Q4,0,0,0
 Prashant Kumar,2018-Q3,0,0,0
 Prashant Kumar,2018-Q2,0,0,0
 Prashant Kumar,2018-Q1,0,0,0
-Abhilash Mahendrakar,2021-Q4,0,0,0
-Abhilash Mahendrakar,2021-Q3,0,0,0
 Abhilash Mahendrakar,2021-Q2,1,0,0
 Abhilash Mahendrakar,2021-Q1,3,3,7
 Abhilash Mahendrakar,2020-Q4,0,0,0
@@ -3487,8 +3051,6 @@ Abhilash Mahendrakar,2018-Q4,0,0,0
 Abhilash Mahendrakar,2018-Q3,0,0,0
 Abhilash Mahendrakar,2018-Q2,0,0,0
 Abhilash Mahendrakar,2018-Q1,0,0,0
-Blake Hechtman,2021-Q4,0,0,0
-Blake Hechtman,2021-Q3,0,0,0
 Blake Hechtman,2021-Q2,2,16,12
 Blake Hechtman,2021-Q1,16,464,35
 Blake Hechtman,2020-Q4,8,29,9
@@ -3503,8 +3065,6 @@ Blake Hechtman,2018-Q4,39,882,190
 Blake Hechtman,2018-Q3,8,223,44
 Blake Hechtman,2018-Q2,33,751,963
 Blake Hechtman,2018-Q1,14,321,69
-Rama ketineni,2021-Q4,0,0,0
-Rama ketineni,2021-Q3,0,0,0
 Rama ketineni,2021-Q2,1,0,0
 Rama ketineni,2021-Q1,0,0,0
 Rama ketineni,2020-Q4,0,0,0
@@ -3519,8 +3079,6 @@ Rama ketineni,2018-Q4,0,0,0
 Rama ketineni,2018-Q3,0,0,0
 Rama ketineni,2018-Q2,0,0,0
 Rama ketineni,2018-Q1,0,0,0
-Nirjas Jakilim,2021-Q4,0,0,0
-Nirjas Jakilim,2021-Q3,0,0,0
 Nirjas Jakilim,2021-Q2,1,0,0
 Nirjas Jakilim,2021-Q1,0,0,0
 Nirjas Jakilim,2020-Q4,0,0,0
@@ -3535,8 +3093,6 @@ Nirjas Jakilim,2018-Q4,0,0,0
 Nirjas Jakilim,2018-Q3,0,0,0
 Nirjas Jakilim,2018-Q2,0,0,0
 Nirjas Jakilim,2018-Q1,0,0,0
-QQ喵,2021-Q4,0,0,0
-QQ喵,2021-Q3,0,0,0
 QQ喵,2021-Q2,2,10,10
 QQ喵,2021-Q1,0,0,0
 QQ喵,2020-Q4,3,2,0
@@ -3551,8 +3107,6 @@ QQ喵,2018-Q4,0,0,0
 QQ喵,2018-Q3,0,0,0
 QQ喵,2018-Q2,0,0,0
 QQ喵,2018-Q1,0,0,0
-Rama Ketineni,2021-Q4,0,0,0
-Rama Ketineni,2021-Q3,0,0,0
 Rama Ketineni,2021-Q2,4,137,42
 Rama Ketineni,2021-Q1,0,0,0
 Rama Ketineni,2020-Q4,2,24,0
@@ -3567,8 +3121,6 @@ Rama Ketineni,2018-Q4,0,0,0
 Rama Ketineni,2018-Q3,0,0,0
 Rama Ketineni,2018-Q2,0,0,0
 Rama Ketineni,2018-Q1,0,0,0
-Stella Laurenzo,2021-Q4,0,0,0
-Stella Laurenzo,2021-Q3,0,0,0
 Stella Laurenzo,2021-Q2,1,0,0
 Stella Laurenzo,2021-Q1,92,410,379
 Stella Laurenzo,2020-Q4,49,15912,478
@@ -3583,8 +3135,6 @@ Stella Laurenzo,2018-Q4,0,0,0
 Stella Laurenzo,2018-Q3,0,0,0
 Stella Laurenzo,2018-Q2,0,0,0
 Stella Laurenzo,2018-Q1,0,0,0
-Johannes Lade,2021-Q4,0,0,0
-Johannes Lade,2021-Q3,0,0,0
 Johannes Lade,2021-Q2,1,2,2
 Johannes Lade,2021-Q1,0,0,0
 Johannes Lade,2020-Q4,0,0,0
@@ -3599,8 +3149,6 @@ Johannes Lade,2018-Q4,0,0,0
 Johannes Lade,2018-Q3,0,0,0
 Johannes Lade,2018-Q2,0,0,0
 Johannes Lade,2018-Q1,0,0,0
-David Rim,2021-Q4,0,0,0
-David Rim,2021-Q3,0,0,0
 David Rim,2021-Q2,11,343,49
 David Rim,2021-Q1,15,319,31
 David Rim,2020-Q4,36,5241,105
@@ -3615,8 +3163,6 @@ David Rim,2018-Q4,0,0,0
 David Rim,2018-Q3,0,0,0
 David Rim,2018-Q2,0,0,0
 David Rim,2018-Q1,0,0,0
-Shanqing Cai,2021-Q4,0,0,0
-Shanqing Cai,2021-Q3,0,0,0
 Shanqing Cai,2021-Q2,1,44,47
 Shanqing Cai,2021-Q1,0,0,0
 Shanqing Cai,2020-Q4,10,18,15
@@ -3631,8 +3177,6 @@ Shanqing Cai,2018-Q4,5,87,8
 Shanqing Cai,2018-Q3,33,338,1333
 Shanqing Cai,2018-Q2,35,656,228
 Shanqing Cai,2018-Q1,175,5597,1783
-Srinivas Vasudevan,2021-Q4,0,0,0
-Srinivas Vasudevan,2021-Q3,0,0,0
 Srinivas Vasudevan,2021-Q2,1,4,6
 Srinivas Vasudevan,2021-Q1,6,34,14
 Srinivas Vasudevan,2020-Q4,5,47,0
@@ -3647,8 +3191,6 @@ Srinivas Vasudevan,2018-Q4,0,0,0
 Srinivas Vasudevan,2018-Q3,0,0,0
 Srinivas Vasudevan,2018-Q2,0,0,0
 Srinivas Vasudevan,2018-Q1,0,0,0
-Jens Meder,2021-Q4,0,0,0
-Jens Meder,2021-Q3,0,0,0
 Jens Meder,2021-Q2,1,0,0
 Jens Meder,2021-Q1,0,0,0
 Jens Meder,2020-Q4,0,0,0
@@ -3663,8 +3205,6 @@ Jens Meder,2018-Q4,0,0,0
 Jens Meder,2018-Q3,0,0,0
 Jens Meder,2018-Q2,0,0,0
 Jens Meder,2018-Q1,0,0,0
-Dmitry Kovalev,2021-Q4,0,0,0
-Dmitry Kovalev,2021-Q3,0,0,0
 Dmitry Kovalev,2021-Q2,2,5,12
 Dmitry Kovalev,2021-Q1,0,0,0
 Dmitry Kovalev,2020-Q4,2,3,2
@@ -3679,8 +3219,6 @@ Dmitry Kovalev,2018-Q4,0,0,0
 Dmitry Kovalev,2018-Q3,0,0,0
 Dmitry Kovalev,2018-Q2,0,0,0
 Dmitry Kovalev,2018-Q1,0,0,0
-zilinzhu,2021-Q4,0,0,0
-zilinzhu,2021-Q3,0,0,0
 zilinzhu,2021-Q2,0,0,0
 zilinzhu,2021-Q1,22,565,321
 zilinzhu,2020-Q4,0,0,0
@@ -3695,8 +3233,6 @@ zilinzhu,2018-Q4,0,0,0
 zilinzhu,2018-Q3,0,0,0
 zilinzhu,2018-Q2,0,0,0
 zilinzhu,2018-Q1,0,0,0
-Vishnuvardhan Janapati,2021-Q4,0,0,0
-Vishnuvardhan Janapati,2021-Q3,0,0,0
 Vishnuvardhan Janapati,2021-Q2,1,2,0
 Vishnuvardhan Janapati,2021-Q1,0,0,0
 Vishnuvardhan Janapati,2020-Q4,0,0,0
@@ -3711,8 +3247,6 @@ Vishnuvardhan Janapati,2018-Q4,0,0,0
 Vishnuvardhan Janapati,2018-Q3,0,0,0
 Vishnuvardhan Janapati,2018-Q2,0,0,0
 Vishnuvardhan Janapati,2018-Q1,0,0,0
-Xiaoming (Jason) Cui,2021-Q4,0,0,0
-Xiaoming (Jason) Cui,2021-Q3,0,0,0
 Xiaoming (Jason) Cui,2021-Q2,1,4,4
 Xiaoming (Jason) Cui,2021-Q1,6,81,1184
 Xiaoming (Jason) Cui,2020-Q4,1,8,7
@@ -3727,8 +3261,6 @@ Xiaoming (Jason) Cui,2018-Q4,1,0,0
 Xiaoming (Jason) Cui,2018-Q3,14,125,84
 Xiaoming (Jason) Cui,2018-Q2,0,0,0
 Xiaoming (Jason) Cui,2018-Q1,2,7,5
-Hao Xiong,2021-Q4,0,0,0
-Hao Xiong,2021-Q3,0,0,0
 Hao Xiong,2021-Q2,1,4,0
 Hao Xiong,2021-Q1,2,6,0
 Hao Xiong,2020-Q4,8,53,24
@@ -3743,8 +3275,6 @@ Hao Xiong,2018-Q4,0,0,0
 Hao Xiong,2018-Q3,0,0,0
 Hao Xiong,2018-Q2,0,0,0
 Hao Xiong,2018-Q1,0,0,0
-Ilya Arzhannikov,2021-Q4,0,0,0
-Ilya Arzhannikov,2021-Q3,0,0,0
 Ilya Arzhannikov,2021-Q2,4,6,9
 Ilya Arzhannikov,2021-Q1,5,31,21
 Ilya Arzhannikov,2020-Q4,0,0,0
@@ -3759,8 +3289,6 @@ Ilya Arzhannikov,2018-Q4,0,0,0
 Ilya Arzhannikov,2018-Q3,0,0,0
 Ilya Arzhannikov,2018-Q2,0,0,0
 Ilya Arzhannikov,2018-Q1,0,0,0
-Ryan Nett,2021-Q4,0,0,0
-Ryan Nett,2021-Q3,0,0,0
 Ryan Nett,2021-Q2,0,0,0
 Ryan Nett,2021-Q1,33,399,83
 Ryan Nett,2020-Q4,0,0,0
@@ -3775,8 +3303,6 @@ Ryan Nett,2018-Q4,0,0,0
 Ryan Nett,2018-Q3,0,0,0
 Ryan Nett,2018-Q2,0,0,0
 Ryan Nett,2018-Q1,0,0,0
-Randy Dodgen,2021-Q4,0,0,0
-Randy Dodgen,2021-Q3,0,0,0
 Randy Dodgen,2021-Q2,0,0,0
 Randy Dodgen,2021-Q1,17,77,48
 Randy Dodgen,2020-Q4,7,164,16
@@ -3791,8 +3317,6 @@ Randy Dodgen,2018-Q4,0,0,0
 Randy Dodgen,2018-Q3,0,0,0
 Randy Dodgen,2018-Q2,0,0,0
 Randy Dodgen,2018-Q1,0,0,0
-Jerry Shih,2021-Q4,0,0,0
-Jerry Shih,2021-Q3,0,0,0
 Jerry Shih,2021-Q2,0,0,0
 Jerry Shih,2021-Q1,40,696,182
 Jerry Shih,2020-Q4,0,0,0
@@ -3807,8 +3331,6 @@ Jerry Shih,2018-Q4,0,0,0
 Jerry Shih,2018-Q3,0,0,0
 Jerry Shih,2018-Q2,0,0,0
 Jerry Shih,2018-Q1,0,0,0
-Paul Donnelly,2021-Q4,0,0,0
-Paul Donnelly,2021-Q3,0,0,0
 Paul Donnelly,2021-Q2,0,0,0
 Paul Donnelly,2021-Q1,2,4,10
 Paul Donnelly,2020-Q4,1,2,2
@@ -3823,8 +3345,6 @@ Paul Donnelly,2018-Q4,5,40,2
 Paul Donnelly,2018-Q3,4,92,2
 Paul Donnelly,2018-Q2,0,0,0
 Paul Donnelly,2018-Q1,0,0,0
-Francois Chollet,2021-Q4,0,0,0
-Francois Chollet,2021-Q3,0,0,0
 Francois Chollet,2021-Q2,0,0,0
 Francois Chollet,2021-Q1,703,3351,3744
 Francois Chollet,2020-Q4,56,957,473
@@ -3839,8 +3359,6 @@ Francois Chollet,2018-Q4,672,11115,8411
 Francois Chollet,2018-Q3,153,2723,8794
 Francois Chollet,2018-Q2,312,8918,5807
 Francois Chollet,2018-Q1,574,17727,12421
-Jake Vanderplas,2021-Q4,0,0,0
-Jake Vanderplas,2021-Q3,0,0,0
 Jake Vanderplas,2021-Q2,0,0,0
 Jake Vanderplas,2021-Q1,1,41,2
 Jake Vanderplas,2020-Q4,0,0,0
@@ -3855,8 +3373,6 @@ Jake Vanderplas,2018-Q4,0,0,0
 Jake Vanderplas,2018-Q3,0,0,0
 Jake Vanderplas,2018-Q2,0,0,0
 Jake Vanderplas,2018-Q1,0,0,0
-Bas Aarts,2021-Q4,0,0,0
-Bas Aarts,2021-Q3,0,0,0
 Bas Aarts,2021-Q2,0,0,0
 Bas Aarts,2021-Q1,29,305,162
 Bas Aarts,2020-Q4,6,11,13
@@ -3871,8 +3387,6 @@ Bas Aarts,2018-Q4,0,0,0
 Bas Aarts,2018-Q3,0,0,0
 Bas Aarts,2018-Q2,0,0,0
 Bas Aarts,2018-Q1,0,0,0
-Bradley Reece,2021-Q4,0,0,0
-Bradley Reece,2021-Q3,0,0,0
 Bradley Reece,2021-Q2,0,0,0
 Bradley Reece,2021-Q1,1,0,0
 Bradley Reece,2020-Q4,0,0,0
@@ -3887,8 +3401,6 @@ Bradley Reece,2018-Q4,0,0,0
 Bradley Reece,2018-Q3,0,0,0
 Bradley Reece,2018-Q2,0,0,0
 Bradley Reece,2018-Q1,0,0,0
-Juhyun Lee,2021-Q4,0,0,0
-Juhyun Lee,2021-Q3,0,0,0
 Juhyun Lee,2021-Q2,0,0,0
 Juhyun Lee,2021-Q1,28,614,509
 Juhyun Lee,2020-Q4,5,131,103
@@ -3903,8 +3415,6 @@ Juhyun Lee,2018-Q4,0,0,0
 Juhyun Lee,2018-Q3,0,0,0
 Juhyun Lee,2018-Q2,0,0,0
 Juhyun Lee,2018-Q1,0,0,0
-Tayo Oguntebi,2021-Q4,0,0,0
-Tayo Oguntebi,2021-Q3,0,0,0
 Tayo Oguntebi,2021-Q2,0,0,0
 Tayo Oguntebi,2021-Q1,28,290,98
 Tayo Oguntebi,2020-Q4,0,0,0
@@ -3919,8 +3429,6 @@ Tayo Oguntebi,2018-Q4,7,452,278
 Tayo Oguntebi,2018-Q3,21,905,96
 Tayo Oguntebi,2018-Q2,1,0,0
 Tayo Oguntebi,2018-Q1,12,334,148
-Philip Sun,2021-Q4,0,0,0
-Philip Sun,2021-Q3,0,0,0
 Philip Sun,2021-Q2,0,0,0
 Philip Sun,2021-Q1,14,156,95
 Philip Sun,2020-Q4,0,0,0
@@ -3935,8 +3443,6 @@ Philip Sun,2018-Q4,0,0,0
 Philip Sun,2018-Q3,0,0,0
 Philip Sun,2018-Q2,0,0,0
 Philip Sun,2018-Q1,0,0,0
-Chen Chen,2021-Q4,0,0,0
-Chen Chen,2021-Q3,0,0,0
 Chen Chen,2021-Q2,0,0,0
 Chen Chen,2021-Q1,3,3,3
 Chen Chen,2020-Q4,1,0,0
@@ -3951,8 +3457,6 @@ Chen Chen,2018-Q4,0,0,0
 Chen Chen,2018-Q3,0,0,0
 Chen Chen,2018-Q2,0,0,0
 Chen Chen,2018-Q1,0,0,0
-Sergei Lebedev,2021-Q4,0,0,0
-Sergei Lebedev,2021-Q3,0,0,0
 Sergei Lebedev,2021-Q2,0,0,0
 Sergei Lebedev,2021-Q1,12,1098,42
 Sergei Lebedev,2020-Q4,0,0,0
@@ -3967,8 +3471,6 @@ Sergei Lebedev,2018-Q4,204,731,1391
 Sergei Lebedev,2018-Q3,5,42,3
 Sergei Lebedev,2018-Q2,1,10,11
 Sergei Lebedev,2018-Q1,1,0,0
-Piergiacomo De Marchi,2021-Q4,0,0,0
-Piergiacomo De Marchi,2021-Q3,0,0,0
 Piergiacomo De Marchi,2021-Q2,0,0,0
 Piergiacomo De Marchi,2021-Q1,1,5,0
 Piergiacomo De Marchi,2020-Q4,0,0,0
@@ -3983,8 +3485,6 @@ Piergiacomo De Marchi,2018-Q4,0,0,0
 Piergiacomo De Marchi,2018-Q3,0,0,0
 Piergiacomo De Marchi,2018-Q2,0,0,0
 Piergiacomo De Marchi,2018-Q1,0,0,0
-Till Brychcy,2021-Q4,0,0,0
-Till Brychcy,2021-Q3,0,0,0
 Till Brychcy,2021-Q2,0,0,0
 Till Brychcy,2021-Q1,1,2,0
 Till Brychcy,2020-Q4,0,0,0
@@ -3999,8 +3499,6 @@ Till Brychcy,2018-Q4,0,0,0
 Till Brychcy,2018-Q3,0,0,0
 Till Brychcy,2018-Q2,0,0,0
 Till Brychcy,2018-Q1,0,0,0
-Jiho Choi,2021-Q4,0,0,0
-Jiho Choi,2021-Q3,0,0,0
 Jiho Choi,2021-Q2,0,0,0
 Jiho Choi,2021-Q1,27,220,63
 Jiho Choi,2020-Q4,38,1033,570
@@ -4015,8 +3513,6 @@ Jiho Choi,2018-Q4,0,0,0
 Jiho Choi,2018-Q3,0,0,0
 Jiho Choi,2018-Q2,0,0,0
 Jiho Choi,2018-Q1,0,0,0
-TensorFlow Release Automation,2021-Q4,0,0,0
-TensorFlow Release Automation,2021-Q3,0,0,0
 TensorFlow Release Automation,2021-Q2,0,0,0
 TensorFlow Release Automation,2021-Q1,1,31,0
 TensorFlow Release Automation,2020-Q4,0,0,0
@@ -4031,8 +3527,6 @@ TensorFlow Release Automation,2018-Q4,0,0,0
 TensorFlow Release Automation,2018-Q3,0,0,0
 TensorFlow Release Automation,2018-Q2,0,0,0
 TensorFlow Release Automation,2018-Q1,0,0,0
-Penporn Koanantakool,2021-Q4,0,0,0
-Penporn Koanantakool,2021-Q3,0,0,0
 Penporn Koanantakool,2021-Q2,0,0,0
 Penporn Koanantakool,2021-Q1,64,913,824
 Penporn Koanantakool,2020-Q4,31,181,204
@@ -4047,8 +3541,6 @@ Penporn Koanantakool,2018-Q4,26,37,14
 Penporn Koanantakool,2018-Q3,0,0,0
 Penporn Koanantakool,2018-Q2,0,0,0
 Penporn Koanantakool,2018-Q1,0,0,0
-Abhijit Karmarkar,2021-Q4,0,0,0
-Abhijit Karmarkar,2021-Q3,0,0,0
 Abhijit Karmarkar,2021-Q2,0,0,0
 Abhijit Karmarkar,2021-Q1,1,4,4
 Abhijit Karmarkar,2020-Q4,1,27,5
@@ -4063,8 +3555,6 @@ Abhijit Karmarkar,2018-Q4,0,0,0
 Abhijit Karmarkar,2018-Q3,3,22,7
 Abhijit Karmarkar,2018-Q2,1,6,2
 Abhijit Karmarkar,2018-Q1,0,0,0
-Thomas O'Malley,2021-Q4,0,0,0
-Thomas O'Malley,2021-Q3,0,0,0
 Thomas O'Malley,2021-Q2,0,0,0
 Thomas O'Malley,2021-Q1,74,2417,567
 Thomas O'Malley,2020-Q4,72,806,212
@@ -4079,8 +3569,6 @@ Thomas O'Malley,2018-Q4,0,0,0
 Thomas O'Malley,2018-Q3,0,0,0
 Thomas O'Malley,2018-Q2,0,0,0
 Thomas O'Malley,2018-Q1,0,0,0
-DEKHTIARJonathan,2021-Q4,0,0,0
-DEKHTIARJonathan,2021-Q3,0,0,0
 DEKHTIARJonathan,2021-Q2,0,0,0
 DEKHTIARJonathan,2021-Q1,12,776,480
 DEKHTIARJonathan,2020-Q4,12,724,374
@@ -4095,8 +3583,6 @@ DEKHTIARJonathan,2018-Q4,0,0,0
 DEKHTIARJonathan,2018-Q3,0,0,0
 DEKHTIARJonathan,2018-Q2,0,0,0
 DEKHTIARJonathan,2018-Q1,0,0,0
-Tamas Bela Feher,2021-Q4,0,0,0
-Tamas Bela Feher,2021-Q3,0,0,0
 Tamas Bela Feher,2021-Q2,0,0,0
 Tamas Bela Feher,2021-Q1,24,1250,319
 Tamas Bela Feher,2020-Q4,33,2815,1608
@@ -4111,8 +3597,6 @@ Tamas Bela Feher,2018-Q4,0,0,0
 Tamas Bela Feher,2018-Q3,0,0,0
 Tamas Bela Feher,2018-Q2,0,0,0
 Tamas Bela Feher,2018-Q1,0,0,0
-Shaochen Shi,2021-Q4,0,0,0
-Shaochen Shi,2021-Q3,0,0,0
 Shaochen Shi,2021-Q2,0,0,0
 Shaochen Shi,2021-Q1,5,59,12
 Shaochen Shi,2020-Q4,0,0,0
@@ -4127,8 +3611,6 @@ Shaochen Shi,2018-Q4,3,109,15
 Shaochen Shi,2018-Q3,0,0,0
 Shaochen Shi,2018-Q2,0,0,0
 Shaochen Shi,2018-Q1,0,0,0
-Yilei Yang,2021-Q4,0,0,0
-Yilei Yang,2021-Q3,0,0,0
 Yilei Yang,2021-Q2,0,0,0
 Yilei Yang,2021-Q1,7,9,9
 Yilei Yang,2020-Q4,0,0,0
@@ -4143,8 +3625,6 @@ Yilei Yang,2018-Q4,0,0,0
 Yilei Yang,2018-Q3,0,0,0
 Yilei Yang,2018-Q2,0,0,0
 Yilei Yang,2018-Q1,0,0,0
-Yair Ehrenwald,2021-Q4,0,0,0
-Yair Ehrenwald,2021-Q3,0,0,0
 Yair Ehrenwald,2021-Q2,0,0,0
 Yair Ehrenwald,2021-Q1,106,8323,3208
 Yair Ehrenwald,2020-Q4,4,26,18
@@ -4159,8 +3639,6 @@ Yair Ehrenwald,2018-Q4,0,0,0
 Yair Ehrenwald,2018-Q3,0,0,0
 Yair Ehrenwald,2018-Q2,0,0,0
 Yair Ehrenwald,2018-Q1,0,0,0
-wxinix,2021-Q4,0,0,0
-wxinix,2021-Q3,0,0,0
 wxinix,2021-Q2,0,0,0
 wxinix,2021-Q1,1,0,2
 wxinix,2020-Q4,0,0,0
@@ -4175,8 +3653,6 @@ wxinix,2018-Q4,0,0,0
 wxinix,2018-Q3,0,0,0
 wxinix,2018-Q2,0,0,0
 wxinix,2018-Q1,0,0,0
-彭震东,2021-Q4,0,0,0
-彭震东,2021-Q3,0,0,0
 彭震东,2021-Q2,0,0,0
 彭震东,2021-Q1,1,0,0
 彭震东,2020-Q4,0,0,0
@@ -4191,8 +3667,6 @@ wxinix,2018-Q1,0,0,0
 彭震东,2018-Q3,0,0,0
 彭震东,2018-Q2,0,0,0
 彭震东,2018-Q1,0,0,0
-Yimei Sun,2021-Q4,0,0,0
-Yimei Sun,2021-Q3,0,0,0
 Yimei Sun,2021-Q2,0,0,0
 Yimei Sun,2021-Q1,5,280,36
 Yimei Sun,2020-Q4,1,9,9
@@ -4207,8 +3681,6 @@ Yimei Sun,2018-Q4,0,0,0
 Yimei Sun,2018-Q3,0,0,0
 Yimei Sun,2018-Q2,0,0,0
 Yimei Sun,2018-Q1,0,0,0
-Niroop Ammbashankar,2021-Q4,0,0,0
-Niroop Ammbashankar,2021-Q3,0,0,0
 Niroop Ammbashankar,2021-Q2,0,0,0
 Niroop Ammbashankar,2021-Q1,1,0,0
 Niroop Ammbashankar,2020-Q4,0,0,0
@@ -4223,8 +3695,6 @@ Niroop Ammbashankar,2018-Q4,0,0,0
 Niroop Ammbashankar,2018-Q3,0,0,0
 Niroop Ammbashankar,2018-Q2,0,0,0
 Niroop Ammbashankar,2018-Q1,0,0,0
-Joachim Gehweiler,2021-Q4,0,0,0
-Joachim Gehweiler,2021-Q3,0,0,0
 Joachim Gehweiler,2021-Q2,0,0,0
 Joachim Gehweiler,2021-Q1,3,0,7
 Joachim Gehweiler,2020-Q4,0,0,0
@@ -4239,8 +3709,6 @@ Joachim Gehweiler,2018-Q4,0,0,0
 Joachim Gehweiler,2018-Q3,0,0,0
 Joachim Gehweiler,2018-Q2,0,0,0
 Joachim Gehweiler,2018-Q1,0,0,0
-jgehw,2021-Q4,0,0,0
-jgehw,2021-Q3,0,0,0
 jgehw,2021-Q2,0,0,0
 jgehw,2021-Q1,5,28,0
 jgehw,2020-Q4,0,0,0
@@ -4255,8 +3723,6 @@ jgehw,2018-Q4,0,0,0
 jgehw,2018-Q3,0,0,0
 jgehw,2018-Q2,0,0,0
 jgehw,2018-Q1,0,0,0
-ag.ramesh,2021-Q4,0,0,0
-ag.ramesh,2021-Q3,0,0,0
 ag.ramesh,2021-Q2,0,0,0
 ag.ramesh,2021-Q1,29,77,83
 ag.ramesh,2020-Q4,31,290,224
@@ -4271,8 +3737,6 @@ ag.ramesh,2018-Q4,0,0,0
 ag.ramesh,2018-Q3,0,0,0
 ag.ramesh,2018-Q2,0,0,0
 ag.ramesh,2018-Q1,0,0,0
-Guanxin Qiao,2021-Q4,0,0,0
-Guanxin Qiao,2021-Q3,0,0,0
 Guanxin Qiao,2021-Q2,0,0,0
 Guanxin Qiao,2021-Q1,1,15,0
 Guanxin Qiao,2020-Q4,0,0,0
@@ -4287,8 +3751,6 @@ Guanxin Qiao,2018-Q4,0,0,0
 Guanxin Qiao,2018-Q3,0,0,0
 Guanxin Qiao,2018-Q2,0,0,0
 Guanxin Qiao,2018-Q1,0,0,0
-Yuriy Chernyshov,2021-Q4,0,0,0
-Yuriy Chernyshov,2021-Q3,0,0,0
 Yuriy Chernyshov,2021-Q2,0,0,0
 Yuriy Chernyshov,2021-Q1,4,7,7
 Yuriy Chernyshov,2020-Q4,0,0,0
@@ -4303,8 +3765,6 @@ Yuriy Chernyshov,2018-Q4,0,0,0
 Yuriy Chernyshov,2018-Q3,0,0,0
 Yuriy Chernyshov,2018-Q2,0,0,0
 Yuriy Chernyshov,2018-Q1,0,0,0
-Cuong V. Nguyen,2021-Q4,0,0,0
-Cuong V. Nguyen,2021-Q3,0,0,0
 Cuong V. Nguyen,2021-Q2,0,0,0
 Cuong V. Nguyen,2021-Q1,1,0,0
 Cuong V. Nguyen,2020-Q4,0,0,0
@@ -4319,8 +3779,6 @@ Cuong V. Nguyen,2018-Q4,0,0,0
 Cuong V. Nguyen,2018-Q3,0,0,0
 Cuong V. Nguyen,2018-Q2,0,0,0
 Cuong V. Nguyen,2018-Q1,0,0,0
-fsx950223,2021-Q4,0,0,0
-fsx950223,2021-Q3,0,0,0
 fsx950223,2021-Q2,0,0,0
 fsx950223,2021-Q1,3,53,28
 fsx950223,2020-Q4,13,60,29
@@ -4335,8 +3793,6 @@ fsx950223,2018-Q4,0,0,0
 fsx950223,2018-Q3,0,0,0
 fsx950223,2018-Q2,0,0,0
 fsx950223,2018-Q1,0,0,0
-Noam Shazeer,2021-Q4,0,0,0
-Noam Shazeer,2021-Q3,0,0,0
 Noam Shazeer,2021-Q2,0,0,0
 Noam Shazeer,2021-Q1,1,12,5
 Noam Shazeer,2020-Q4,0,0,0
@@ -4351,8 +3807,6 @@ Noam Shazeer,2018-Q4,0,0,0
 Noam Shazeer,2018-Q3,0,0,0
 Noam Shazeer,2018-Q2,0,0,0
 Noam Shazeer,2018-Q1,0,0,0
-Zhoulong Jiang,2021-Q4,0,0,0
-Zhoulong Jiang,2021-Q3,0,0,0
 Zhoulong Jiang,2021-Q2,0,0,0
 Zhoulong Jiang,2021-Q1,66,458,414
 Zhoulong Jiang,2020-Q4,130,3804,858
@@ -4367,8 +3821,6 @@ Zhoulong Jiang,2018-Q4,0,0,0
 Zhoulong Jiang,2018-Q3,0,0,0
 Zhoulong Jiang,2018-Q2,0,0,0
 Zhoulong Jiang,2018-Q1,0,0,0
-Xinyi Wang,2021-Q4,0,0,0
-Xinyi Wang,2021-Q3,0,0,0
 Xinyi Wang,2021-Q2,0,0,0
 Xinyi Wang,2021-Q1,43,722,233
 Xinyi Wang,2020-Q4,60,1370,639
@@ -4383,8 +3835,6 @@ Xinyi Wang,2018-Q4,0,0,0
 Xinyi Wang,2018-Q3,0,0,0
 Xinyi Wang,2018-Q2,0,0,0
 Xinyi Wang,2018-Q1,0,0,0
-Hye Soo Yang,2021-Q4,0,0,0
-Hye Soo Yang,2021-Q3,0,0,0
 Hye Soo Yang,2021-Q2,0,0,0
 Hye Soo Yang,2021-Q1,9,89,13
 Hye Soo Yang,2020-Q4,74,1669,638
@@ -4399,8 +3849,6 @@ Hye Soo Yang,2018-Q4,0,0,0
 Hye Soo Yang,2018-Q3,0,0,0
 Hye Soo Yang,2018-Q2,0,0,0
 Hye Soo Yang,2018-Q1,0,0,0
-Mangpo Phothilimthana,2021-Q4,0,0,0
-Mangpo Phothilimthana,2021-Q3,0,0,0
 Mangpo Phothilimthana,2021-Q2,0,0,0
 Mangpo Phothilimthana,2021-Q1,10,131,26
 Mangpo Phothilimthana,2020-Q4,3,6,15
@@ -4415,8 +3863,6 @@ Mangpo Phothilimthana,2018-Q4,0,0,0
 Mangpo Phothilimthana,2018-Q3,0,0,0
 Mangpo Phothilimthana,2018-Q2,0,0,0
 Mangpo Phothilimthana,2018-Q1,0,0,0
-Allen Wang,2021-Q4,0,0,0
-Allen Wang,2021-Q3,0,0,0
 Allen Wang,2021-Q2,0,0,0
 Allen Wang,2021-Q1,40,3036,78
 Allen Wang,2020-Q4,1,2,0
@@ -4431,8 +3877,6 @@ Allen Wang,2018-Q4,0,0,0
 Allen Wang,2018-Q3,0,0,0
 Allen Wang,2018-Q2,0,0,0
 Allen Wang,2018-Q1,0,0,0
-PratsBhatt,2021-Q4,0,0,0
-PratsBhatt,2021-Q3,0,0,0
 PratsBhatt,2021-Q2,0,0,0
 PratsBhatt,2021-Q1,5,120,40
 PratsBhatt,2020-Q4,0,0,0
@@ -4447,8 +3891,6 @@ PratsBhatt,2018-Q4,0,0,0
 PratsBhatt,2018-Q3,0,0,0
 PratsBhatt,2018-Q2,0,0,0
 PratsBhatt,2018-Q1,0,0,0
-Kulin Seth,2021-Q4,0,0,0
-Kulin Seth,2021-Q3,0,0,0
 Kulin Seth,2021-Q2,0,0,0
 Kulin Seth,2021-Q1,9,140,12
 Kulin Seth,2020-Q4,0,0,0
@@ -4463,8 +3905,6 @@ Kulin Seth,2018-Q4,0,0,0
 Kulin Seth,2018-Q3,0,0,0
 Kulin Seth,2018-Q2,0,0,0
 Kulin Seth,2018-Q1,0,0,0
-Lev Proleev,2021-Q4,0,0,0
-Lev Proleev,2021-Q3,0,0,0
 Lev Proleev,2021-Q2,0,0,0
 Lev Proleev,2021-Q1,11,209,161
 Lev Proleev,2020-Q4,0,0,0
@@ -4479,8 +3919,6 @@ Lev Proleev,2018-Q4,0,0,0
 Lev Proleev,2018-Q3,0,0,0
 Lev Proleev,2018-Q2,0,0,0
 Lev Proleev,2018-Q1,0,0,0
-Sunoru,2021-Q4,0,0,0
-Sunoru,2021-Q3,0,0,0
 Sunoru,2021-Q2,0,0,0
 Sunoru,2021-Q1,4,76,65
 Sunoru,2020-Q4,0,0,0
@@ -4495,8 +3933,6 @@ Sunoru,2018-Q4,0,0,0
 Sunoru,2018-Q3,0,0,0
 Sunoru,2018-Q2,0,0,0
 Sunoru,2018-Q1,0,0,0
-Peng Wang,2021-Q4,0,0,0
-Peng Wang,2021-Q3,0,0,0
 Peng Wang,2021-Q2,0,0,0
 Peng Wang,2021-Q1,61,1313,1176
 Peng Wang,2020-Q4,37,1473,63
@@ -4511,8 +3947,6 @@ Peng Wang,2018-Q4,0,0,0
 Peng Wang,2018-Q3,0,0,0
 Peng Wang,2018-Q2,0,0,0
 Peng Wang,2018-Q1,0,0,0
-Parker Schuh,2021-Q4,0,0,0
-Parker Schuh,2021-Q3,0,0,0
 Parker Schuh,2021-Q2,0,0,0
 Parker Schuh,2021-Q1,8,72,58
 Parker Schuh,2020-Q4,0,0,0
@@ -4527,8 +3961,6 @@ Parker Schuh,2018-Q4,0,0,0
 Parker Schuh,2018-Q3,0,0,0
 Parker Schuh,2018-Q2,0,0,0
 Parker Schuh,2018-Q1,0,0,0
-Dimitris Vardoulakis,2021-Q4,0,0,0
-Dimitris Vardoulakis,2021-Q3,0,0,0
 Dimitris Vardoulakis,2021-Q2,0,0,0
 Dimitris Vardoulakis,2021-Q1,7,74,10
 Dimitris Vardoulakis,2020-Q4,1,0,0
@@ -4543,8 +3975,6 @@ Dimitris Vardoulakis,2018-Q4,125,2212,983
 Dimitris Vardoulakis,2018-Q3,77,724,697
 Dimitris Vardoulakis,2018-Q2,100,1284,862
 Dimitris Vardoulakis,2018-Q1,13,252,31
-Pete Warden,2021-Q4,0,0,0
-Pete Warden,2021-Q3,0,0,0
 Pete Warden,2021-Q2,0,0,0
 Pete Warden,2021-Q1,3,0,0
 Pete Warden,2020-Q4,3,10,7
@@ -4559,8 +3989,6 @@ Pete Warden,2018-Q4,161,12567,2772
 Pete Warden,2018-Q3,190,4810,2945
 Pete Warden,2018-Q2,18,680,36
 Pete Warden,2018-Q1,12,818,460
-Dawid Wojciechowski,2021-Q4,0,0,0
-Dawid Wojciechowski,2021-Q3,0,0,0
 Dawid Wojciechowski,2021-Q2,0,0,0
 Dawid Wojciechowski,2021-Q1,3,5,5
 Dawid Wojciechowski,2020-Q4,0,0,0
@@ -4575,8 +4003,6 @@ Dawid Wojciechowski,2018-Q4,0,0,0
 Dawid Wojciechowski,2018-Q3,0,0,0
 Dawid Wojciechowski,2018-Q2,0,0,0
 Dawid Wojciechowski,2018-Q1,0,0,0
-Doe Hyun Yoon,2021-Q4,0,0,0
-Doe Hyun Yoon,2021-Q3,0,0,0
 Doe Hyun Yoon,2021-Q2,0,0,0
 Doe Hyun Yoon,2021-Q1,6,440,38
 Doe Hyun Yoon,2020-Q4,6,647,387
@@ -4591,8 +4017,6 @@ Doe Hyun Yoon,2018-Q4,11,674,93
 Doe Hyun Yoon,2018-Q3,13,689,201
 Doe Hyun Yoon,2018-Q2,0,0,0
 Doe Hyun Yoon,2018-Q1,0,0,0
-Eugene Kuznetsov,2021-Q4,0,0,0
-Eugene Kuznetsov,2021-Q3,0,0,0
 Eugene Kuznetsov,2021-Q2,0,0,0
 Eugene Kuznetsov,2021-Q1,3,53,3
 Eugene Kuznetsov,2020-Q4,0,0,0
@@ -4607,8 +4031,6 @@ Eugene Kuznetsov,2018-Q4,0,0,0
 Eugene Kuznetsov,2018-Q3,0,0,0
 Eugene Kuznetsov,2018-Q2,0,0,0
 Eugene Kuznetsov,2018-Q1,0,0,0
-Ewa Matejska,2021-Q4,0,0,0
-Ewa Matejska,2021-Q3,0,0,0
 Ewa Matejska,2021-Q2,0,0,0
 Ewa Matejska,2021-Q1,2,37,0
 Ewa Matejska,2020-Q4,0,0,0
@@ -4623,8 +4045,6 @@ Ewa Matejska,2018-Q4,0,0,0
 Ewa Matejska,2018-Q3,0,0,0
 Ewa Matejska,2018-Q2,0,0,0
 Ewa Matejska,2018-Q1,0,0,0
-Ron Shapiro,2021-Q4,0,0,0
-Ron Shapiro,2021-Q3,0,0,0
 Ron Shapiro,2021-Q2,0,0,0
 Ron Shapiro,2021-Q1,6,101,71
 Ron Shapiro,2020-Q4,0,0,0
@@ -4639,8 +4059,6 @@ Ron Shapiro,2018-Q4,0,0,0
 Ron Shapiro,2018-Q3,0,0,0
 Ron Shapiro,2018-Q2,0,0,0
 Ron Shapiro,2018-Q1,0,0,0
-Tom Hennigan,2021-Q4,0,0,0
-Tom Hennigan,2021-Q3,0,0,0
 Tom Hennigan,2021-Q2,0,0,0
 Tom Hennigan,2021-Q1,1,3,2
 Tom Hennigan,2020-Q4,2,19,12
@@ -4655,8 +4073,6 @@ Tom Hennigan,2018-Q4,14,242,60
 Tom Hennigan,2018-Q3,36,248,120
 Tom Hennigan,2018-Q2,120,1090,850
 Tom Hennigan,2018-Q1,0,0,0
-Chen Qian,2021-Q4,0,0,0
-Chen Qian,2021-Q3,0,0,0
 Chen Qian,2021-Q2,0,0,0
 Chen Qian,2021-Q1,28,819,138
 Chen Qian,2020-Q4,0,0,0
@@ -4671,8 +4087,6 @@ Chen Qian,2018-Q4,0,0,0
 Chen Qian,2018-Q3,0,0,0
 Chen Qian,2018-Q2,0,0,0
 Chen Qian,2018-Q1,0,0,0
-Stephan Lee,2021-Q4,0,0,0
-Stephan Lee,2021-Q3,0,0,0
 Stephan Lee,2021-Q2,0,0,0
 Stephan Lee,2021-Q1,5,68,19
 Stephan Lee,2020-Q4,8,165,19
@@ -4687,8 +4101,6 @@ Stephan Lee,2018-Q4,6,127,3
 Stephan Lee,2018-Q3,0,0,0
 Stephan Lee,2018-Q2,0,0,0
 Stephan Lee,2018-Q1,0,0,0
-Peter Ma,2021-Q4,0,0,0
-Peter Ma,2021-Q3,0,0,0
 Peter Ma,2021-Q2,0,0,0
 Peter Ma,2021-Q1,6,46,31
 Peter Ma,2020-Q4,0,0,0
@@ -4703,8 +4115,6 @@ Peter Ma,2018-Q4,25,458,286
 Peter Ma,2018-Q3,7,195,19
 Peter Ma,2018-Q2,0,0,0
 Peter Ma,2018-Q1,0,0,0
-Trevor Gale,2021-Q4,0,0,0
-Trevor Gale,2021-Q3,0,0,0
 Trevor Gale,2021-Q2,0,0,0
 Trevor Gale,2021-Q1,3,4,0
 Trevor Gale,2020-Q4,0,0,0
@@ -4719,8 +4129,6 @@ Trevor Gale,2018-Q4,0,0,0
 Trevor Gale,2018-Q3,0,0,0
 Trevor Gale,2018-Q2,0,0,0
 Trevor Gale,2018-Q1,0,0,0
-Guangda Lai,2021-Q4,0,0,0
-Guangda Lai,2021-Q3,0,0,0
 Guangda Lai,2021-Q2,0,0,0
 Guangda Lai,2021-Q1,9,132,72
 Guangda Lai,2020-Q4,0,0,0
@@ -4735,8 +4143,6 @@ Guangda Lai,2018-Q4,131,6178,3023
 Guangda Lai,2018-Q3,77,1061,855
 Guangda Lai,2018-Q2,18,233,130
 Guangda Lai,2018-Q1,72,1479,290
-Frederic Rechtenstein,2021-Q4,0,0,0
-Frederic Rechtenstein,2021-Q3,0,0,0
 Frederic Rechtenstein,2021-Q2,0,0,0
 Frederic Rechtenstein,2021-Q1,35,170,1458
 Frederic Rechtenstein,2020-Q4,5,159,3
@@ -4751,8 +4157,6 @@ Frederic Rechtenstein,2018-Q4,0,0,0
 Frederic Rechtenstein,2018-Q3,0,0,0
 Frederic Rechtenstein,2018-Q2,0,0,0
 Frederic Rechtenstein,2018-Q1,0,0,0
-Orivej Desh,2021-Q4,0,0,0
-Orivej Desh,2021-Q3,0,0,0
 Orivej Desh,2021-Q2,0,0,0
 Orivej Desh,2021-Q1,2,3,3
 Orivej Desh,2020-Q4,0,0,0
@@ -4767,8 +4171,6 @@ Orivej Desh,2018-Q4,0,0,0
 Orivej Desh,2018-Q3,0,0,0
 Orivej Desh,2018-Q2,0,0,0
 Orivej Desh,2018-Q1,0,0,0
-Zeno Gantner,2021-Q4,0,0,0
-Zeno Gantner,2021-Q3,0,0,0
 Zeno Gantner,2021-Q2,0,0,0
 Zeno Gantner,2021-Q1,12,33,52
 Zeno Gantner,2020-Q4,0,0,0
@@ -4783,8 +4185,6 @@ Zeno Gantner,2018-Q4,0,0,0
 Zeno Gantner,2018-Q3,0,0,0
 Zeno Gantner,2018-Q2,0,0,0
 Zeno Gantner,2018-Q1,0,0,0
-CyanXu,2021-Q4,0,0,0
-CyanXu,2021-Q3,0,0,0
 CyanXu,2021-Q2,0,0,0
 CyanXu,2021-Q1,13,157,143
 CyanXu,2020-Q4,0,0,0
@@ -4799,8 +4199,6 @@ CyanXu,2018-Q4,0,0,0
 CyanXu,2018-Q3,0,0,0
 CyanXu,2018-Q2,0,0,0
 CyanXu,2018-Q1,0,0,0
-Waqar Hameed,2021-Q4,0,0,0
-Waqar Hameed,2021-Q3,0,0,0
 Waqar Hameed,2021-Q2,0,0,0
 Waqar Hameed,2021-Q1,2,21,0
 Waqar Hameed,2020-Q4,0,0,0
@@ -4815,8 +4213,6 @@ Waqar Hameed,2018-Q4,0,0,0
 Waqar Hameed,2018-Q3,0,0,0
 Waqar Hameed,2018-Q2,0,0,0
 Waqar Hameed,2018-Q1,0,0,0
-Maxiwell S. Garcia,2021-Q4,0,0,0
-Maxiwell S. Garcia,2021-Q3,0,0,0
 Maxiwell S. Garcia,2021-Q2,0,0,0
 Maxiwell S. Garcia,2021-Q1,2,16,0
 Maxiwell S. Garcia,2020-Q4,0,0,0
@@ -4831,8 +4227,6 @@ Maxiwell S. Garcia,2018-Q4,0,0,0
 Maxiwell S. Garcia,2018-Q3,0,0,0
 Maxiwell S. Garcia,2018-Q2,0,0,0
 Maxiwell S. Garcia,2018-Q1,0,0,0
-Andrew Goodbody,2021-Q4,0,0,0
-Andrew Goodbody,2021-Q3,0,0,0
 Andrew Goodbody,2021-Q2,0,0,0
 Andrew Goodbody,2021-Q1,2,4,0
 Andrew Goodbody,2020-Q4,0,0,0
@@ -4847,8 +4241,6 @@ Andrew Goodbody,2018-Q4,0,0,0
 Andrew Goodbody,2018-Q3,0,0,0
 Andrew Goodbody,2018-Q2,0,0,0
 Andrew Goodbody,2018-Q1,0,0,0
-Juho Ha,2021-Q4,0,0,0
-Juho Ha,2021-Q3,0,0,0
 Juho Ha,2021-Q2,0,0,0
 Juho Ha,2021-Q1,8,382,0
 Juho Ha,2020-Q4,0,0,0
@@ -4863,8 +4255,6 @@ Juho Ha,2018-Q4,0,0,0
 Juho Ha,2018-Q3,0,0,0
 Juho Ha,2018-Q2,0,0,0
 Juho Ha,2018-Q1,0,0,0
-ShengYang1,2021-Q4,0,0,0
-ShengYang1,2021-Q3,0,0,0
 ShengYang1,2021-Q2,0,0,0
 ShengYang1,2021-Q1,4,514,0
 ShengYang1,2020-Q4,2,18,15
@@ -4879,8 +4269,6 @@ ShengYang1,2018-Q4,0,0,0
 ShengYang1,2018-Q3,0,0,0
 ShengYang1,2018-Q2,0,0,0
 ShengYang1,2018-Q1,0,0,0
-Yanhua Sun,2021-Q4,0,0,0
-Yanhua Sun,2021-Q3,0,0,0
 Yanhua Sun,2021-Q2,0,0,0
 Yanhua Sun,2021-Q1,46,125,66
 Yanhua Sun,2020-Q4,92,2014,1549
@@ -4895,8 +4283,6 @@ Yanhua Sun,2018-Q4,0,0,0
 Yanhua Sun,2018-Q3,0,0,0
 Yanhua Sun,2018-Q2,0,0,0
 Yanhua Sun,2018-Q1,0,0,0
-Ashish Jha,2021-Q4,0,0,0
-Ashish Jha,2021-Q3,0,0,0
 Ashish Jha,2021-Q2,0,0,0
 Ashish Jha,2021-Q1,1,0,0
 Ashish Jha,2020-Q4,0,0,0
@@ -4911,8 +4297,6 @@ Ashish Jha,2018-Q4,0,0,0
 Ashish Jha,2018-Q3,0,0,0
 Ashish Jha,2018-Q2,0,0,0
 Ashish Jha,2018-Q1,0,0,0
-Julien STEPHAN,2021-Q4,0,0,0
-Julien STEPHAN,2021-Q3,0,0,0
 Julien STEPHAN,2021-Q2,0,0,0
 Julien STEPHAN,2021-Q1,1,0,0
 Julien STEPHAN,2020-Q4,0,0,0
@@ -4927,8 +4311,6 @@ Julien STEPHAN,2018-Q4,0,0,0
 Julien STEPHAN,2018-Q3,0,0,0
 Julien STEPHAN,2018-Q2,0,0,0
 Julien STEPHAN,2018-Q1,0,0,0
-Jasmijn Bastings,2021-Q4,0,0,0
-Jasmijn Bastings,2021-Q3,0,0,0
 Jasmijn Bastings,2021-Q2,0,0,0
 Jasmijn Bastings,2021-Q1,1,0,0
 Jasmijn Bastings,2020-Q4,0,0,0
@@ -4943,8 +4325,6 @@ Jasmijn Bastings,2018-Q4,0,0,0
 Jasmijn Bastings,2018-Q3,0,0,0
 Jasmijn Bastings,2018-Q2,0,0,0
 Jasmijn Bastings,2018-Q1,0,0,0
-Mahesh Ravishankar,2021-Q4,0,0,0
-Mahesh Ravishankar,2021-Q3,0,0,0
 Mahesh Ravishankar,2021-Q2,0,0,0
 Mahesh Ravishankar,2021-Q1,3,110,94
 Mahesh Ravishankar,2020-Q4,0,0,0
@@ -4959,8 +4339,6 @@ Mahesh Ravishankar,2018-Q4,0,0,0
 Mahesh Ravishankar,2018-Q3,0,0,0
 Mahesh Ravishankar,2018-Q2,0,0,0
 Mahesh Ravishankar,2018-Q1,0,0,0
-Gil Tabak,2021-Q4,0,0,0
-Gil Tabak,2021-Q3,0,0,0
 Gil Tabak,2021-Q2,0,0,0
 Gil Tabak,2021-Q1,8,237,61
 Gil Tabak,2020-Q4,0,0,0
@@ -4975,8 +4353,6 @@ Gil Tabak,2018-Q4,0,0,0
 Gil Tabak,2018-Q3,0,0,0
 Gil Tabak,2018-Q2,0,0,0
 Gil Tabak,2018-Q1,0,0,0
-Haiming Bao,2021-Q4,0,0,0
-Haiming Bao,2021-Q3,0,0,0
 Haiming Bao,2021-Q2,0,0,0
 Haiming Bao,2021-Q1,3,41,25
 Haiming Bao,2020-Q4,7,352,11
@@ -4991,8 +4367,6 @@ Haiming Bao,2018-Q4,0,0,0
 Haiming Bao,2018-Q3,0,0,0
 Haiming Bao,2018-Q2,0,0,0
 Haiming Bao,2018-Q1,0,0,0
-Sergii Khomenko,2021-Q4,0,0,0
-Sergii Khomenko,2021-Q3,0,0,0
 Sergii Khomenko,2021-Q2,0,0,0
 Sergii Khomenko,2021-Q1,2,10,10
 Sergii Khomenko,2020-Q4,1,3,3
@@ -5007,8 +4381,6 @@ Sergii Khomenko,2018-Q4,0,0,0
 Sergii Khomenko,2018-Q3,2,5,2
 Sergii Khomenko,2018-Q2,5,9,7
 Sergii Khomenko,2018-Q1,2,3,3
-Mikhail Stepanov,2021-Q4,0,0,0
-Mikhail Stepanov,2021-Q3,0,0,0
 Mikhail Stepanov,2021-Q2,0,0,0
 Mikhail Stepanov,2021-Q1,5,34,19
 Mikhail Stepanov,2020-Q4,0,0,0
@@ -5023,8 +4395,6 @@ Mikhail Stepanov,2018-Q4,0,0,0
 Mikhail Stepanov,2018-Q3,0,0,0
 Mikhail Stepanov,2018-Q2,0,0,0
 Mikhail Stepanov,2018-Q1,0,0,0
-Colin Carroll,2021-Q4,0,0,0
-Colin Carroll,2021-Q3,0,0,0
 Colin Carroll,2021-Q2,0,0,0
 Colin Carroll,2021-Q1,3,11,0
 Colin Carroll,2020-Q4,3,20,2
@@ -5039,8 +4409,6 @@ Colin Carroll,2018-Q4,0,0,0
 Colin Carroll,2018-Q3,0,0,0
 Colin Carroll,2018-Q2,0,0,0
 Colin Carroll,2018-Q1,0,0,0
-Rohit Santhanam,2021-Q4,0,0,0
-Rohit Santhanam,2021-Q3,0,0,0
 Rohit Santhanam,2021-Q2,0,0,0
 Rohit Santhanam,2021-Q1,28,186,205
 Rohit Santhanam,2020-Q4,19,106,53
@@ -5055,8 +4423,6 @@ Rohit Santhanam,2018-Q4,0,0,0
 Rohit Santhanam,2018-Q3,0,0,0
 Rohit Santhanam,2018-Q2,0,0,0
 Rohit Santhanam,2018-Q1,0,0,0
-Ben,2021-Q4,0,0,0
-Ben,2021-Q3,0,0,0
 Ben,2021-Q2,0,0,0
 Ben,2021-Q1,1,16,0
 Ben,2020-Q4,0,0,0
@@ -5071,8 +4437,6 @@ Ben,2018-Q4,0,0,0
 Ben,2018-Q3,8,88,89
 Ben,2018-Q2,2,18,11
 Ben,2018-Q1,4,44,21
-Tzu-Wei Sung,2021-Q4,0,0,0
-Tzu-Wei Sung,2021-Q3,0,0,0
 Tzu-Wei Sung,2021-Q2,0,0,0
 Tzu-Wei Sung,2021-Q1,90,2487,1058
 Tzu-Wei Sung,2020-Q4,8,133,16
@@ -5087,8 +4451,6 @@ Tzu-Wei Sung,2018-Q4,0,0,0
 Tzu-Wei Sung,2018-Q3,0,0,0
 Tzu-Wei Sung,2018-Q2,0,0,0
 Tzu-Wei Sung,2018-Q1,0,0,0
-Andiry Xu,2021-Q4,0,0,0
-Andiry Xu,2021-Q3,0,0,0
 Andiry Xu,2021-Q2,0,0,0
 Andiry Xu,2021-Q1,3,30,0
 Andiry Xu,2020-Q4,0,0,0
@@ -5103,8 +4465,6 @@ Andiry Xu,2018-Q4,5,25,10
 Andiry Xu,2018-Q3,0,0,0
 Andiry Xu,2018-Q2,0,0,0
 Andiry Xu,2018-Q1,0,0,0
-annarev,2021-Q4,0,0,0
-annarev,2021-Q3,0,0,0
 annarev,2021-Q2,0,0,0
 annarev,2021-Q1,2,7,2
 annarev,2020-Q4,0,0,0
@@ -5119,8 +4479,6 @@ annarev,2018-Q4,1,2,0
 annarev,2018-Q3,0,0,0
 annarev,2018-Q2,1,2,0
 annarev,2018-Q1,0,0,0
-Michael Kuperstein,2021-Q4,0,0,0
-Michael Kuperstein,2021-Q3,0,0,0
 Michael Kuperstein,2021-Q2,0,0,0
 Michael Kuperstein,2021-Q1,1,0,0
 Michael Kuperstein,2020-Q4,0,0,0
@@ -5135,8 +4493,6 @@ Michael Kuperstein,2018-Q4,105,1856,545
 Michael Kuperstein,2018-Q3,107,1779,906
 Michael Kuperstein,2018-Q2,49,1205,494
 Michael Kuperstein,2018-Q1,24,425,193
-Srinivasan Narayanamoorthy,2021-Q4,0,0,0
-Srinivasan Narayanamoorthy,2021-Q3,0,0,0
 Srinivasan Narayanamoorthy,2021-Q2,0,0,0
 Srinivasan Narayanamoorthy,2021-Q1,2,24,2
 Srinivasan Narayanamoorthy,2020-Q4,0,0,0
@@ -5151,8 +4507,6 @@ Srinivasan Narayanamoorthy,2018-Q4,0,0,0
 Srinivasan Narayanamoorthy,2018-Q3,0,0,0
 Srinivasan Narayanamoorthy,2018-Q2,0,0,0
 Srinivasan Narayanamoorthy,2018-Q1,0,0,0
-Michal Szutenberg,2021-Q4,0,0,0
-Michal Szutenberg,2021-Q3,0,0,0
 Michal Szutenberg,2021-Q2,0,0,0
 Michal Szutenberg,2021-Q1,2,14,6
 Michal Szutenberg,2020-Q4,0,0,0
@@ -5167,8 +4521,6 @@ Michal Szutenberg,2018-Q4,0,0,0
 Michal Szutenberg,2018-Q3,0,0,0
 Michal Szutenberg,2018-Q2,0,0,0
 Michal Szutenberg,2018-Q1,0,0,0
-Tiezhen WANG,2021-Q4,0,0,0
-Tiezhen WANG,2021-Q3,0,0,0
 Tiezhen WANG,2021-Q2,0,0,0
 Tiezhen WANG,2021-Q1,5,10,8
 Tiezhen WANG,2020-Q4,10,23,16
@@ -5183,8 +4535,6 @@ Tiezhen WANG,2018-Q4,2,10,7
 Tiezhen WANG,2018-Q3,4,8,2
 Tiezhen WANG,2018-Q2,0,0,0
 Tiezhen WANG,2018-Q1,0,0,0
-Võ Văn Nghĩa,2021-Q4,0,0,0
-Võ Văn Nghĩa,2021-Q3,0,0,0
 Võ Văn Nghĩa,2021-Q2,0,0,0
 Võ Văn Nghĩa,2021-Q1,63,1210,2754
 Võ Văn Nghĩa,2020-Q4,131,2589,1181
@@ -5199,8 +4549,6 @@ Võ Văn Nghĩa,2018-Q4,0,0,0
 Võ Văn Nghĩa,2018-Q3,0,0,0
 Võ Văn Nghĩa,2018-Q2,0,0,0
 Võ Văn Nghĩa,2018-Q1,0,0,0
-Stephan,2021-Q4,0,0,0
-Stephan,2021-Q3,0,0,0
 Stephan,2021-Q2,0,0,0
 Stephan,2021-Q1,8,4,40
 Stephan,2020-Q4,27,1686,1264
@@ -5215,8 +4563,6 @@ Stephan,2018-Q4,0,0,0
 Stephan,2018-Q3,0,0,0
 Stephan,2018-Q2,0,0,0
 Stephan,2018-Q1,0,0,0
-Quintin,2021-Q4,0,0,0
-Quintin,2021-Q3,0,0,0
 Quintin,2021-Q2,0,0,0
 Quintin,2021-Q1,6,52,38
 Quintin,2020-Q4,8,385,44
@@ -5231,8 +4577,6 @@ Quintin,2018-Q4,0,0,0
 Quintin,2018-Q3,0,0,0
 Quintin,2018-Q2,0,0,0
 Quintin,2018-Q1,0,0,0
-Bairen Yi,2021-Q4,0,0,0
-Bairen Yi,2021-Q3,0,0,0
 Bairen Yi,2021-Q2,0,0,0
 Bairen Yi,2021-Q1,2,0,4
 Bairen Yi,2020-Q4,0,0,0
@@ -5247,8 +4591,6 @@ Bairen Yi,2018-Q4,13,231,357
 Bairen Yi,2018-Q3,2,102,63
 Bairen Yi,2018-Q2,0,0,0
 Bairen Yi,2018-Q1,0,0,0
-Junha Park,2021-Q4,0,0,0
-Junha Park,2021-Q3,0,0,0
 Junha Park,2021-Q2,0,0,0
 Junha Park,2021-Q1,1,0,2
 Junha Park,2020-Q4,0,0,0
@@ -5263,8 +4605,6 @@ Junha Park,2018-Q4,0,0,0
 Junha Park,2018-Q3,0,0,0
 Junha Park,2018-Q2,0,0,0
 Junha Park,2018-Q1,0,0,0
-Marius Brehler,2021-Q4,0,0,0
-Marius Brehler,2021-Q3,0,0,0
 Marius Brehler,2021-Q2,0,0,0
 Marius Brehler,2021-Q1,3,3,3
 Marius Brehler,2020-Q4,3,15,8
@@ -5279,8 +4619,6 @@ Marius Brehler,2018-Q4,0,0,0
 Marius Brehler,2018-Q3,0,0,0
 Marius Brehler,2018-Q2,0,0,0
 Marius Brehler,2018-Q1,0,0,0
-Frederick Liu,2021-Q4,0,0,0
-Frederick Liu,2021-Q3,0,0,0
 Frederick Liu,2021-Q2,0,0,0
 Frederick Liu,2021-Q1,3,40,17
 Frederick Liu,2020-Q4,0,0,0
@@ -5295,8 +4633,6 @@ Frederick Liu,2018-Q4,0,0,0
 Frederick Liu,2018-Q3,0,0,0
 Frederick Liu,2018-Q2,0,0,0
 Frederick Liu,2018-Q1,0,0,0
-ksood12345,2021-Q4,0,0,0
-ksood12345,2021-Q3,0,0,0
 ksood12345,2021-Q2,0,0,0
 ksood12345,2021-Q1,1,0,0
 ksood12345,2020-Q4,0,0,0
@@ -5311,8 +4647,6 @@ ksood12345,2018-Q4,0,0,0
 ksood12345,2018-Q3,0,0,0
 ksood12345,2018-Q2,0,0,0
 ksood12345,2018-Q1,0,0,0
-Sung Jin Hwang,2021-Q4,0,0,0
-Sung Jin Hwang,2021-Q3,0,0,0
 Sung Jin Hwang,2021-Q2,0,0,0
 Sung Jin Hwang,2021-Q1,6,113,32
 Sung Jin Hwang,2020-Q4,0,0,0
@@ -5327,8 +4661,6 @@ Sung Jin Hwang,2018-Q4,1,0,0
 Sung Jin Hwang,2018-Q3,13,206,15
 Sung Jin Hwang,2018-Q2,8,431,22
 Sung Jin Hwang,2018-Q1,27,2055,34
-justkw,2021-Q4,0,0,0
-justkw,2021-Q3,0,0,0
 justkw,2021-Q2,0,0,0
 justkw,2021-Q1,6,19,15
 justkw,2020-Q4,0,0,0
@@ -5343,8 +4675,6 @@ justkw,2018-Q4,0,0,0
 justkw,2018-Q3,0,0,0
 justkw,2018-Q2,0,0,0
 justkw,2018-Q1,0,0,0
-Omri Steiner,2021-Q4,0,0,0
-Omri Steiner,2021-Q3,0,0,0
 Omri Steiner,2021-Q2,0,0,0
 Omri Steiner,2021-Q1,4,73,45
 Omri Steiner,2020-Q4,0,0,0
@@ -5359,8 +4689,6 @@ Omri Steiner,2018-Q4,0,0,0
 Omri Steiner,2018-Q3,0,0,0
 Omri Steiner,2018-Q2,0,0,0
 Omri Steiner,2018-Q1,0,0,0
-puneeshkhanna,2021-Q4,0,0,0
-puneeshkhanna,2021-Q3,0,0,0
 puneeshkhanna,2021-Q2,0,0,0
 puneeshkhanna,2021-Q1,2,7,7
 puneeshkhanna,2020-Q4,0,0,0
@@ -5375,8 +4703,6 @@ puneeshkhanna,2018-Q4,0,0,0
 puneeshkhanna,2018-Q3,0,0,0
 puneeshkhanna,2018-Q2,0,0,0
 puneeshkhanna,2018-Q1,0,0,0
-AG Ramesh,2021-Q4,0,0,0
-AG Ramesh,2021-Q3,0,0,0
 AG Ramesh,2021-Q2,0,0,0
 AG Ramesh,2021-Q1,2,0,0
 AG Ramesh,2020-Q4,0,0,0
@@ -5391,8 +4717,6 @@ AG Ramesh,2018-Q4,37,550,1144
 AG Ramesh,2018-Q3,24,144,318
 AG Ramesh,2018-Q2,33,174,91
 AG Ramesh,2018-Q1,30,168,112
-Chris Olivier,2021-Q4,0,0,0
-Chris Olivier,2021-Q3,0,0,0
 Chris Olivier,2021-Q2,0,0,0
 Chris Olivier,2021-Q1,1,2,2
 Chris Olivier,2020-Q4,0,0,0
@@ -5407,8 +4731,6 @@ Chris Olivier,2018-Q4,0,0,0
 Chris Olivier,2018-Q3,0,0,0
 Chris Olivier,2018-Q2,0,0,0
 Chris Olivier,2018-Q1,0,0,0
-Keith Rush,2021-Q4,0,0,0
-Keith Rush,2021-Q3,0,0,0
 Keith Rush,2021-Q2,0,0,0
 Keith Rush,2021-Q1,10,330,7
 Keith Rush,2020-Q4,2,25,0
@@ -5423,8 +4745,6 @@ Keith Rush,2018-Q4,0,0,0
 Keith Rush,2018-Q3,0,0,0
 Keith Rush,2018-Q2,0,0,0
 Keith Rush,2018-Q1,0,0,0
-Bastiaan Aarts,2021-Q4,0,0,0
-Bastiaan Aarts,2021-Q3,0,0,0
 Bastiaan Aarts,2021-Q2,0,0,0
 Bastiaan Aarts,2021-Q1,0,0,0
 Bastiaan Aarts,2020-Q4,4,20,13
@@ -5439,8 +4759,6 @@ Bastiaan Aarts,2018-Q4,0,0,0
 Bastiaan Aarts,2018-Q3,0,0,0
 Bastiaan Aarts,2018-Q2,0,0,0
 Bastiaan Aarts,2018-Q1,0,0,0
-Piotr Zierhoffer,2021-Q4,0,0,0
-Piotr Zierhoffer,2021-Q3,0,0,0
 Piotr Zierhoffer,2021-Q2,0,0,0
 Piotr Zierhoffer,2021-Q1,1,0,0
 Piotr Zierhoffer,2020-Q4,0,0,0
@@ -5455,8 +4773,6 @@ Piotr Zierhoffer,2018-Q4,0,0,0
 Piotr Zierhoffer,2018-Q3,0,0,0
 Piotr Zierhoffer,2018-Q2,0,0,0
 Piotr Zierhoffer,2018-Q1,0,0,0
-Michael Gielda,2021-Q4,0,0,0
-Michael Gielda,2021-Q3,0,0,0
 Michael Gielda,2021-Q2,0,0,0
 Michael Gielda,2021-Q1,1,6,4
 Michael Gielda,2020-Q4,0,0,0
@@ -5471,8 +4787,6 @@ Michael Gielda,2018-Q4,5,37,15
 Michael Gielda,2018-Q3,0,0,0
 Michael Gielda,2018-Q2,0,0,0
 Michael Gielda,2018-Q1,0,0,0
-WindQAQ,2021-Q4,0,0,0
-WindQAQ,2021-Q3,0,0,0
 WindQAQ,2021-Q2,0,0,0
 WindQAQ,2021-Q1,2,55,4
 WindQAQ,2020-Q4,0,0,0
@@ -5487,8 +4801,6 @@ WindQAQ,2018-Q4,0,0,0
 WindQAQ,2018-Q3,0,0,0
 WindQAQ,2018-Q2,0,0,0
 WindQAQ,2018-Q1,0,0,0
-Yunlu Li,2021-Q4,0,0,0
-Yunlu Li,2021-Q3,0,0,0
 Yunlu Li,2021-Q2,0,0,0
 Yunlu Li,2021-Q1,17,849,366
 Yunlu Li,2020-Q4,30,517,123
@@ -5503,8 +4815,6 @@ Yunlu Li,2018-Q4,11,585,70
 Yunlu Li,2018-Q3,10,82,45
 Yunlu Li,2018-Q2,0,0,0
 Yunlu Li,2018-Q1,0,0,0
-Sai Ganesh Bandiatmakuri,2021-Q4,0,0,0
-Sai Ganesh Bandiatmakuri,2021-Q3,0,0,0
 Sai Ganesh Bandiatmakuri,2021-Q2,0,0,0
 Sai Ganesh Bandiatmakuri,2021-Q1,3,298,146
 Sai Ganesh Bandiatmakuri,2020-Q4,1,4,4
@@ -5519,8 +4829,6 @@ Sai Ganesh Bandiatmakuri,2018-Q4,0,0,0
 Sai Ganesh Bandiatmakuri,2018-Q3,0,0,0
 Sai Ganesh Bandiatmakuri,2018-Q2,0,0,0
 Sai Ganesh Bandiatmakuri,2018-Q1,0,0,0
-Simon Maurer,2021-Q4,0,0,0
-Simon Maurer,2021-Q3,0,0,0
 Simon Maurer,2021-Q2,0,0,0
 Simon Maurer,2021-Q1,2,4,4
 Simon Maurer,2020-Q4,0,0,0
@@ -5535,8 +4843,6 @@ Simon Maurer,2018-Q4,0,0,0
 Simon Maurer,2018-Q3,0,0,0
 Simon Maurer,2018-Q2,0,0,0
 Simon Maurer,2018-Q1,0,0,0
-Anirudh Sriram,2021-Q4,0,0,0
-Anirudh Sriram,2021-Q3,0,0,0
 Anirudh Sriram,2021-Q2,0,0,0
 Anirudh Sriram,2021-Q1,41,372,369
 Anirudh Sriram,2020-Q4,3,187,236
@@ -5551,8 +4857,6 @@ Anirudh Sriram,2018-Q4,0,0,0
 Anirudh Sriram,2018-Q3,0,0,0
 Anirudh Sriram,2018-Q2,0,0,0
 Anirudh Sriram,2018-Q1,0,0,0
-Guillaume Klein,2021-Q4,0,0,0
-Guillaume Klein,2021-Q3,0,0,0
 Guillaume Klein,2021-Q2,0,0,0
 Guillaume Klein,2021-Q1,1,0,0
 Guillaume Klein,2020-Q4,0,0,0
@@ -5567,8 +4871,6 @@ Guillaume Klein,2018-Q4,0,0,0
 Guillaume Klein,2018-Q3,2,47,9
 Guillaume Klein,2018-Q2,2,102,10
 Guillaume Klein,2018-Q1,5,284,18
-youshenmebutuo,2021-Q4,0,0,0
-youshenmebutuo,2021-Q3,0,0,0
 youshenmebutuo,2021-Q2,0,0,0
 youshenmebutuo,2021-Q1,1,0,0
 youshenmebutuo,2020-Q4,0,0,0
@@ -5583,8 +4885,6 @@ youshenmebutuo,2018-Q4,0,0,0
 youshenmebutuo,2018-Q3,0,0,0
 youshenmebutuo,2018-Q2,0,0,0
 youshenmebutuo,2018-Q1,0,0,0
-Nico Jahn,2021-Q4,0,0,0
-Nico Jahn,2021-Q3,0,0,0
 Nico Jahn,2021-Q2,0,0,0
 Nico Jahn,2021-Q1,1,0,0
 Nico Jahn,2020-Q4,0,0,0
@@ -5599,8 +4899,6 @@ Nico Jahn,2018-Q4,0,0,0
 Nico Jahn,2018-Q3,0,0,0
 Nico Jahn,2018-Q2,0,0,0
 Nico Jahn,2018-Q1,0,0,0
-Harry Slatyer,2021-Q4,0,0,0
-Harry Slatyer,2021-Q3,0,0,0
 Harry Slatyer,2021-Q2,0,0,0
 Harry Slatyer,2021-Q1,4,51,15
 Harry Slatyer,2020-Q4,0,0,0
@@ -5615,8 +4913,6 @@ Harry Slatyer,2018-Q4,0,0,0
 Harry Slatyer,2018-Q3,0,0,0
 Harry Slatyer,2018-Q2,0,0,0
 Harry Slatyer,2018-Q1,0,0,0
-Zhuoran Liu,2021-Q4,0,0,0
-Zhuoran Liu,2021-Q3,0,0,0
 Zhuoran Liu,2021-Q2,0,0,0
 Zhuoran Liu,2021-Q1,3,7,5
 Zhuoran Liu,2020-Q4,0,0,0
@@ -5631,8 +4927,6 @@ Zhuoran Liu,2018-Q4,0,0,0
 Zhuoran Liu,2018-Q3,0,0,0
 Zhuoran Liu,2018-Q2,0,0,0
 Zhuoran Liu,2018-Q1,0,0,0
-Xunkai Zhang,2021-Q4,0,0,0
-Xunkai Zhang,2021-Q3,0,0,0
 Xunkai Zhang,2021-Q2,0,0,0
 Xunkai Zhang,2021-Q1,4,21,17
 Xunkai Zhang,2020-Q4,3,6,19
@@ -5647,8 +4941,6 @@ Xunkai Zhang,2018-Q4,0,0,0
 Xunkai Zhang,2018-Q3,0,0,0
 Xunkai Zhang,2018-Q2,0,0,0
 Xunkai Zhang,2018-Q1,0,0,0
-Vinayaka Bandishti,2021-Q4,0,0,0
-Vinayaka Bandishti,2021-Q3,0,0,0
 Vinayaka Bandishti,2021-Q2,0,0,0
 Vinayaka Bandishti,2021-Q1,2,14,5
 Vinayaka Bandishti,2020-Q4,0,0,0
@@ -5663,8 +4955,6 @@ Vinayaka Bandishti,2018-Q4,0,0,0
 Vinayaka Bandishti,2018-Q3,0,0,0
 Vinayaka Bandishti,2018-Q2,0,0,0
 Vinayaka Bandishti,2018-Q1,0,0,0
-Alex Stark,2021-Q4,0,0,0
-Alex Stark,2021-Q3,0,0,0
 Alex Stark,2021-Q2,0,0,0
 Alex Stark,2021-Q1,17,1898,570
 Alex Stark,2020-Q4,0,0,0
@@ -5679,8 +4969,6 @@ Alex Stark,2018-Q4,0,0,0
 Alex Stark,2018-Q3,0,0,0
 Alex Stark,2018-Q2,0,0,0
 Alex Stark,2018-Q1,0,0,0
-Revan Sopher,2021-Q4,0,0,0
-Revan Sopher,2021-Q3,0,0,0
 Revan Sopher,2021-Q2,0,0,0
 Revan Sopher,2021-Q1,23,538,105
 Revan Sopher,2020-Q4,10,357,124
@@ -5695,8 +4983,6 @@ Revan Sopher,2018-Q4,8,331,54
 Revan Sopher,2018-Q3,27,38,664
 Revan Sopher,2018-Q2,0,0,0
 Revan Sopher,2018-Q1,0,0,0
-Scott Wegner,2021-Q4,0,0,0
-Scott Wegner,2021-Q3,0,0,0
 Scott Wegner,2021-Q2,0,0,0
 Scott Wegner,2021-Q1,1,13,2
 Scott Wegner,2020-Q4,0,0,0
@@ -5711,8 +4997,6 @@ Scott Wegner,2018-Q4,0,0,0
 Scott Wegner,2018-Q3,0,0,0
 Scott Wegner,2018-Q2,0,0,0
 Scott Wegner,2018-Q1,0,0,0
-Eric Spishak-Thomas,2021-Q4,0,0,0
-Eric Spishak-Thomas,2021-Q3,0,0,0
 Eric Spishak-Thomas,2021-Q2,0,0,0
 Eric Spishak-Thomas,2021-Q1,3,30,16
 Eric Spishak-Thomas,2020-Q4,0,0,0
@@ -5727,8 +5011,6 @@ Eric Spishak-Thomas,2018-Q4,0,0,0
 Eric Spishak-Thomas,2018-Q3,0,0,0
 Eric Spishak-Thomas,2018-Q2,0,0,0
 Eric Spishak-Thomas,2018-Q1,0,0,0
-viktprog,2021-Q4,0,0,0
-viktprog,2021-Q3,0,0,0
 viktprog,2021-Q2,0,0,0
 viktprog,2021-Q1,1,5,0
 viktprog,2020-Q4,0,0,0
@@ -5743,8 +5025,6 @@ viktprog,2018-Q4,0,0,0
 viktprog,2018-Q3,0,0,0
 viktprog,2018-Q2,0,0,0
 viktprog,2018-Q1,0,0,0
-Scott Main,2021-Q4,0,0,0
-Scott Main,2021-Q3,0,0,0
 Scott Main,2021-Q2,0,0,0
 Scott Main,2021-Q1,2,53,143
 Scott Main,2020-Q4,2,32,22
@@ -5759,8 +5039,6 @@ Scott Main,2018-Q4,0,0,0
 Scott Main,2018-Q3,0,0,0
 Scott Main,2018-Q2,0,0,0
 Scott Main,2018-Q1,0,0,0
-Rehan Guha,2021-Q4,0,0,0
-Rehan Guha,2021-Q3,0,0,0
 Rehan Guha,2021-Q2,0,0,0
 Rehan Guha,2021-Q1,2,8,7
 Rehan Guha,2020-Q4,0,0,0
@@ -5775,8 +5053,6 @@ Rehan Guha,2018-Q4,0,0,0
 Rehan Guha,2018-Q3,0,0,0
 Rehan Guha,2018-Q2,0,0,0
 Rehan Guha,2018-Q1,0,0,0
-Mao Yunfei,2021-Q4,0,0,0
-Mao Yunfei,2021-Q3,0,0,0
 Mao Yunfei,2021-Q2,0,0,0
 Mao Yunfei,2021-Q1,3,10,15
 Mao Yunfei,2020-Q4,1,8,0
@@ -5791,8 +5067,6 @@ Mao Yunfei,2018-Q4,0,0,0
 Mao Yunfei,2018-Q3,0,0,0
 Mao Yunfei,2018-Q2,0,0,0
 Mao Yunfei,2018-Q1,0,0,0
-Jungshik Jang,2021-Q4,0,0,0
-Jungshik Jang,2021-Q3,0,0,0
 Jungshik Jang,2021-Q2,0,0,0
 Jungshik Jang,2021-Q1,2,2,2
 Jungshik Jang,2020-Q4,0,0,0
@@ -5807,8 +5081,6 @@ Jungshik Jang,2018-Q4,0,0,0
 Jungshik Jang,2018-Q3,0,0,0
 Jungshik Jang,2018-Q2,0,0,0
 Jungshik Jang,2018-Q1,0,0,0
-Marconi Jiang,2021-Q4,0,0,0
-Marconi Jiang,2021-Q3,0,0,0
 Marconi Jiang,2021-Q2,0,0,0
 Marconi Jiang,2021-Q1,1,0,0
 Marconi Jiang,2020-Q4,0,0,0
@@ -5823,8 +5095,6 @@ Marconi Jiang,2018-Q4,0,0,0
 Marconi Jiang,2018-Q3,0,0,0
 Marconi Jiang,2018-Q2,0,0,0
 Marconi Jiang,2018-Q1,0,0,0
-Sean Moriarity,2021-Q4,0,0,0
-Sean Moriarity,2021-Q3,0,0,0
 Sean Moriarity,2021-Q2,0,0,0
 Sean Moriarity,2021-Q1,1,0,0
 Sean Moriarity,2020-Q4,0,0,0
@@ -5839,8 +5109,6 @@ Sean Moriarity,2018-Q4,0,0,0
 Sean Moriarity,2018-Q3,0,0,0
 Sean Moriarity,2018-Q2,0,0,0
 Sean Moriarity,2018-Q1,0,0,0
-gerbauz,2021-Q4,0,0,0
-gerbauz,2021-Q3,0,0,0
 gerbauz,2021-Q2,0,0,0
 gerbauz,2021-Q1,9,22,20
 gerbauz,2020-Q4,23,963,731
@@ -5855,8 +5123,6 @@ gerbauz,2018-Q4,0,0,0
 gerbauz,2018-Q3,0,0,0
 gerbauz,2018-Q2,0,0,0
 gerbauz,2018-Q1,0,0,0
-Håkon Sandsmark,2021-Q4,0,0,0
-Håkon Sandsmark,2021-Q3,0,0,0
 Håkon Sandsmark,2021-Q2,0,0,0
 Håkon Sandsmark,2021-Q1,0,0,0
 Håkon Sandsmark,2020-Q4,0,0,0
@@ -5871,8 +5137,6 @@ Håkon Sandsmark,2018-Q4,0,0,0
 Håkon Sandsmark,2018-Q3,0,0,0
 Håkon Sandsmark,2018-Q2,0,0,0
 Håkon Sandsmark,2018-Q1,0,0,0
-marconi1964,2021-Q4,0,0,0
-marconi1964,2021-Q3,0,0,0
 marconi1964,2021-Q2,0,0,0
 marconi1964,2021-Q1,1,0,0
 marconi1964,2020-Q4,0,0,0
@@ -5887,8 +5151,6 @@ marconi1964,2018-Q4,0,0,0
 marconi1964,2018-Q3,0,0,0
 marconi1964,2018-Q2,0,0,0
 marconi1964,2018-Q1,0,0,0
-Ryan Kuester,2021-Q4,0,0,0
-Ryan Kuester,2021-Q3,0,0,0
 Ryan Kuester,2021-Q2,0,0,0
 Ryan Kuester,2021-Q1,24,841,132
 Ryan Kuester,2020-Q4,23,638,272
@@ -5903,8 +5165,6 @@ Ryan Kuester,2018-Q4,0,0,0
 Ryan Kuester,2018-Q3,0,0,0
 Ryan Kuester,2018-Q2,0,0,0
 Ryan Kuester,2018-Q1,0,0,0
-Paul Klinger,2021-Q4,0,0,0
-Paul Klinger,2021-Q3,0,0,0
 Paul Klinger,2021-Q2,0,0,0
 Paul Klinger,2021-Q1,2,22,9
 Paul Klinger,2020-Q4,0,0,0
@@ -5919,8 +5179,6 @@ Paul Klinger,2018-Q4,0,0,0
 Paul Klinger,2018-Q3,0,0,0
 Paul Klinger,2018-Q2,0,0,0
 Paul Klinger,2018-Q1,0,0,0
-Jonathan Shen,2021-Q4,0,0,0
-Jonathan Shen,2021-Q3,0,0,0
 Jonathan Shen,2021-Q2,0,0,0
 Jonathan Shen,2021-Q1,3,18,12
 Jonathan Shen,2020-Q4,0,0,0
@@ -5935,8 +5193,6 @@ Jonathan Shen,2018-Q4,5,130,28
 Jonathan Shen,2018-Q3,1,4,0
 Jonathan Shen,2018-Q2,0,0,0
 Jonathan Shen,2018-Q1,0,0,0
-Phoenix Meadowlark,2021-Q4,0,0,0
-Phoenix Meadowlark,2021-Q3,0,0,0
 Phoenix Meadowlark,2021-Q2,0,0,0
 Phoenix Meadowlark,2021-Q1,1,0,0
 Phoenix Meadowlark,2020-Q4,9,107,2
@@ -5951,8 +5207,6 @@ Phoenix Meadowlark,2018-Q4,0,0,0
 Phoenix Meadowlark,2018-Q3,0,0,0
 Phoenix Meadowlark,2018-Q2,0,0,0
 Phoenix Meadowlark,2018-Q1,0,0,0
-pnikam-cad,2021-Q4,0,0,0
-pnikam-cad,2021-Q3,0,0,0
 pnikam-cad,2021-Q2,0,0,0
 pnikam-cad,2021-Q1,2,4,4
 pnikam-cad,2020-Q4,0,0,0
@@ -5967,8 +5221,6 @@ pnikam-cad,2018-Q4,0,0,0
 pnikam-cad,2018-Q3,0,0,0
 pnikam-cad,2018-Q2,0,0,0
 pnikam-cad,2018-Q1,0,0,0
-Scott Tseng,2021-Q4,0,0,0
-Scott Tseng,2021-Q3,0,0,0
 Scott Tseng,2021-Q2,0,0,0
 Scott Tseng,2021-Q1,2,18,0
 Scott Tseng,2020-Q4,0,0,0
@@ -5983,8 +5235,6 @@ Scott Tseng,2018-Q4,0,0,0
 Scott Tseng,2018-Q3,0,0,0
 Scott Tseng,2018-Q2,6,19,11
 Scott Tseng,2018-Q1,4,16,20
-Suxin Guo,2021-Q4,0,0,0
-Suxin Guo,2021-Q3,0,0,0
 Suxin Guo,2021-Q2,0,0,0
 Suxin Guo,2021-Q1,1,0,0
 Suxin Guo,2020-Q4,0,0,0
@@ -5999,8 +5249,6 @@ Suxin Guo,2018-Q4,0,0,0
 Suxin Guo,2018-Q3,0,0,0
 Suxin Guo,2018-Q2,0,0,0
 Suxin Guo,2018-Q1,0,0,0
-Mingsheng Hong,2021-Q4,0,0,0
-Mingsheng Hong,2021-Q3,0,0,0
 Mingsheng Hong,2021-Q2,0,0,0
 Mingsheng Hong,2021-Q1,26,818,62
 Mingsheng Hong,2020-Q4,31,293,191
@@ -6015,8 +5263,6 @@ Mingsheng Hong,2018-Q4,6,40,9
 Mingsheng Hong,2018-Q3,34,666,94
 Mingsheng Hong,2018-Q2,5,143,27
 Mingsheng Hong,2018-Q1,108,10491,1066
-Behzad Abghari,2021-Q4,0,0,0
-Behzad Abghari,2021-Q3,0,0,0
 Behzad Abghari,2021-Q2,0,0,0
 Behzad Abghari,2021-Q1,1,4,2
 Behzad Abghari,2020-Q4,0,0,0
@@ -6031,8 +5277,6 @@ Behzad Abghari,2018-Q4,0,0,0
 Behzad Abghari,2018-Q3,0,0,0
 Behzad Abghari,2018-Q2,0,0,0
 Behzad Abghari,2018-Q1,0,0,0
-zhuyie,2021-Q4,0,0,0
-zhuyie,2021-Q3,0,0,0
 zhuyie,2021-Q2,0,0,0
 zhuyie,2021-Q1,3,76,7
 zhuyie,2020-Q4,0,0,0
@@ -6047,8 +5291,6 @@ zhuyie,2018-Q4,0,0,0
 zhuyie,2018-Q3,0,0,0
 zhuyie,2018-Q2,0,0,0
 zhuyie,2018-Q1,0,0,0
-Marissa Ikonomidis,2021-Q4,0,0,0
-Marissa Ikonomidis,2021-Q3,0,0,0
 Marissa Ikonomidis,2021-Q2,0,0,0
 Marissa Ikonomidis,2021-Q1,1,8,0
 Marissa Ikonomidis,2020-Q4,81,626,276
@@ -6063,8 +5305,6 @@ Marissa Ikonomidis,2018-Q4,0,0,0
 Marissa Ikonomidis,2018-Q3,0,0,0
 Marissa Ikonomidis,2018-Q2,0,0,0
 Marissa Ikonomidis,2018-Q1,0,0,0
-Takayoshi Koizumi,2021-Q4,0,0,0
-Takayoshi Koizumi,2021-Q3,0,0,0
 Takayoshi Koizumi,2021-Q2,0,0,0
 Takayoshi Koizumi,2021-Q1,12,599,0
 Takayoshi Koizumi,2020-Q4,0,0,0
@@ -6079,8 +5319,6 @@ Takayoshi Koizumi,2018-Q4,0,0,0
 Takayoshi Koizumi,2018-Q3,0,0,0
 Takayoshi Koizumi,2018-Q2,0,0,0
 Takayoshi Koizumi,2018-Q1,0,0,0
-Oceania2018,2021-Q4,0,0,0
-Oceania2018,2021-Q3,0,0,0
 Oceania2018,2021-Q2,0,0,0
 Oceania2018,2021-Q1,12,123,16
 Oceania2018,2020-Q4,3,40,43
@@ -6095,8 +5333,6 @@ Oceania2018,2018-Q4,0,0,0
 Oceania2018,2018-Q3,0,0,0
 Oceania2018,2018-Q2,0,0,0
 Oceania2018,2018-Q1,0,0,0
-Harry Zhang,2021-Q4,0,0,0
-Harry Zhang,2021-Q3,0,0,0
 Harry Zhang,2021-Q2,0,0,0
 Harry Zhang,2021-Q1,1,4,2
 Harry Zhang,2020-Q4,0,0,0
@@ -6111,8 +5347,6 @@ Harry Zhang,2018-Q4,0,0,0
 Harry Zhang,2018-Q3,0,0,0
 Harry Zhang,2018-Q2,0,0,0
 Harry Zhang,2018-Q1,0,0,0
-8bitmp3,2021-Q4,0,0,0
-8bitmp3,2021-Q3,0,0,0
 8bitmp3,2021-Q2,0,0,0
 8bitmp3,2021-Q1,3,7,6
 8bitmp3,2020-Q4,0,0,0
@@ -6127,8 +5361,6 @@ Harry Zhang,2018-Q1,0,0,0
 8bitmp3,2018-Q3,0,0,0
 8bitmp3,2018-Q2,0,0,0
 8bitmp3,2018-Q1,0,0,0
-Summer Yue,2021-Q4,0,0,0
-Summer Yue,2021-Q3,0,0,0
 Summer Yue,2021-Q2,0,0,0
 Summer Yue,2021-Q1,1,0,0
 Summer Yue,2020-Q4,0,0,0
@@ -6143,8 +5375,6 @@ Summer Yue,2018-Q4,0,0,0
 Summer Yue,2018-Q3,0,0,0
 Summer Yue,2018-Q2,0,0,0
 Summer Yue,2018-Q1,0,0,0
-mbhuiyan,2021-Q4,0,0,0
-mbhuiyan,2021-Q3,0,0,0
 mbhuiyan,2021-Q2,0,0,0
 mbhuiyan,2021-Q1,3,4,4
 mbhuiyan,2020-Q4,1,10,0
@@ -6159,8 +5389,6 @@ mbhuiyan,2018-Q4,8,53,730
 mbhuiyan,2018-Q3,31,1220,289
 mbhuiyan,2018-Q2,7,79,47
 mbhuiyan,2018-Q1,0,0,0
-Ayush Dubey,2021-Q4,0,0,0
-Ayush Dubey,2021-Q3,0,0,0
 Ayush Dubey,2021-Q2,0,0,0
 Ayush Dubey,2021-Q1,30,731,613
 Ayush Dubey,2020-Q4,34,974,125
@@ -6175,8 +5403,6 @@ Ayush Dubey,2018-Q4,60,1821,1203
 Ayush Dubey,2018-Q3,55,2588,1604
 Ayush Dubey,2018-Q2,23,350,142
 Ayush Dubey,2018-Q1,24,1614,45
-Taebum Kim,2021-Q4,0,0,0
-Taebum Kim,2021-Q3,0,0,0
 Taebum Kim,2021-Q2,0,0,0
 Taebum Kim,2021-Q1,1,2,0
 Taebum Kim,2020-Q4,0,0,0
@@ -6191,8 +5417,6 @@ Taebum Kim,2018-Q4,0,0,0
 Taebum Kim,2018-Q3,0,0,0
 Taebum Kim,2018-Q2,0,0,0
 Taebum Kim,2018-Q1,0,0,0
-Hongkun Yu,2021-Q4,0,0,0
-Hongkun Yu,2021-Q3,0,0,0
 Hongkun Yu,2021-Q2,0,0,0
 Hongkun Yu,2021-Q1,6,116,21
 Hongkun Yu,2020-Q4,7,62,65
@@ -6207,8 +5431,6 @@ Hongkun Yu,2018-Q4,0,0,0
 Hongkun Yu,2018-Q3,0,0,0
 Hongkun Yu,2018-Q2,0,0,0
 Hongkun Yu,2018-Q1,0,0,0
-Jaehong Kim,2021-Q4,0,0,0
-Jaehong Kim,2021-Q3,0,0,0
 Jaehong Kim,2021-Q2,0,0,0
 Jaehong Kim,2021-Q1,3,42,6
 Jaehong Kim,2020-Q4,20,83,47
@@ -6223,8 +5445,6 @@ Jaehong Kim,2018-Q4,0,0,0
 Jaehong Kim,2018-Q3,0,0,0
 Jaehong Kim,2018-Q2,0,0,0
 Jaehong Kim,2018-Q1,0,0,0
-David Davis,2021-Q4,0,0,0
-David Davis,2021-Q3,0,0,0
 David Davis,2021-Q2,0,0,0
 David Davis,2021-Q1,0,0,0
 David Davis,2020-Q4,16,1321,597
@@ -6239,8 +5459,6 @@ David Davis,2018-Q4,0,0,0
 David Davis,2018-Q3,0,0,0
 David Davis,2018-Q2,0,0,0
 David Davis,2018-Q1,0,0,0
-Yanhui Liang,2021-Q4,0,0,0
-Yanhui Liang,2021-Q3,0,0,0
 Yanhui Liang,2021-Q2,0,0,0
 Yanhui Liang,2021-Q1,13,224,104
 Yanhui Liang,2020-Q4,81,1490,294
@@ -6255,8 +5473,6 @@ Yanhui Liang,2018-Q4,60,550,180
 Yanhui Liang,2018-Q3,0,0,0
 Yanhui Liang,2018-Q2,0,0,0
 Yanhui Liang,2018-Q1,0,0,0
-Suraj Upadhyay,2021-Q4,0,0,0
-Suraj Upadhyay,2021-Q3,0,0,0
 Suraj Upadhyay,2021-Q2,0,0,0
 Suraj Upadhyay,2021-Q1,2,4,2
 Suraj Upadhyay,2020-Q4,0,0,0
@@ -6271,8 +5487,6 @@ Suraj Upadhyay,2018-Q4,0,0,0
 Suraj Upadhyay,2018-Q3,0,0,0
 Suraj Upadhyay,2018-Q2,0,0,0
 Suraj Upadhyay,2018-Q1,0,0,0
-Abolfazl Shahbazi,2021-Q4,0,0,0
-Abolfazl Shahbazi,2021-Q3,0,0,0
 Abolfazl Shahbazi,2021-Q2,0,0,0
 Abolfazl Shahbazi,2021-Q1,142,2162,608
 Abolfazl Shahbazi,2020-Q4,25,232,243
@@ -6287,8 +5501,6 @@ Abolfazl Shahbazi,2018-Q4,0,0,0
 Abolfazl Shahbazi,2018-Q3,0,0,0
 Abolfazl Shahbazi,2018-Q2,0,0,0
 Abolfazl Shahbazi,2018-Q1,0,0,0
-Vincent ABRIOU,2021-Q4,0,0,0
-Vincent ABRIOU,2021-Q3,0,0,0
 Vincent ABRIOU,2021-Q2,0,0,0
 Vincent ABRIOU,2021-Q1,1,0,2
 Vincent ABRIOU,2020-Q4,0,0,0
@@ -6303,8 +5515,6 @@ Vincent ABRIOU,2018-Q4,0,0,0
 Vincent ABRIOU,2018-Q3,0,0,0
 Vincent ABRIOU,2018-Q2,0,0,0
 Vincent ABRIOU,2018-Q1,0,0,0
-Xinan Jiang,2021-Q4,0,0,0
-Xinan Jiang,2021-Q3,0,0,0
 Xinan Jiang,2021-Q2,0,0,0
 Xinan Jiang,2021-Q1,8,132,2
 Xinan Jiang,2020-Q4,3,12,3
@@ -6319,8 +5529,6 @@ Xinan Jiang,2018-Q4,0,0,0
 Xinan Jiang,2018-Q3,0,0,0
 Xinan Jiang,2018-Q2,0,0,0
 Xinan Jiang,2018-Q1,0,0,0
-Stephen Matthews,2021-Q4,0,0,0
-Stephen Matthews,2021-Q3,0,0,0
 Stephen Matthews,2021-Q2,0,0,0
 Stephen Matthews,2021-Q1,1,2,2
 Stephen Matthews,2020-Q4,0,0,0
@@ -6335,8 +5543,6 @@ Stephen Matthews,2018-Q4,0,0,0
 Stephen Matthews,2018-Q3,0,0,0
 Stephen Matthews,2018-Q2,0,0,0
 Stephen Matthews,2018-Q1,0,0,0
-Anh Tuan Nguyen,2021-Q4,0,0,0
-Anh Tuan Nguyen,2021-Q3,0,0,0
 Anh Tuan Nguyen,2021-Q2,0,0,0
 Anh Tuan Nguyen,2021-Q1,1,5,4
 Anh Tuan Nguyen,2020-Q4,0,0,0
@@ -6351,8 +5557,6 @@ Anh Tuan Nguyen,2018-Q4,0,0,0
 Anh Tuan Nguyen,2018-Q3,0,0,0
 Anh Tuan Nguyen,2018-Q2,0,0,0
 Anh Tuan Nguyen,2018-Q1,0,0,0
-David Kao,2021-Q4,0,0,0
-David Kao,2021-Q3,0,0,0
 David Kao,2021-Q2,0,0,0
 David Kao,2021-Q1,2,7,5
 David Kao,2020-Q4,2,32,27
@@ -6367,8 +5571,6 @@ David Kao,2018-Q4,0,0,0
 David Kao,2018-Q3,0,0,0
 David Kao,2018-Q2,0,0,0
 David Kao,2018-Q1,0,0,0
-Jin Young Sohn,2021-Q4,0,0,0
-Jin Young Sohn,2021-Q3,0,0,0
 Jin Young Sohn,2021-Q2,0,0,0
 Jin Young Sohn,2021-Q1,8,448,261
 Jin Young Sohn,2020-Q4,0,0,0
@@ -6383,8 +5585,6 @@ Jin Young Sohn,2018-Q4,0,0,0
 Jin Young Sohn,2018-Q3,0,0,0
 Jin Young Sohn,2018-Q2,0,0,0
 Jin Young Sohn,2018-Q1,0,0,0
-Christina Sorokin,2021-Q4,0,0,0
-Christina Sorokin,2021-Q3,0,0,0
 Christina Sorokin,2021-Q2,0,0,0
 Christina Sorokin,2021-Q1,1,2,3
 Christina Sorokin,2020-Q4,0,0,0
@@ -6399,8 +5599,6 @@ Christina Sorokin,2018-Q4,0,0,0
 Christina Sorokin,2018-Q3,1,11,4
 Christina Sorokin,2018-Q2,0,0,0
 Christina Sorokin,2018-Q1,0,0,0
-Lei Zhang,2021-Q4,0,0,0
-Lei Zhang,2021-Q3,0,0,0
 Lei Zhang,2021-Q2,0,0,0
 Lei Zhang,2021-Q1,4,69,7
 Lei Zhang,2020-Q4,0,0,0
@@ -6415,8 +5613,6 @@ Lei Zhang,2018-Q4,63,708,231
 Lei Zhang,2018-Q3,0,0,0
 Lei Zhang,2018-Q2,0,0,0
 Lei Zhang,2018-Q1,0,0,0
-Ayan Moitra,2021-Q4,0,0,0
-Ayan Moitra,2021-Q3,0,0,0
 Ayan Moitra,2021-Q2,0,0,0
 Ayan Moitra,2021-Q1,2,11,0
 Ayan Moitra,2020-Q4,0,0,0
@@ -6431,8 +5627,6 @@ Ayan Moitra,2018-Q4,0,0,0
 Ayan Moitra,2018-Q3,0,0,0
 Ayan Moitra,2018-Q2,0,0,0
 Ayan Moitra,2018-Q1,0,0,0
-Alfie Edwards,2021-Q4,0,0,0
-Alfie Edwards,2021-Q3,0,0,0
 Alfie Edwards,2021-Q2,0,0,0
 Alfie Edwards,2021-Q1,5,44,7
 Alfie Edwards,2020-Q4,9,70,13
@@ -6447,8 +5641,6 @@ Alfie Edwards,2018-Q4,0,0,0
 Alfie Edwards,2018-Q3,0,0,0
 Alfie Edwards,2018-Q2,0,0,0
 Alfie Edwards,2018-Q1,0,0,0
-Etienne Pot,2021-Q4,0,0,0
-Etienne Pot,2021-Q3,0,0,0
 Etienne Pot,2021-Q2,0,0,0
 Etienne Pot,2021-Q1,6,26,0
 Etienne Pot,2020-Q4,6,64,7
@@ -6463,8 +5655,6 @@ Etienne Pot,2018-Q4,0,0,0
 Etienne Pot,2018-Q3,0,0,0
 Etienne Pot,2018-Q2,0,0,0
 Etienne Pot,2018-Q1,0,0,0
-Mohamed Nour Abouelseoud,2021-Q4,0,0,0
-Mohamed Nour Abouelseoud,2021-Q3,0,0,0
 Mohamed Nour Abouelseoud,2021-Q2,0,0,0
 Mohamed Nour Abouelseoud,2021-Q1,0,0,0
 Mohamed Nour Abouelseoud,2020-Q4,31,292,6
@@ -6479,8 +5669,6 @@ Mohamed Nour Abouelseoud,2018-Q4,0,0,0
 Mohamed Nour Abouelseoud,2018-Q3,0,0,0
 Mohamed Nour Abouelseoud,2018-Q2,0,0,0
 Mohamed Nour Abouelseoud,2018-Q1,0,0,0
-Xiao Yang,2021-Q4,0,0,0
-Xiao Yang,2021-Q3,0,0,0
 Xiao Yang,2021-Q2,0,0,0
 Xiao Yang,2021-Q1,1,3,0
 Xiao Yang,2020-Q4,0,0,0
@@ -6495,8 +5683,6 @@ Xiao Yang,2018-Q4,0,0,0
 Xiao Yang,2018-Q3,0,0,0
 Xiao Yang,2018-Q2,0,0,0
 Xiao Yang,2018-Q1,0,0,0
-fo40225,2021-Q4,0,0,0
-fo40225,2021-Q3,0,0,0
 fo40225,2021-Q2,0,0,0
 fo40225,2021-Q1,4,7,7
 fo40225,2020-Q4,0,0,0
@@ -6511,8 +5697,6 @@ fo40225,2018-Q4,0,0,0
 fo40225,2018-Q3,5,10,0
 fo40225,2018-Q2,9,59,23
 fo40225,2018-Q1,29,113,111
-Eli Osherovich,2021-Q4,0,0,0
-Eli Osherovich,2021-Q3,0,0,0
 Eli Osherovich,2021-Q2,0,0,0
 Eli Osherovich,2021-Q1,1,0,0
 Eli Osherovich,2020-Q4,0,0,0
@@ -6527,8 +5711,6 @@ Eli Osherovich,2018-Q4,0,0,0
 Eli Osherovich,2018-Q3,0,0,0
 Eli Osherovich,2018-Q2,0,0,0
 Eli Osherovich,2018-Q1,0,0,0
-yair_ehrenwald,2021-Q4,0,0,0
-yair_ehrenwald,2021-Q3,0,0,0
 yair_ehrenwald,2021-Q2,0,0,0
 yair_ehrenwald,2021-Q1,2,11,520
 yair_ehrenwald,2020-Q4,0,0,0
@@ -6543,8 +5725,6 @@ yair_ehrenwald,2018-Q4,0,0,0
 yair_ehrenwald,2018-Q3,0,0,0
 yair_ehrenwald,2018-Q2,0,0,0
 yair_ehrenwald,2018-Q1,0,0,0
-Måns Bermell,2021-Q4,0,0,0
-Måns Bermell,2021-Q3,0,0,0
 Måns Bermell,2021-Q2,0,0,0
 Måns Bermell,2021-Q1,1,14,0
 Måns Bermell,2020-Q4,0,0,0
@@ -6559,8 +5739,6 @@ Måns Bermell,2018-Q4,0,0,0
 Måns Bermell,2018-Q3,0,0,0
 Måns Bermell,2018-Q2,0,0,0
 Måns Bermell,2018-Q1,0,0,0
-Harsh188,2021-Q4,0,0,0
-Harsh188,2021-Q3,0,0,0
 Harsh188,2021-Q2,0,0,0
 Harsh188,2021-Q1,2,0,0
 Harsh188,2020-Q4,4,22,13
@@ -6575,8 +5753,6 @@ Harsh188,2018-Q4,0,0,0
 Harsh188,2018-Q3,0,0,0
 Harsh188,2018-Q2,0,0,0
 Harsh188,2018-Q1,0,0,0
-Traun Leyden,2021-Q4,0,0,0
-Traun Leyden,2021-Q3,0,0,0
 Traun Leyden,2021-Q2,0,0,0
 Traun Leyden,2021-Q1,1,0,0
 Traun Leyden,2020-Q4,0,0,0
@@ -6591,8 +5767,6 @@ Traun Leyden,2018-Q4,0,0,0
 Traun Leyden,2018-Q3,0,0,0
 Traun Leyden,2018-Q2,0,0,0
 Traun Leyden,2018-Q1,0,0,0
-rmothukuru,2021-Q4,0,0,0
-rmothukuru,2021-Q3,0,0,0
 rmothukuru,2021-Q2,0,0,0
 rmothukuru,2021-Q1,3,21,23
 rmothukuru,2020-Q4,6,43,26
@@ -6607,8 +5781,6 @@ rmothukuru,2018-Q4,0,0,0
 rmothukuru,2018-Q3,0,0,0
 rmothukuru,2018-Q2,0,0,0
 rmothukuru,2018-Q1,0,0,0
-Sami Kama,2021-Q4,0,0,0
-Sami Kama,2021-Q3,0,0,0
 Sami Kama,2021-Q2,0,0,0
 Sami Kama,2021-Q1,1,30,11
 Sami Kama,2020-Q4,2,94,26
@@ -6623,8 +5795,6 @@ Sami Kama,2018-Q4,64,507,354
 Sami Kama,2018-Q3,9,393,137
 Sami Kama,2018-Q2,185,4801,2999
 Sami Kama,2018-Q1,240,8572,2369
-Natanael,2021-Q4,0,0,0
-Natanael,2021-Q3,0,0,0
 Natanael,2021-Q2,0,0,0
 Natanael,2021-Q1,3,8,15
 Natanael,2020-Q4,0,0,0
@@ -6639,8 +5809,6 @@ Natanael,2018-Q4,0,0,0
 Natanael,2018-Q3,0,0,0
 Natanael,2018-Q2,0,0,0
 Natanael,2018-Q1,0,0,0
-Liangzhe Yuan,2021-Q4,0,0,0
-Liangzhe Yuan,2021-Q3,0,0,0
 Liangzhe Yuan,2021-Q2,0,0,0
 Liangzhe Yuan,2021-Q1,1,0,0
 Liangzhe Yuan,2020-Q4,0,0,0
@@ -6655,8 +5823,6 @@ Liangzhe Yuan,2018-Q4,0,0,0
 Liangzhe Yuan,2018-Q3,0,0,0
 Liangzhe Yuan,2018-Q2,0,0,0
 Liangzhe Yuan,2018-Q1,0,0,0
-ravikyram,2021-Q4,0,0,0
-ravikyram,2021-Q3,0,0,0
 ravikyram,2021-Q2,0,0,0
 ravikyram,2021-Q1,1,0,0
 ravikyram,2020-Q4,1,0,2
@@ -6671,8 +5837,6 @@ ravikyram,2018-Q4,0,0,0
 ravikyram,2018-Q3,0,0,0
 ravikyram,2018-Q2,0,0,0
 ravikyram,2018-Q1,0,0,0
-Matej,2021-Q4,0,0,0
-Matej,2021-Q3,0,0,0
 Matej,2021-Q2,0,0,0
 Matej,2021-Q1,1,2,0
 Matej,2020-Q4,0,0,0
@@ -6687,8 +5851,6 @@ Matej,2018-Q4,0,0,0
 Matej,2018-Q3,0,0,0
 Matej,2018-Q2,0,0,0
 Matej,2018-Q1,0,0,0
-Jingyue Wu,2021-Q4,0,0,0
-Jingyue Wu,2021-Q3,0,0,0
 Jingyue Wu,2021-Q2,0,0,0
 Jingyue Wu,2021-Q1,7,73,8
 Jingyue Wu,2020-Q4,0,0,0
@@ -6703,8 +5865,6 @@ Jingyue Wu,2018-Q4,7,70,8
 Jingyue Wu,2018-Q3,5,47,20
 Jingyue Wu,2018-Q2,8,165,67
 Jingyue Wu,2018-Q1,7,286,24
-Simrit,2021-Q4,0,0,0
-Simrit,2021-Q3,0,0,0
 Simrit,2021-Q2,0,0,0
 Simrit,2021-Q1,2,0,48
 Simrit,2020-Q4,0,0,0
@@ -6719,8 +5879,6 @@ Simrit,2018-Q4,0,0,0
 Simrit,2018-Q3,0,0,0
 Simrit,2018-Q2,0,0,0
 Simrit,2018-Q1,0,0,0
-Artemiy Ryabinkov,2021-Q4,0,0,0
-Artemiy Ryabinkov,2021-Q3,0,0,0
 Artemiy Ryabinkov,2021-Q2,0,0,0
 Artemiy Ryabinkov,2021-Q1,1,18,0
 Artemiy Ryabinkov,2020-Q4,0,0,0
@@ -6735,8 +5893,6 @@ Artemiy Ryabinkov,2018-Q4,0,0,0
 Artemiy Ryabinkov,2018-Q3,0,0,0
 Artemiy Ryabinkov,2018-Q2,0,0,0
 Artemiy Ryabinkov,2018-Q1,0,0,0
-Mark Sandler,2021-Q4,0,0,0
-Mark Sandler,2021-Q3,0,0,0
 Mark Sandler,2021-Q2,0,0,0
 Mark Sandler,2021-Q1,4,121,78
 Mark Sandler,2020-Q4,0,0,0
@@ -6751,8 +5907,6 @@ Mark Sandler,2018-Q4,0,0,0
 Mark Sandler,2018-Q3,0,0,0
 Mark Sandler,2018-Q2,0,0,0
 Mark Sandler,2018-Q1,0,0,0
-Jens Elofsson,2021-Q4,0,0,0
-Jens Elofsson,2021-Q3,0,0,0
 Jens Elofsson,2021-Q2,0,0,0
 Jens Elofsson,2021-Q1,9,80,5
 Jens Elofsson,2020-Q4,1,0,0
@@ -6767,8 +5921,6 @@ Jens Elofsson,2018-Q4,0,0,0
 Jens Elofsson,2018-Q3,0,0,0
 Jens Elofsson,2018-Q2,0,0,0
 Jens Elofsson,2018-Q1,0,0,0
-wangsiyu,2021-Q4,0,0,0
-wangsiyu,2021-Q3,0,0,0
 wangsiyu,2021-Q2,0,0,0
 wangsiyu,2021-Q1,3,39,0
 wangsiyu,2020-Q4,0,0,0
@@ -6783,8 +5935,6 @@ wangsiyu,2018-Q4,21,413,136
 wangsiyu,2018-Q3,7,90,7
 wangsiyu,2018-Q2,9,46,20
 wangsiyu,2018-Q1,0,0,0
-henri,2021-Q4,0,0,0
-henri,2021-Q3,0,0,0
 henri,2021-Q2,0,0,0
 henri,2021-Q1,2,0,0
 henri,2020-Q4,0,0,0
@@ -6799,8 +5949,6 @@ henri,2018-Q4,0,0,0
 henri,2018-Q3,0,0,0
 henri,2018-Q2,0,0,0
 henri,2018-Q1,0,0,0
-RJ Skerry-Ryan,2021-Q4,0,0,0
-RJ Skerry-Ryan,2021-Q3,0,0,0
 RJ Skerry-Ryan,2021-Q2,0,0,0
 RJ Skerry-Ryan,2021-Q1,4,38,4
 RJ Skerry-Ryan,2020-Q4,0,0,0
@@ -6815,8 +5963,6 @@ RJ Skerry-Ryan,2018-Q4,0,0,0
 RJ Skerry-Ryan,2018-Q3,0,0,0
 RJ Skerry-Ryan,2018-Q2,0,0,0
 RJ Skerry-Ryan,2018-Q1,0,0,0
-Nathan Luehr,2021-Q4,0,0,0
-Nathan Luehr,2021-Q3,0,0,0
 Nathan Luehr,2021-Q2,0,0,0
 Nathan Luehr,2021-Q1,13,4999,4
 Nathan Luehr,2020-Q4,5,73,27
@@ -6831,8 +5977,6 @@ Nathan Luehr,2018-Q4,0,0,0
 Nathan Luehr,2018-Q3,3,299,259
 Nathan Luehr,2018-Q2,0,0,0
 Nathan Luehr,2018-Q1,1,33,4
-Benjamin Klimczak,2021-Q4,0,0,0
-Benjamin Klimczak,2021-Q3,0,0,0
 Benjamin Klimczak,2021-Q2,0,0,0
 Benjamin Klimczak,2021-Q1,0,0,0
 Benjamin Klimczak,2020-Q4,9,118,16
@@ -6847,8 +5991,6 @@ Benjamin Klimczak,2018-Q4,0,0,0
 Benjamin Klimczak,2018-Q3,0,0,0
 Benjamin Klimczak,2018-Q2,0,0,0
 Benjamin Klimczak,2018-Q1,0,0,0
-Matej Rizman,2021-Q4,0,0,0
-Matej Rizman,2021-Q3,0,0,0
 Matej Rizman,2021-Q2,0,0,0
 Matej Rizman,2021-Q1,4,295,72
 Matej Rizman,2020-Q4,10,724,368
@@ -6863,8 +6005,6 @@ Matej Rizman,2018-Q4,11,191,0
 Matej Rizman,2018-Q3,0,0,0
 Matej Rizman,2018-Q2,0,0,0
 Matej Rizman,2018-Q1,0,0,0
-Daniel Moore,2021-Q4,0,0,0
-Daniel Moore,2021-Q3,0,0,0
 Daniel Moore,2021-Q2,0,0,0
 Daniel Moore,2021-Q1,1,0,0
 Daniel Moore,2020-Q4,0,0,0
@@ -6879,8 +6019,6 @@ Daniel Moore,2018-Q4,0,0,0
 Daniel Moore,2018-Q3,0,0,0
 Daniel Moore,2018-Q2,0,0,0
 Daniel Moore,2018-Q1,0,0,0
-kushanam,2021-Q4,0,0,0
-kushanam,2021-Q3,0,0,0
 kushanam,2021-Q2,0,0,0
 kushanam,2021-Q1,2,0,0
 kushanam,2020-Q4,46,595,360
@@ -6895,8 +6033,6 @@ kushanam,2018-Q4,0,0,0
 kushanam,2018-Q3,0,0,0
 kushanam,2018-Q2,0,0,0
 kushanam,2018-Q1,0,0,0
-Chunxiang (Jake) Zheng,2021-Q4,0,0,0
-Chunxiang (Jake) Zheng,2021-Q3,0,0,0
 Chunxiang (Jake) Zheng,2021-Q2,0,0,0
 Chunxiang (Jake) Zheng,2021-Q1,2,3,0
 Chunxiang (Jake) Zheng,2020-Q4,0,0,0
@@ -6911,8 +6047,6 @@ Chunxiang (Jake) Zheng,2018-Q4,0,0,0
 Chunxiang (Jake) Zheng,2018-Q3,0,0,0
 Chunxiang (Jake) Zheng,2018-Q2,0,0,0
 Chunxiang (Jake) Zheng,2018-Q1,0,0,0
-Jeremy Lau,2021-Q4,0,0,0
-Jeremy Lau,2021-Q3,0,0,0
 Jeremy Lau,2021-Q2,0,0,0
 Jeremy Lau,2021-Q1,5,30,31
 Jeremy Lau,2020-Q4,4,0,4
@@ -6927,8 +6061,6 @@ Jeremy Lau,2018-Q4,26,189,80
 Jeremy Lau,2018-Q3,6,130,111
 Jeremy Lau,2018-Q2,39,1598,1234
 Jeremy Lau,2018-Q1,35,542,66
-Corey Cole,2021-Q4,0,0,0
-Corey Cole,2021-Q3,0,0,0
 Corey Cole,2021-Q2,0,0,0
 Corey Cole,2021-Q1,2,0,0
 Corey Cole,2020-Q4,1,2,2
@@ -6943,8 +6075,6 @@ Corey Cole,2018-Q4,0,0,0
 Corey Cole,2018-Q3,0,0,0
 Corey Cole,2018-Q2,0,0,0
 Corey Cole,2018-Q1,0,0,0
-Yun Peng,2021-Q4,0,0,0
-Yun Peng,2021-Q3,0,0,0
 Yun Peng,2021-Q2,0,0,0
 Yun Peng,2021-Q1,6,22,2
 Yun Peng,2020-Q4,13,97,36
@@ -6959,8 +6089,6 @@ Yun Peng,2018-Q4,1,3,0
 Yun Peng,2018-Q3,3,2,0
 Yun Peng,2018-Q2,5,33,3
 Yun Peng,2018-Q1,67,643,181
-Phat Tran,2021-Q4,0,0,0
-Phat Tran,2021-Q3,0,0,0
 Phat Tran,2021-Q2,0,0,0
 Phat Tran,2021-Q1,1,3,3
 Phat Tran,2020-Q4,0,0,0
@@ -6975,8 +6103,6 @@ Phat Tran,2018-Q4,0,0,0
 Phat Tran,2018-Q3,0,0,0
 Phat Tran,2018-Q2,0,0,0
 Phat Tran,2018-Q1,0,0,0
-Eugene Brevdo,2021-Q4,0,0,0
-Eugene Brevdo,2021-Q3,0,0,0
 Eugene Brevdo,2021-Q2,0,0,0
 Eugene Brevdo,2021-Q1,2,16,0
 Eugene Brevdo,2020-Q4,20,542,79
@@ -6991,8 +6117,6 @@ Eugene Brevdo,2018-Q4,66,1323,267
 Eugene Brevdo,2018-Q3,106,1194,786
 Eugene Brevdo,2018-Q2,33,975,145
 Eugene Brevdo,2018-Q1,122,4354,1865
-Bramandia Ramadhana,2021-Q4,0,0,0
-Bramandia Ramadhana,2021-Q3,0,0,0
 Bramandia Ramadhana,2021-Q2,0,0,0
 Bramandia Ramadhana,2021-Q1,3,10,2
 Bramandia Ramadhana,2020-Q4,0,0,0
@@ -7007,8 +6131,6 @@ Bramandia Ramadhana,2018-Q4,0,0,0
 Bramandia Ramadhana,2018-Q3,0,0,0
 Bramandia Ramadhana,2018-Q2,0,0,0
 Bramandia Ramadhana,2018-Q1,0,0,0
-TVLIgnacy,2021-Q4,0,0,0
-TVLIgnacy,2021-Q3,0,0,0
 TVLIgnacy,2021-Q2,0,0,0
 TVLIgnacy,2021-Q1,1,0,0
 TVLIgnacy,2020-Q4,0,0,0
@@ -7023,8 +6145,6 @@ TVLIgnacy,2018-Q4,0,0,0
 TVLIgnacy,2018-Q3,0,0,0
 TVLIgnacy,2018-Q2,0,0,0
 TVLIgnacy,2018-Q1,0,0,0
-Abhinav Upadhyay,2021-Q4,0,0,0
-Abhinav Upadhyay,2021-Q3,0,0,0
 Abhinav Upadhyay,2021-Q2,0,0,0
 Abhinav Upadhyay,2021-Q1,1,0,0
 Abhinav Upadhyay,2020-Q4,0,0,0
@@ -7039,8 +6159,6 @@ Abhinav Upadhyay,2018-Q4,1,0,0
 Abhinav Upadhyay,2018-Q3,0,0,0
 Abhinav Upadhyay,2018-Q2,0,0,0
 Abhinav Upadhyay,2018-Q1,0,0,0
-Mehmet Deveci,2021-Q4,0,0,0
-Mehmet Deveci,2021-Q3,0,0,0
 Mehmet Deveci,2021-Q2,0,0,0
 Mehmet Deveci,2021-Q1,2,20,0
 Mehmet Deveci,2020-Q4,11,230,119
@@ -7055,8 +6173,6 @@ Mehmet Deveci,2018-Q4,0,0,0
 Mehmet Deveci,2018-Q3,0,0,0
 Mehmet Deveci,2018-Q2,0,0,0
 Mehmet Deveci,2018-Q1,0,0,0
-Sean Silva,2021-Q4,0,0,0
-Sean Silva,2021-Q3,0,0,0
 Sean Silva,2021-Q2,0,0,0
 Sean Silva,2021-Q1,2,19,0
 Sean Silva,2020-Q4,9,350,272
@@ -7071,8 +6187,6 @@ Sean Silva,2018-Q4,0,0,0
 Sean Silva,2018-Q3,0,0,0
 Sean Silva,2018-Q2,1,0,0
 Sean Silva,2018-Q1,0,0,0
-rposts,2021-Q4,0,0,0
-rposts,2021-Q3,0,0,0
 rposts,2021-Q2,0,0,0
 rposts,2021-Q1,3,8,4
 rposts,2020-Q4,5,85,0
@@ -7087,8 +6201,6 @@ rposts,2018-Q4,0,0,0
 rposts,2018-Q3,0,0,0
 rposts,2018-Q2,0,0,0
 rposts,2018-Q1,0,0,0
-Mitchel Humpherys,2021-Q4,0,0,0
-Mitchel Humpherys,2021-Q3,0,0,0
 Mitchel Humpherys,2021-Q2,0,0,0
 Mitchel Humpherys,2021-Q1,1,6,3
 Mitchel Humpherys,2020-Q4,0,0,0
@@ -7103,8 +6215,6 @@ Mitchel Humpherys,2018-Q4,0,0,0
 Mitchel Humpherys,2018-Q3,0,0,0
 Mitchel Humpherys,2018-Q2,0,0,0
 Mitchel Humpherys,2018-Q1,0,0,0
-Jia Fu Low,2021-Q4,0,0,0
-Jia Fu Low,2021-Q3,0,0,0
 Jia Fu Low,2021-Q2,0,0,0
 Jia Fu Low,2021-Q1,1,4,4
 Jia Fu Low,2020-Q4,0,0,0
@@ -7119,8 +6229,6 @@ Jia Fu Low,2018-Q4,0,0,0
 Jia Fu Low,2018-Q3,0,0,0
 Jia Fu Low,2018-Q2,0,0,0
 Jia Fu Low,2018-Q1,0,0,0
-rsun-bdti,2021-Q4,0,0,0
-rsun-bdti,2021-Q3,0,0,0
 rsun-bdti,2021-Q2,0,0,0
 rsun-bdti,2021-Q1,1,0,123
 rsun-bdti,2020-Q4,0,0,0
@@ -7135,8 +6243,6 @@ rsun-bdti,2018-Q4,0,0,0
 rsun-bdti,2018-Q3,0,0,0
 rsun-bdti,2018-Q2,0,0,0
 rsun-bdti,2018-Q1,0,0,0
-Kazuaki Ishizaki,2021-Q4,0,0,0
-Kazuaki Ishizaki,2021-Q3,0,0,0
 Kazuaki Ishizaki,2021-Q2,0,0,0
 Kazuaki Ishizaki,2021-Q1,14,17,17
 Kazuaki Ishizaki,2020-Q4,27,44,44
@@ -7151,8 +6257,6 @@ Kazuaki Ishizaki,2018-Q4,0,0,0
 Kazuaki Ishizaki,2018-Q3,0,0,0
 Kazuaki Ishizaki,2018-Q2,0,0,0
 Kazuaki Ishizaki,2018-Q1,0,0,0
-kashyapraval,2021-Q4,0,0,0
-kashyapraval,2021-Q3,0,0,0
 kashyapraval,2021-Q2,0,0,0
 kashyapraval,2021-Q1,1,0,0
 kashyapraval,2020-Q4,0,0,0
@@ -7167,8 +6271,6 @@ kashyapraval,2018-Q4,0,0,0
 kashyapraval,2018-Q3,0,0,0
 kashyapraval,2018-Q2,0,0,0
 kashyapraval,2018-Q1,0,0,0
-mdfaijul,2021-Q4,0,0,0
-mdfaijul,2021-Q3,0,0,0
 mdfaijul,2021-Q2,0,0,0
 mdfaijul,2021-Q1,1,8,10
 mdfaijul,2020-Q4,13,997,262
@@ -7183,8 +6285,6 @@ mdfaijul,2018-Q4,18,804,2393
 mdfaijul,2018-Q3,0,0,0
 mdfaijul,2018-Q2,0,0,0
 mdfaijul,2018-Q1,1,16,7
-ganand1,2021-Q4,0,0,0
-ganand1,2021-Q3,0,0,0
 ganand1,2021-Q2,0,0,0
 ganand1,2021-Q1,1,5,5
 ganand1,2020-Q4,9,292,42
@@ -7199,8 +6299,6 @@ ganand1,2018-Q4,0,0,0
 ganand1,2018-Q3,0,0,0
 ganand1,2018-Q2,0,0,0
 ganand1,2018-Q1,0,0,0
-Keith Mok,2021-Q4,0,0,0
-Keith Mok,2021-Q3,0,0,0
 Keith Mok,2021-Q2,0,0,0
 Keith Mok,2021-Q1,1,0,0
 Keith Mok,2020-Q4,0,0,0
@@ -7215,8 +6313,6 @@ Keith Mok,2018-Q4,0,0,0
 Keith Mok,2018-Q3,0,0,0
 Keith Mok,2018-Q2,0,0,0
 Keith Mok,2018-Q1,0,0,0
-Martin Kubovčík,2021-Q4,0,0,0
-Martin Kubovčík,2021-Q3,0,0,0
 Martin Kubovčík,2021-Q2,0,0,0
 Martin Kubovčík,2021-Q1,1,6,6
 Martin Kubovčík,2020-Q4,0,0,0
@@ -7231,8 +6327,6 @@ Martin Kubovčík,2018-Q4,0,0,0
 Martin Kubovčík,2018-Q3,0,0,0
 Martin Kubovčík,2018-Q2,0,0,0
 Martin Kubovčík,2018-Q1,0,0,0
-Bart Ribbers,2021-Q4,0,0,0
-Bart Ribbers,2021-Q3,0,0,0
 Bart Ribbers,2021-Q2,0,0,0
 Bart Ribbers,2021-Q1,1,3,3
 Bart Ribbers,2020-Q4,0,0,0
@@ -7247,8 +6341,6 @@ Bart Ribbers,2018-Q4,0,0,0
 Bart Ribbers,2018-Q3,0,0,0
 Bart Ribbers,2018-Q2,0,0,0
 Bart Ribbers,2018-Q1,0,0,0
-ewsn1593,2021-Q4,0,0,0
-ewsn1593,2021-Q3,0,0,0
 ewsn1593,2021-Q2,0,0,0
 ewsn1593,2021-Q1,1,0,0
 ewsn1593,2020-Q4,0,0,0
@@ -7263,8 +6355,6 @@ ewsn1593,2018-Q4,0,0,0
 ewsn1593,2018-Q3,0,0,0
 ewsn1593,2018-Q2,0,0,0
 ewsn1593,2018-Q1,0,0,0
-machineko,2021-Q4,0,0,0
-machineko,2021-Q3,0,0,0
 machineko,2021-Q2,0,0,0
 machineko,2021-Q1,1,6,4
 machineko,2020-Q4,1,8,0
@@ -7279,8 +6369,6 @@ machineko,2018-Q4,0,0,0
 machineko,2018-Q3,0,0,0
 machineko,2018-Q2,0,0,0
 machineko,2018-Q1,0,0,0
-Junhyuk So,2021-Q4,0,0,0
-Junhyuk So,2021-Q3,0,0,0
 Junhyuk So,2021-Q2,0,0,0
 Junhyuk So,2021-Q1,1,0,0
 Junhyuk So,2020-Q4,0,0,0
@@ -7295,8 +6383,6 @@ Junhyuk So,2018-Q4,0,0,0
 Junhyuk So,2018-Q3,0,0,0
 Junhyuk So,2018-Q2,0,0,0
 Junhyuk So,2018-Q1,0,0,0
-Dean Wyatte,2021-Q4,0,0,0
-Dean Wyatte,2021-Q3,0,0,0
 Dean Wyatte,2021-Q2,0,0,0
 Dean Wyatte,2021-Q1,0,0,0
 Dean Wyatte,2020-Q4,2,164,22
@@ -7311,8 +6397,6 @@ Dean Wyatte,2018-Q4,0,0,0
 Dean Wyatte,2018-Q3,0,0,0
 Dean Wyatte,2018-Q2,0,0,0
 Dean Wyatte,2018-Q1,0,0,0
-dependabot[bot],2021-Q4,0,0,0
-dependabot[bot],2021-Q3,0,0,0
 dependabot[bot],2021-Q2,0,0,0
 dependabot[bot],2021-Q1,0,0,0
 dependabot[bot],2020-Q4,3,0,0
@@ -7327,8 +6411,6 @@ dependabot[bot],2018-Q4,0,0,0
 dependabot[bot],2018-Q3,0,0,0
 dependabot[bot],2018-Q2,0,0,0
 dependabot[bot],2018-Q1,0,0,0
-Ikko Ashimine,2021-Q4,0,0,0
-Ikko Ashimine,2021-Q3,0,0,0
 Ikko Ashimine,2021-Q2,0,0,0
 Ikko Ashimine,2021-Q1,0,0,0
 Ikko Ashimine,2020-Q4,2,0,0
@@ -7343,8 +6425,6 @@ Ikko Ashimine,2018-Q4,0,0,0
 Ikko Ashimine,2018-Q3,0,0,0
 Ikko Ashimine,2018-Q2,0,0,0
 Ikko Ashimine,2018-Q1,0,0,0
-Chris Leary,2021-Q4,0,0,0
-Chris Leary,2021-Q3,0,0,0
 Chris Leary,2021-Q2,0,0,0
 Chris Leary,2021-Q1,0,0,0
 Chris Leary,2020-Q4,1,0,0
@@ -7359,8 +6439,6 @@ Chris Leary,2018-Q4,4,10,5
 Chris Leary,2018-Q3,17,188,45
 Chris Leary,2018-Q2,66,2959,1413
 Chris Leary,2018-Q1,130,1970,481
-ather,2021-Q4,0,0,0
-ather,2021-Q3,0,0,0
 ather,2021-Q2,0,0,0
 ather,2021-Q1,0,0,0
 ather,2020-Q4,5,867,860
@@ -7375,8 +6453,6 @@ ather,2018-Q4,0,0,0
 ather,2018-Q3,0,0,0
 ather,2018-Q2,0,0,0
 ather,2018-Q1,0,0,0
-Dominic Jack,2021-Q4,0,0,0
-Dominic Jack,2021-Q3,0,0,0
 Dominic Jack,2021-Q2,0,0,0
 Dominic Jack,2021-Q1,0,0,0
 Dominic Jack,2020-Q4,4,19,15
@@ -7391,8 +6467,6 @@ Dominic Jack,2018-Q4,0,0,0
 Dominic Jack,2018-Q3,0,0,0
 Dominic Jack,2018-Q2,0,0,0
 Dominic Jack,2018-Q1,0,0,0
-Vikram Dattu,2021-Q4,0,0,0
-Vikram Dattu,2021-Q3,0,0,0
 Vikram Dattu,2021-Q2,0,0,0
 Vikram Dattu,2021-Q1,0,0,0
 Vikram Dattu,2020-Q4,14,139,39
@@ -7407,8 +6481,6 @@ Vikram Dattu,2018-Q4,0,0,0
 Vikram Dattu,2018-Q3,0,0,0
 Vikram Dattu,2018-Q2,0,0,0
 Vikram Dattu,2018-Q1,0,0,0
-vaibhav,2021-Q4,0,0,0
-vaibhav,2021-Q3,0,0,0
 vaibhav,2021-Q2,0,0,0
 vaibhav,2021-Q1,0,0,0
 vaibhav,2020-Q4,4,44,0
@@ -7423,8 +6495,6 @@ vaibhav,2018-Q4,0,0,0
 vaibhav,2018-Q3,0,0,0
 vaibhav,2018-Q2,0,0,0
 vaibhav,2018-Q1,0,0,0
-yunfeima,2021-Q4,0,0,0
-yunfeima,2021-Q3,0,0,0
 yunfeima,2021-Q2,0,0,0
 yunfeima,2021-Q1,0,0,0
 yunfeima,2020-Q4,7,31,17
@@ -7439,8 +6509,6 @@ yunfeima,2018-Q4,0,0,0
 yunfeima,2018-Q3,0,0,0
 yunfeima,2018-Q2,0,0,0
 yunfeima,2018-Q1,0,0,0
-Teng Lu,2021-Q4,0,0,0
-Teng Lu,2021-Q3,0,0,0
 Teng Lu,2021-Q2,0,0,0
 Teng Lu,2021-Q1,0,0,0
 Teng Lu,2020-Q4,17,244,284
@@ -7455,8 +6523,6 @@ Teng Lu,2018-Q4,0,0,0
 Teng Lu,2018-Q3,0,0,0
 Teng Lu,2018-Q2,0,0,0
 Teng Lu,2018-Q1,0,0,0
-yqtianust,2021-Q4,0,0,0
-yqtianust,2021-Q3,0,0,0
 yqtianust,2021-Q2,0,0,0
 yqtianust,2021-Q1,0,0,0
 yqtianust,2020-Q4,1,0,0
@@ -7471,8 +6537,6 @@ yqtianust,2018-Q4,0,0,0
 yqtianust,2018-Q3,0,0,0
 yqtianust,2018-Q2,0,0,0
 yqtianust,2018-Q1,0,0,0
-Oskar Flordal,2021-Q4,0,0,0
-Oskar Flordal,2021-Q3,0,0,0
 Oskar Flordal,2021-Q2,0,0,0
 Oskar Flordal,2021-Q1,0,0,0
 Oskar Flordal,2020-Q4,3,3,3
@@ -7487,8 +6551,6 @@ Oskar Flordal,2018-Q4,0,0,0
 Oskar Flordal,2018-Q3,0,0,0
 Oskar Flordal,2018-Q2,0,0,0
 Oskar Flordal,2018-Q1,0,0,0
-Jae H. Yoo,2021-Q4,0,0,0
-Jae H. Yoo,2021-Q3,0,0,0
 Jae H. Yoo,2021-Q2,0,0,0
 Jae H. Yoo,2021-Q1,0,0,0
 Jae H. Yoo,2020-Q4,27,533,239
@@ -7503,8 +6565,6 @@ Jae H. Yoo,2018-Q4,0,0,0
 Jae H. Yoo,2018-Q3,0,0,0
 Jae H. Yoo,2018-Q2,0,0,0
 Jae H. Yoo,2018-Q1,0,0,0
-mazharul,2021-Q4,0,0,0
-mazharul,2021-Q3,0,0,0
 mazharul,2021-Q2,0,0,0
 mazharul,2021-Q1,0,0,0
 mazharul,2020-Q4,6,9,60
@@ -7519,8 +6579,6 @@ mazharul,2018-Q4,0,0,0
 mazharul,2018-Q3,0,0,0
 mazharul,2018-Q2,0,0,0
 mazharul,2018-Q1,0,0,0
-Samuel Marks,2021-Q4,0,0,0
-Samuel Marks,2021-Q3,0,0,0
 Samuel Marks,2021-Q2,0,0,0
 Samuel Marks,2021-Q1,0,0,0
 Samuel Marks,2020-Q4,148,834,829
@@ -7535,8 +6593,6 @@ Samuel Marks,2018-Q4,0,0,0
 Samuel Marks,2018-Q3,0,0,0
 Samuel Marks,2018-Q2,0,0,0
 Samuel Marks,2018-Q1,0,0,0
-Chris Kennelly,2021-Q4,0,0,0
-Chris Kennelly,2021-Q3,0,0,0
 Chris Kennelly,2021-Q2,0,0,0
 Chris Kennelly,2021-Q1,0,0,0
 Chris Kennelly,2020-Q4,31,39,39
@@ -7551,8 +6607,6 @@ Chris Kennelly,2018-Q4,0,0,0
 Chris Kennelly,2018-Q3,0,0,0
 Chris Kennelly,2018-Q2,4,37,37
 Chris Kennelly,2018-Q1,0,0,0
-Dong Lin,2021-Q4,0,0,0
-Dong Lin,2021-Q3,0,0,0
 Dong Lin,2021-Q2,0,0,0
 Dong Lin,2021-Q1,0,0,0
 Dong Lin,2020-Q4,30,1185,69
@@ -7567,8 +6621,6 @@ Dong Lin,2018-Q4,0,0,0
 Dong Lin,2018-Q3,0,0,0
 Dong Lin,2018-Q2,0,0,0
 Dong Lin,2018-Q1,0,0,0
-jpodivin,2021-Q4,0,0,0
-jpodivin,2021-Q3,0,0,0
 jpodivin,2021-Q2,0,0,0
 jpodivin,2021-Q1,0,0,0
 jpodivin,2020-Q4,3,0,2
@@ -7583,8 +6635,6 @@ jpodivin,2018-Q4,0,0,0
 jpodivin,2018-Q3,0,0,0
 jpodivin,2018-Q2,0,0,0
 jpodivin,2018-Q1,0,0,0
-Erik Smistad,2021-Q4,0,0,0
-Erik Smistad,2021-Q3,0,0,0
 Erik Smistad,2021-Q2,0,0,0
 Erik Smistad,2021-Q1,0,0,0
 Erik Smistad,2020-Q4,2,8,0
@@ -7599,8 +6649,6 @@ Erik Smistad,2018-Q4,0,0,0
 Erik Smistad,2018-Q3,1,9,3
 Erik Smistad,2018-Q2,3,27,22
 Erik Smistad,2018-Q1,0,0,0
-Simrit Kaur,2021-Q4,0,0,0
-Simrit Kaur,2021-Q3,0,0,0
 Simrit Kaur,2021-Q2,0,0,0
 Simrit Kaur,2021-Q1,0,0,0
 Simrit Kaur,2020-Q4,1,0,22
@@ -7615,8 +6663,6 @@ Simrit Kaur,2018-Q4,0,0,0
 Simrit Kaur,2018-Q3,0,0,0
 Simrit Kaur,2018-Q2,0,0,0
 Simrit Kaur,2018-Q1,0,0,0
-Jakub Jatczak,2021-Q4,0,0,0
-Jakub Jatczak,2021-Q3,0,0,0
 Jakub Jatczak,2021-Q2,0,0,0
 Jakub Jatczak,2021-Q1,0,0,0
 Jakub Jatczak,2020-Q4,56,352,358
@@ -7631,8 +6677,6 @@ Jakub Jatczak,2018-Q4,0,0,0
 Jakub Jatczak,2018-Q3,0,0,0
 Jakub Jatczak,2018-Q2,0,0,0
 Jakub Jatczak,2018-Q1,0,0,0
-Mingxing Tan,2021-Q4,0,0,0
-Mingxing Tan,2021-Q3,0,0,0
 Mingxing Tan,2021-Q2,0,0,0
 Mingxing Tan,2021-Q1,0,0,0
 Mingxing Tan,2020-Q4,1,2,0
@@ -7647,8 +6691,6 @@ Mingxing Tan,2018-Q4,3,46,111
 Mingxing Tan,2018-Q3,1,17,0
 Mingxing Tan,2018-Q2,156,6609,1780
 Mingxing Tan,2018-Q1,2,17,2
-Robert Suderman,2021-Q4,0,0,0
-Robert Suderman,2021-Q3,0,0,0
 Robert Suderman,2021-Q2,0,0,0
 Robert Suderman,2021-Q1,0,0,0
 Robert Suderman,2020-Q4,26,1043,132
@@ -7663,8 +6705,6 @@ Robert Suderman,2018-Q4,0,0,0
 Robert Suderman,2018-Q3,0,0,0
 Robert Suderman,2018-Q2,0,0,0
 Robert Suderman,2018-Q1,0,0,0
-Mazhar,2021-Q4,0,0,0
-Mazhar,2021-Q3,0,0,0
 Mazhar,2021-Q2,0,0,0
 Mazhar,2021-Q1,0,0,0
 Mazhar,2020-Q4,3,18,18
@@ -7679,8 +6719,6 @@ Mazhar,2018-Q4,0,0,0
 Mazhar,2018-Q3,0,0,0
 Mazhar,2018-Q2,0,0,0
 Mazhar,2018-Q1,0,0,0
-Anna R,2021-Q4,0,0,0
-Anna R,2021-Q3,0,0,0
 Anna R,2021-Q2,0,0,0
 Anna R,2021-Q1,0,0,0
 Anna R,2020-Q4,161,3198,2411
@@ -7695,8 +6733,6 @@ Anna R,2018-Q4,512,7729,6015
 Anna R,2018-Q3,1442,51985,4210
 Anna R,2018-Q2,343,2898,3168
 Anna R,2018-Q1,991,22442,35573
-Victor de Souza,2021-Q4,0,0,0
-Victor de Souza,2021-Q3,0,0,0
 Victor de Souza,2021-Q2,0,0,0
 Victor de Souza,2021-Q1,0,0,0
 Victor de Souza,2020-Q4,7,196,50
@@ -7711,8 +6747,6 @@ Victor de Souza,2018-Q4,0,0,0
 Victor de Souza,2018-Q3,0,0,0
 Victor de Souza,2018-Q2,0,0,0
 Victor de Souza,2018-Q1,0,0,0
-Thomas Joerg,2021-Q4,0,0,0
-Thomas Joerg,2021-Q3,0,0,0
 Thomas Joerg,2021-Q2,0,0,0
 Thomas Joerg,2021-Q1,0,0,0
 Thomas Joerg,2020-Q4,89,557,145
@@ -7727,8 +6761,6 @@ Thomas Joerg,2018-Q4,14,1564,779
 Thomas Joerg,2018-Q3,27,1013,150
 Thomas Joerg,2018-Q2,28,1392,71
 Thomas Joerg,2018-Q1,0,0,0
-Sidong-Wei,2021-Q4,0,0,0
-Sidong-Wei,2021-Q3,0,0,0
 Sidong-Wei,2021-Q2,0,0,0
 Sidong-Wei,2021-Q1,0,0,0
 Sidong-Wei,2020-Q4,15,85,21
@@ -7743,8 +6775,6 @@ Sidong-Wei,2018-Q4,0,0,0
 Sidong-Wei,2018-Q3,0,0,0
 Sidong-Wei,2018-Q2,0,0,0
 Sidong-Wei,2018-Q1,0,0,0
-Yosshi999,2021-Q4,0,0,0
-Yosshi999,2021-Q3,0,0,0
 Yosshi999,2021-Q2,0,0,0
 Yosshi999,2021-Q1,0,0,0
 Yosshi999,2020-Q4,1,0,0
@@ -7759,8 +6789,6 @@ Yosshi999,2018-Q4,0,0,0
 Yosshi999,2018-Q3,0,0,0
 Yosshi999,2018-Q2,0,0,0
 Yosshi999,2018-Q1,0,0,0
-Prateek Gupta,2021-Q4,0,0,0
-Prateek Gupta,2021-Q3,0,0,0
 Prateek Gupta,2021-Q2,0,0,0
 Prateek Gupta,2021-Q1,0,0,0
 Prateek Gupta,2020-Q4,19,400,238
@@ -7775,8 +6803,6 @@ Prateek Gupta,2018-Q4,0,0,0
 Prateek Gupta,2018-Q3,0,0,0
 Prateek Gupta,2018-Q2,0,0,0
 Prateek Gupta,2018-Q1,0,0,0
-Alexander Grund,2021-Q4,0,0,0
-Alexander Grund,2021-Q3,0,0,0
 Alexander Grund,2021-Q2,0,0,0
 Alexander Grund,2021-Q1,0,0,0
 Alexander Grund,2020-Q4,25,176,157
@@ -7791,8 +6817,6 @@ Alexander Grund,2018-Q4,0,0,0
 Alexander Grund,2018-Q3,0,0,0
 Alexander Grund,2018-Q2,0,0,0
 Alexander Grund,2018-Q1,0,0,0
-Georgiy Manuilov,2021-Q4,0,0,0
-Georgiy Manuilov,2021-Q3,0,0,0
 Georgiy Manuilov,2021-Q2,0,0,0
 Georgiy Manuilov,2021-Q1,0,0,0
 Georgiy Manuilov,2020-Q4,5,44,14
@@ -7807,8 +6831,6 @@ Georgiy Manuilov,2018-Q4,0,0,0
 Georgiy Manuilov,2018-Q3,0,0,0
 Georgiy Manuilov,2018-Q2,0,0,0
 Georgiy Manuilov,2018-Q1,0,0,0
-TomWildenhain-Microsoft,2021-Q4,0,0,0
-TomWildenhain-Microsoft,2021-Q3,0,0,0
 TomWildenhain-Microsoft,2021-Q2,0,0,0
 TomWildenhain-Microsoft,2021-Q1,0,0,0
 TomWildenhain-Microsoft,2020-Q4,1,0,0
@@ -7823,8 +6845,6 @@ TomWildenhain-Microsoft,2018-Q4,0,0,0
 TomWildenhain-Microsoft,2018-Q3,0,0,0
 TomWildenhain-Microsoft,2018-Q2,0,0,0
 TomWildenhain-Microsoft,2018-Q1,0,0,0
-latyas,2021-Q4,0,0,0
-latyas,2021-Q3,0,0,0
 latyas,2021-Q2,0,0,0
 latyas,2021-Q1,0,0,0
 latyas,2020-Q4,1,5,5
@@ -7839,8 +6859,6 @@ latyas,2018-Q4,0,0,0
 latyas,2018-Q3,0,0,0
 latyas,2018-Q2,0,0,0
 latyas,2018-Q1,0,0,0
-Marcin Juszkiewicz,2021-Q4,0,0,0
-Marcin Juszkiewicz,2021-Q3,0,0,0
 Marcin Juszkiewicz,2021-Q2,0,0,0
 Marcin Juszkiewicz,2021-Q1,0,0,0
 Marcin Juszkiewicz,2020-Q4,1,2,2
@@ -7855,8 +6873,6 @@ Marcin Juszkiewicz,2018-Q4,0,0,0
 Marcin Juszkiewicz,2018-Q3,0,0,0
 Marcin Juszkiewicz,2018-Q2,0,0,0
 Marcin Juszkiewicz,2018-Q1,0,0,0
-Jared Smolens,2021-Q4,0,0,0
-Jared Smolens,2021-Q3,0,0,0
 Jared Smolens,2021-Q2,0,0,0
 Jared Smolens,2021-Q1,0,0,0
 Jared Smolens,2020-Q4,14,2983,2318
@@ -7871,8 +6887,6 @@ Jared Smolens,2018-Q4,0,0,0
 Jared Smolens,2018-Q3,0,0,0
 Jared Smolens,2018-Q2,0,0,0
 Jared Smolens,2018-Q1,0,0,0
-Jab Hofmeier,2021-Q4,0,0,0
-Jab Hofmeier,2021-Q3,0,0,0
 Jab Hofmeier,2021-Q2,0,0,0
 Jab Hofmeier,2021-Q1,0,0,0
 Jab Hofmeier,2020-Q4,1,6,0
@@ -7887,8 +6901,6 @@ Jab Hofmeier,2018-Q4,0,0,0
 Jab Hofmeier,2018-Q3,0,0,0
 Jab Hofmeier,2018-Q2,0,0,0
 Jab Hofmeier,2018-Q1,0,0,0
-James Qin,2021-Q4,0,0,0
-James Qin,2021-Q3,0,0,0
 James Qin,2021-Q2,0,0,0
 James Qin,2021-Q1,0,0,0
 James Qin,2020-Q4,1,2,0
@@ -7903,8 +6915,6 @@ James Qin,2018-Q4,37,1806,1189
 James Qin,2018-Q3,10,278,36
 James Qin,2018-Q2,67,2911,816
 James Qin,2018-Q1,21,379,212
-Jungsub Lim,2021-Q4,0,0,0
-Jungsub Lim,2021-Q3,0,0,0
 Jungsub Lim,2021-Q2,0,0,0
 Jungsub Lim,2021-Q1,0,0,0
 Jungsub Lim,2020-Q4,1,0,0
@@ -7919,8 +6929,6 @@ Jungsub Lim,2018-Q4,0,0,0
 Jungsub Lim,2018-Q3,0,0,0
 Jungsub Lim,2018-Q2,0,0,0
 Jungsub Lim,2018-Q1,0,0,0
-shwetaoj,2021-Q4,0,0,0
-shwetaoj,2021-Q3,0,0,0
 shwetaoj,2021-Q2,0,0,0
 shwetaoj,2021-Q1,0,0,0
 shwetaoj,2020-Q4,2,0,0
@@ -7935,8 +6943,6 @@ shwetaoj,2018-Q4,0,0,0
 shwetaoj,2018-Q3,0,0,0
 shwetaoj,2018-Q2,0,0,0
 shwetaoj,2018-Q1,0,0,0
-Can Wang,2021-Q4,0,0,0
-Can Wang,2021-Q3,0,0,0
 Can Wang,2021-Q2,0,0,0
 Can Wang,2021-Q1,0,0,0
 Can Wang,2020-Q4,1,2,2
@@ -7951,8 +6957,6 @@ Can Wang,2018-Q4,0,0,0
 Can Wang,2018-Q3,0,0,0
 Can Wang,2018-Q2,0,0,0
 Can Wang,2018-Q1,0,0,0
-Jenny Plunkett,2021-Q4,0,0,0
-Jenny Plunkett,2021-Q3,0,0,0
 Jenny Plunkett,2021-Q2,0,0,0
 Jenny Plunkett,2021-Q1,0,0,0
 Jenny Plunkett,2020-Q4,2,6,6
@@ -7967,8 +6971,6 @@ Jenny Plunkett,2018-Q4,0,0,0
 Jenny Plunkett,2018-Q3,0,0,0
 Jenny Plunkett,2018-Q2,0,0,0
 Jenny Plunkett,2018-Q1,0,0,0
-Phil Stahlfeld,2021-Q4,0,0,0
-Phil Stahlfeld,2021-Q3,0,0,0
 Phil Stahlfeld,2021-Q2,0,0,0
 Phil Stahlfeld,2021-Q1,0,0,0
 Phil Stahlfeld,2020-Q4,2,41,9
@@ -7983,8 +6985,6 @@ Phil Stahlfeld,2018-Q4,0,0,0
 Phil Stahlfeld,2018-Q3,0,0,0
 Phil Stahlfeld,2018-Q2,0,0,0
 Phil Stahlfeld,2018-Q1,0,0,0
-Denisa Roberts,2021-Q4,0,0,0
-Denisa Roberts,2021-Q3,0,0,0
 Denisa Roberts,2021-Q2,0,0,0
 Denisa Roberts,2021-Q1,0,0,0
 Denisa Roberts,2020-Q4,2,16,6
@@ -7999,8 +6999,6 @@ Denisa Roberts,2018-Q4,0,0,0
 Denisa Roberts,2018-Q3,0,0,0
 Denisa Roberts,2018-Q2,0,0,0
 Denisa Roberts,2018-Q1,0,0,0
-icysapphire,2021-Q4,0,0,0
-icysapphire,2021-Q3,0,0,0
 icysapphire,2021-Q2,0,0,0
 icysapphire,2021-Q1,0,0,0
 icysapphire,2020-Q4,1,3,3
@@ -8015,8 +7013,6 @@ icysapphire,2018-Q4,0,0,0
 icysapphire,2018-Q3,0,0,0
 icysapphire,2018-Q2,0,0,0
 icysapphire,2018-Q1,0,0,0
-Zhenyu Tan,2021-Q4,0,0,0
-Zhenyu Tan,2021-Q3,0,0,0
 Zhenyu Tan,2021-Q2,0,0,0
 Zhenyu Tan,2021-Q1,0,0,0
 Zhenyu Tan,2020-Q4,27,147,151
@@ -8031,8 +7027,6 @@ Zhenyu Tan,2018-Q4,225,11357,6803
 Zhenyu Tan,2018-Q3,75,3952,714
 Zhenyu Tan,2018-Q2,16,553,22
 Zhenyu Tan,2018-Q1,0,0,0
-Hollow Man,2021-Q4,0,0,0
-Hollow Man,2021-Q3,0,0,0
 Hollow Man,2021-Q2,0,0,0
 Hollow Man,2021-Q1,0,0,0
 Hollow Man,2020-Q4,1,0,0
@@ -8047,8 +7041,6 @@ Hollow Man,2018-Q4,0,0,0
 Hollow Man,2018-Q3,0,0,0
 Hollow Man,2018-Q2,0,0,0
 Hollow Man,2018-Q1,0,0,0
-Maria Vexlard,2021-Q4,0,0,0
-Maria Vexlard,2021-Q3,0,0,0
 Maria Vexlard,2021-Q2,0,0,0
 Maria Vexlard,2021-Q1,0,0,0
 Maria Vexlard,2020-Q4,1,15,0
@@ -8063,8 +7055,6 @@ Maria Vexlard,2018-Q4,0,0,0
 Maria Vexlard,2018-Q3,0,0,0
 Maria Vexlard,2018-Q2,0,0,0
 Maria Vexlard,2018-Q1,0,0,0
-Milan Straka,2021-Q4,0,0,0
-Milan Straka,2021-Q3,0,0,0
 Milan Straka,2021-Q2,0,0,0
 Milan Straka,2021-Q1,0,0,0
 Milan Straka,2020-Q4,1,2,0
@@ -8079,8 +7069,6 @@ Milan Straka,2018-Q4,0,0,0
 Milan Straka,2018-Q3,0,0,0
 Milan Straka,2018-Q2,0,0,0
 Milan Straka,2018-Q1,0,0,0
-Clemens Giuliani,2021-Q4,0,0,0
-Clemens Giuliani,2021-Q3,0,0,0
 Clemens Giuliani,2021-Q2,0,0,0
 Clemens Giuliani,2021-Q1,0,0,0
 Clemens Giuliani,2020-Q4,10,20,19
@@ -8095,8 +7083,6 @@ Clemens Giuliani,2018-Q4,0,0,0
 Clemens Giuliani,2018-Q3,0,0,0
 Clemens Giuliani,2018-Q2,0,0,0
 Clemens Giuliani,2018-Q1,0,0,0
-Aman Kishore,2021-Q4,0,0,0
-Aman Kishore,2021-Q3,0,0,0
 Aman Kishore,2021-Q2,0,0,0
 Aman Kishore,2021-Q1,0,0,0
 Aman Kishore,2020-Q4,3,23,23
@@ -8111,8 +7097,6 @@ Aman Kishore,2018-Q4,0,0,0
 Aman Kishore,2018-Q3,0,0,0
 Aman Kishore,2018-Q2,0,0,0
 Aman Kishore,2018-Q1,0,0,0
-Lucy Fox,2021-Q4,0,0,0
-Lucy Fox,2021-Q3,0,0,0
 Lucy Fox,2021-Q2,0,0,0
 Lucy Fox,2021-Q1,0,0,0
 Lucy Fox,2020-Q4,20,129,67
@@ -8127,8 +7111,6 @@ Lucy Fox,2018-Q4,0,0,0
 Lucy Fox,2018-Q3,0,0,0
 Lucy Fox,2018-Q2,0,0,0
 Lucy Fox,2018-Q1,0,0,0
-Vivek Panyam,2021-Q4,0,0,0
-Vivek Panyam,2021-Q3,0,0,0
 Vivek Panyam,2021-Q2,0,0,0
 Vivek Panyam,2021-Q1,0,0,0
 Vivek Panyam,2020-Q4,2,3,0
@@ -8143,8 +7125,6 @@ Vivek Panyam,2018-Q4,0,0,0
 Vivek Panyam,2018-Q3,0,0,0
 Vivek Panyam,2018-Q2,0,0,0
 Vivek Panyam,2018-Q1,0,0,0
-Pravin Karandikar,2021-Q4,0,0,0
-Pravin Karandikar,2021-Q3,0,0,0
 Pravin Karandikar,2021-Q2,0,0,0
 Pravin Karandikar,2021-Q1,0,0,0
 Pravin Karandikar,2020-Q4,2,24,17
@@ -8159,8 +7139,6 @@ Pravin Karandikar,2018-Q4,0,0,0
 Pravin Karandikar,2018-Q3,0,0,0
 Pravin Karandikar,2018-Q2,0,0,0
 Pravin Karandikar,2018-Q1,0,0,0
-Yajush Vyas,2021-Q4,0,0,0
-Yajush Vyas,2021-Q3,0,0,0
 Yajush Vyas,2021-Q2,0,0,0
 Yajush Vyas,2021-Q1,0,0,0
 Yajush Vyas,2020-Q4,2,0,0
@@ -8175,8 +7153,6 @@ Yajush Vyas,2018-Q4,0,0,0
 Yajush Vyas,2018-Q3,0,0,0
 Yajush Vyas,2018-Q2,0,0,0
 Yajush Vyas,2018-Q1,0,0,0
-Trevor Cai,2021-Q4,0,0,0
-Trevor Cai,2021-Q3,0,0,0
 Trevor Cai,2021-Q2,0,0,0
 Trevor Cai,2021-Q1,0,0,0
 Trevor Cai,2020-Q4,3,54,216
@@ -8191,8 +7167,6 @@ Trevor Cai,2018-Q4,0,0,0
 Trevor Cai,2018-Q3,0,0,0
 Trevor Cai,2018-Q2,0,0,0
 Trevor Cai,2018-Q1,0,0,0
-James Bernardi,2021-Q4,0,0,0
-James Bernardi,2021-Q3,0,0,0
 James Bernardi,2021-Q2,0,0,0
 James Bernardi,2021-Q1,0,0,0
 James Bernardi,2020-Q4,1,9,5
@@ -8207,8 +7181,6 @@ James Bernardi,2018-Q4,0,0,0
 James Bernardi,2018-Q3,0,0,0
 James Bernardi,2018-Q2,0,0,0
 James Bernardi,2018-Q1,0,0,0
-Roger Cheng,2021-Q4,0,0,0
-Roger Cheng,2021-Q3,0,0,0
 Roger Cheng,2021-Q2,0,0,0
 Roger Cheng,2021-Q1,0,0,0
 Roger Cheng,2020-Q4,2,33,5
@@ -8223,8 +7195,6 @@ Roger Cheng,2018-Q4,0,0,0
 Roger Cheng,2018-Q3,0,0,0
 Roger Cheng,2018-Q2,0,0,0
 Roger Cheng,2018-Q1,0,0,0
-Jeffrey A. Dean,2021-Q4,0,0,0
-Jeffrey A. Dean,2021-Q3,0,0,0
 Jeffrey A. Dean,2021-Q2,0,0,0
 Jeffrey A. Dean,2021-Q1,0,0,0
 Jeffrey A. Dean,2020-Q4,1,5,0
@@ -8239,8 +7209,6 @@ Jeffrey A. Dean,2018-Q4,0,0,0
 Jeffrey A. Dean,2018-Q3,0,0,0
 Jeffrey A. Dean,2018-Q2,0,0,0
 Jeffrey A. Dean,2018-Q1,1,19,13
-Priya Gupta,2021-Q4,0,0,0
-Priya Gupta,2021-Q3,0,0,0
 Priya Gupta,2021-Q2,0,0,0
 Priya Gupta,2021-Q1,0,0,0
 Priya Gupta,2020-Q4,6,42,39
@@ -8255,8 +7223,6 @@ Priya Gupta,2018-Q4,113,2558,1836
 Priya Gupta,2018-Q3,103,2704,1188
 Priya Gupta,2018-Q2,78,1802,316
 Priya Gupta,2018-Q1,27,438,77
-Rui Huang,2021-Q4,0,0,0
-Rui Huang,2021-Q3,0,0,0
 Rui Huang,2021-Q2,0,0,0
 Rui Huang,2021-Q1,0,0,0
 Rui Huang,2020-Q4,2,0,0
@@ -8271,8 +7237,6 @@ Rui Huang,2018-Q4,0,0,0
 Rui Huang,2018-Q3,0,0,0
 Rui Huang,2018-Q2,0,0,0
 Rui Huang,2018-Q1,0,0,0
-ryanking13,2021-Q4,0,0,0
-ryanking13,2021-Q3,0,0,0
 ryanking13,2021-Q2,0,0,0
 ryanking13,2021-Q1,0,0,0
 ryanking13,2020-Q4,2,2,2
@@ -8287,8 +7251,6 @@ ryanking13,2018-Q4,0,0,0
 ryanking13,2018-Q3,0,0,0
 ryanking13,2018-Q2,0,0,0
 ryanking13,2018-Q1,0,0,0
-kopytjuk,2021-Q4,0,0,0
-kopytjuk,2021-Q3,0,0,0
 kopytjuk,2021-Q2,0,0,0
 kopytjuk,2021-Q1,0,0,0
 kopytjuk,2020-Q4,1,54,28
@@ -8303,8 +7265,6 @@ kopytjuk,2018-Q4,0,0,0
 kopytjuk,2018-Q3,0,0,0
 kopytjuk,2018-Q2,0,0,0
 kopytjuk,2018-Q1,0,0,0
-Andrzej Pomirski,2021-Q4,0,0,0
-Andrzej Pomirski,2021-Q3,0,0,0
 Andrzej Pomirski,2021-Q2,0,0,0
 Andrzej Pomirski,2021-Q1,0,0,0
 Andrzej Pomirski,2020-Q4,1,0,0
@@ -8319,8 +7279,6 @@ Andrzej Pomirski,2018-Q4,0,0,0
 Andrzej Pomirski,2018-Q3,0,0,0
 Andrzej Pomirski,2018-Q2,0,0,0
 Andrzej Pomirski,2018-Q1,0,0,0
-Pavithra Vijay,2021-Q4,0,0,0
-Pavithra Vijay,2021-Q3,0,0,0
 Pavithra Vijay,2021-Q2,0,0,0
 Pavithra Vijay,2021-Q1,0,0,0
 Pavithra Vijay,2020-Q4,35,285,268
@@ -8335,8 +7293,6 @@ Pavithra Vijay,2018-Q4,517,19672,5482
 Pavithra Vijay,2018-Q3,450,3631,2152
 Pavithra Vijay,2018-Q2,514,6494,4393
 Pavithra Vijay,2018-Q1,16,665,123
-Yiming Zhang,2021-Q4,0,0,0
-Yiming Zhang,2021-Q3,0,0,0
 Yiming Zhang,2021-Q2,0,0,0
 Yiming Zhang,2021-Q1,0,0,0
 Yiming Zhang,2020-Q4,1,0,0
@@ -8351,8 +7307,6 @@ Yiming Zhang,2018-Q4,0,0,0
 Yiming Zhang,2018-Q3,0,0,0
 Yiming Zhang,2018-Q2,0,0,0
 Yiming Zhang,2018-Q1,0,0,0
-Simrit-Kaur,2021-Q4,0,0,0
-Simrit-Kaur,2021-Q3,0,0,0
 Simrit-Kaur,2021-Q2,0,0,0
 Simrit-Kaur,2021-Q1,0,0,0
 Simrit-Kaur,2020-Q4,2,7,0
@@ -8367,8 +7321,6 @@ Simrit-Kaur,2018-Q4,0,0,0
 Simrit-Kaur,2018-Q3,0,0,0
 Simrit-Kaur,2018-Q2,0,0,0
 Simrit-Kaur,2018-Q1,0,0,0
-Aaron S. Mondal,2021-Q4,0,0,0
-Aaron S. Mondal,2021-Q3,0,0,0
 Aaron S. Mondal,2021-Q2,0,0,0
 Aaron S. Mondal,2021-Q1,0,0,0
 Aaron S. Mondal,2020-Q4,1,0,0
@@ -8383,8 +7335,6 @@ Aaron S. Mondal,2018-Q4,0,0,0
 Aaron S. Mondal,2018-Q3,0,0,0
 Aaron S. Mondal,2018-Q2,0,0,0
 Aaron S. Mondal,2018-Q1,0,0,0
-Nick Johnston,2021-Q4,0,0,0
-Nick Johnston,2021-Q3,0,0,0
 Nick Johnston,2021-Q2,0,0,0
 Nick Johnston,2021-Q1,0,0,0
 Nick Johnston,2020-Q4,2,2,0
@@ -8399,8 +7349,6 @@ Nick Johnston,2018-Q4,0,0,0
 Nick Johnston,2018-Q3,0,0,0
 Nick Johnston,2018-Q2,0,0,0
 Nick Johnston,2018-Q1,0,0,0
-Dmitry Volodin,2021-Q4,0,0,0
-Dmitry Volodin,2021-Q3,0,0,0
 Dmitry Volodin,2021-Q2,0,0,0
 Dmitry Volodin,2021-Q1,0,0,0
 Dmitry Volodin,2020-Q4,194,450,455
@@ -8415,8 +7363,6 @@ Dmitry Volodin,2018-Q4,0,0,0
 Dmitry Volodin,2018-Q3,0,0,0
 Dmitry Volodin,2018-Q2,0,0,0
 Dmitry Volodin,2018-Q1,0,0,0
-Mohamed Moselhy,2021-Q4,0,0,0
-Mohamed Moselhy,2021-Q3,0,0,0
 Mohamed Moselhy,2021-Q2,0,0,0
 Mohamed Moselhy,2021-Q1,0,0,0
 Mohamed Moselhy,2020-Q4,2,4,2
@@ -8431,8 +7377,6 @@ Mohamed Moselhy,2018-Q4,0,0,0
 Mohamed Moselhy,2018-Q3,0,0,0
 Mohamed Moselhy,2018-Q2,0,0,0
 Mohamed Moselhy,2018-Q1,0,0,0
-Cloud Han,2021-Q4,0,0,0
-Cloud Han,2021-Q3,0,0,0
 Cloud Han,2021-Q2,0,0,0
 Cloud Han,2021-Q1,0,0,0
 Cloud Han,2020-Q4,5,42,4
@@ -8447,8 +7391,6 @@ Cloud Han,2018-Q4,0,0,0
 Cloud Han,2018-Q3,0,0,0
 Cloud Han,2018-Q2,0,0,0
 Cloud Han,2018-Q1,0,0,0
-qqq.jq,2021-Q4,0,0,0
-qqq.jq,2021-Q3,0,0,0
 qqq.jq,2021-Q2,0,0,0
 qqq.jq,2021-Q1,0,0,0
 qqq.jq,2020-Q4,18,372,179
@@ -8463,8 +7405,6 @@ qqq.jq,2018-Q4,0,0,0
 qqq.jq,2018-Q3,0,0,0
 qqq.jq,2018-Q2,0,0,0
 qqq.jq,2018-Q1,0,0,0
-Yuta Fukasawa,2021-Q4,0,0,0
-Yuta Fukasawa,2021-Q3,0,0,0
 Yuta Fukasawa,2021-Q2,0,0,0
 Yuta Fukasawa,2021-Q1,0,0,0
 Yuta Fukasawa,2020-Q4,2,6,3
@@ -8479,8 +7419,6 @@ Yuta Fukasawa,2018-Q4,0,0,0
 Yuta Fukasawa,2018-Q3,0,0,0
 Yuta Fukasawa,2018-Q2,0,0,0
 Yuta Fukasawa,2018-Q1,0,0,0
-Ben Vanik,2021-Q4,0,0,0
-Ben Vanik,2021-Q3,0,0,0
 Ben Vanik,2021-Q2,0,0,0
 Ben Vanik,2021-Q1,0,0,0
 Ben Vanik,2020-Q4,2,6,12
@@ -8495,8 +7433,6 @@ Ben Vanik,2018-Q4,0,0,0
 Ben Vanik,2018-Q3,0,0,0
 Ben Vanik,2018-Q2,0,0,0
 Ben Vanik,2018-Q1,0,0,0
-Peter Buchlovsky,2021-Q4,0,0,0
-Peter Buchlovsky,2021-Q3,0,0,0
 Peter Buchlovsky,2021-Q2,0,0,0
 Peter Buchlovsky,2021-Q1,0,0,0
 Peter Buchlovsky,2020-Q4,1,0,0
@@ -8511,8 +7447,6 @@ Peter Buchlovsky,2018-Q4,9,67,6
 Peter Buchlovsky,2018-Q3,1,2,2
 Peter Buchlovsky,2018-Q2,0,0,0
 Peter Buchlovsky,2018-Q1,0,0,0
-Pedro Gonnet,2021-Q4,0,0,0
-Pedro Gonnet,2021-Q3,0,0,0
 Pedro Gonnet,2021-Q2,0,0,0
 Pedro Gonnet,2021-Q1,0,0,0
 Pedro Gonnet,2020-Q4,2,10,11
@@ -8527,8 +7461,6 @@ Pedro Gonnet,2018-Q4,0,0,0
 Pedro Gonnet,2018-Q3,0,0,0
 Pedro Gonnet,2018-Q2,0,0,0
 Pedro Gonnet,2018-Q1,0,0,0
-gbaned,2021-Q4,0,0,0
-gbaned,2021-Q3,0,0,0
 gbaned,2021-Q2,0,0,0
 gbaned,2021-Q1,0,0,0
 gbaned,2020-Q4,1,12,5
@@ -8543,8 +7475,6 @@ gbaned,2018-Q4,0,0,0
 gbaned,2018-Q3,0,0,0
 gbaned,2018-Q2,0,0,0
 gbaned,2018-Q1,0,0,0
-Jacob Valdez,2021-Q4,0,0,0
-Jacob Valdez,2021-Q3,0,0,0
 Jacob Valdez,2021-Q2,0,0,0
 Jacob Valdez,2021-Q1,0,0,0
 Jacob Valdez,2020-Q4,1,0,0
@@ -8559,8 +7489,6 @@ Jacob Valdez,2018-Q4,0,0,0
 Jacob Valdez,2018-Q3,0,0,0
 Jacob Valdez,2018-Q2,0,0,0
 Jacob Valdez,2018-Q1,0,0,0
-Sergey Popov,2021-Q4,0,0,0
-Sergey Popov,2021-Q3,0,0,0
 Sergey Popov,2021-Q2,0,0,0
 Sergey Popov,2021-Q1,0,0,0
 Sergey Popov,2020-Q4,2,9,0
@@ -8575,8 +7503,6 @@ Sergey Popov,2018-Q4,0,0,0
 Sergey Popov,2018-Q3,0,0,0
 Sergey Popov,2018-Q2,0,0,0
 Sergey Popov,2018-Q1,0,0,0
-Vishakha Agrawal,2021-Q4,0,0,0
-Vishakha Agrawal,2021-Q3,0,0,0
 Vishakha Agrawal,2021-Q2,0,0,0
 Vishakha Agrawal,2021-Q1,0,0,0
 Vishakha Agrawal,2020-Q4,5,24,7
@@ -8591,8 +7517,6 @@ Vishakha Agrawal,2018-Q4,0,0,0
 Vishakha Agrawal,2018-Q3,0,0,0
 Vishakha Agrawal,2018-Q2,0,0,0
 Vishakha Agrawal,2018-Q1,0,0,0
-Felix Fent,2021-Q4,0,0,0
-Felix Fent,2021-Q3,0,0,0
 Felix Fent,2021-Q2,0,0,0
 Felix Fent,2021-Q1,0,0,0
 Felix Fent,2020-Q4,3,22,12
@@ -8607,8 +7531,6 @@ Felix Fent,2018-Q4,0,0,0
 Felix Fent,2018-Q3,0,0,0
 Felix Fent,2018-Q2,0,0,0
 Felix Fent,2018-Q1,0,0,0
-Michael Kuchnik,2021-Q4,0,0,0
-Michael Kuchnik,2021-Q3,0,0,0
 Michael Kuchnik,2021-Q2,0,0,0
 Michael Kuchnik,2021-Q1,0,0,0
 Michael Kuchnik,2020-Q4,63,410,267
@@ -8623,8 +7545,6 @@ Michael Kuchnik,2018-Q4,0,0,0
 Michael Kuchnik,2018-Q3,0,0,0
 Michael Kuchnik,2018-Q2,0,0,0
 Michael Kuchnik,2018-Q1,0,0,0
-Yuan Tang,2021-Q4,0,0,0
-Yuan Tang,2021-Q3,0,0,0
 Yuan Tang,2021-Q2,0,0,0
 Yuan Tang,2021-Q1,0,0,0
 Yuan Tang,2020-Q4,1,0,2
@@ -8639,8 +7559,6 @@ Yuan Tang,2018-Q4,0,0,0
 Yuan Tang,2018-Q3,0,0,0
 Yuan Tang,2018-Q2,0,0,0
 Yuan Tang,2018-Q1,0,0,0
-Luca Versari,2021-Q4,0,0,0
-Luca Versari,2021-Q3,0,0,0
 Luca Versari,2021-Q2,0,0,0
 Luca Versari,2021-Q1,0,0,0
 Luca Versari,2020-Q4,1,28,19
@@ -8655,8 +7573,6 @@ Luca Versari,2018-Q4,0,0,0
 Luca Versari,2018-Q3,0,0,0
 Luca Versari,2018-Q2,0,0,0
 Luca Versari,2018-Q1,0,0,0
-Albert Villanova del Moral,2021-Q4,0,0,0
-Albert Villanova del Moral,2021-Q3,0,0,0
 Albert Villanova del Moral,2021-Q2,0,0,0
 Albert Villanova del Moral,2021-Q1,0,0,0
 Albert Villanova del Moral,2020-Q4,6,14,14
@@ -8671,8 +7587,6 @@ Albert Villanova del Moral,2018-Q4,0,0,0
 Albert Villanova del Moral,2018-Q3,0,0,0
 Albert Villanova del Moral,2018-Q2,0,0,0
 Albert Villanova del Moral,2018-Q1,0,0,0
-Alexander Bayandin,2021-Q4,0,0,0
-Alexander Bayandin,2021-Q3,0,0,0
 Alexander Bayandin,2021-Q2,0,0,0
 Alexander Bayandin,2021-Q1,0,0,0
 Alexander Bayandin,2020-Q4,2,16,0
@@ -8687,8 +7601,6 @@ Alexander Bayandin,2018-Q4,0,0,0
 Alexander Bayandin,2018-Q3,0,0,0
 Alexander Bayandin,2018-Q2,0,0,0
 Alexander Bayandin,2018-Q1,0,0,0
-Will Cromar,2021-Q4,0,0,0
-Will Cromar,2021-Q3,0,0,0
 Will Cromar,2021-Q2,0,0,0
 Will Cromar,2021-Q1,0,0,0
 Will Cromar,2020-Q4,2,14,12
@@ -8703,8 +7615,6 @@ Will Cromar,2018-Q4,0,0,0
 Will Cromar,2018-Q3,0,0,0
 Will Cromar,2018-Q2,0,0,0
 Will Cromar,2018-Q1,0,0,0
-Brendan Collins,2021-Q4,0,0,0
-Brendan Collins,2021-Q3,0,0,0
 Brendan Collins,2021-Q2,0,0,0
 Brendan Collins,2021-Q1,0,0,0
 Brendan Collins,2020-Q4,1,3,0
@@ -8719,8 +7629,6 @@ Brendan Collins,2018-Q4,0,0,0
 Brendan Collins,2018-Q3,0,0,0
 Brendan Collins,2018-Q2,0,0,0
 Brendan Collins,2018-Q1,0,0,0
-Maxwell Bileschi,2021-Q4,0,0,0
-Maxwell Bileschi,2021-Q3,0,0,0
 Maxwell Bileschi,2021-Q2,0,0,0
 Maxwell Bileschi,2021-Q1,0,0,0
 Maxwell Bileschi,2020-Q4,1,0,0
@@ -8735,8 +7643,6 @@ Maxwell Bileschi,2018-Q4,0,0,0
 Maxwell Bileschi,2018-Q3,0,0,0
 Maxwell Bileschi,2018-Q2,0,0,0
 Maxwell Bileschi,2018-Q1,0,0,0
-firejq,2021-Q4,0,0,0
-firejq,2021-Q3,0,0,0
 firejq,2021-Q2,0,0,0
 firejq,2021-Q1,0,0,0
 firejq,2020-Q4,8,123,188
@@ -8751,8 +7657,6 @@ firejq,2018-Q4,0,0,0
 firejq,2018-Q3,0,0,0
 firejq,2018-Q2,0,0,0
 firejq,2018-Q1,0,0,0
-Vladimir Silyaev,2021-Q4,0,0,0
-Vladimir Silyaev,2021-Q3,0,0,0
 Vladimir Silyaev,2021-Q2,0,0,0
 Vladimir Silyaev,2021-Q1,0,0,0
 Vladimir Silyaev,2020-Q4,0,0,0
@@ -8767,8 +7671,6 @@ Vladimir Silyaev,2018-Q4,0,0,0
 Vladimir Silyaev,2018-Q3,0,0,0
 Vladimir Silyaev,2018-Q2,0,0,0
 Vladimir Silyaev,2018-Q1,0,0,0
-Jason Zaman,2021-Q4,0,0,0
-Jason Zaman,2021-Q3,0,0,0
 Jason Zaman,2021-Q2,0,0,0
 Jason Zaman,2021-Q1,0,0,0
 Jason Zaman,2020-Q4,9,86,84
@@ -8783,8 +7685,6 @@ Jason Zaman,2018-Q4,19,70,31
 Jason Zaman,2018-Q3,55,1295,226
 Jason Zaman,2018-Q2,39,804,79
 Jason Zaman,2018-Q1,0,0,0
-Aleksey Vitebskiy,2021-Q4,0,0,0
-Aleksey Vitebskiy,2021-Q3,0,0,0
 Aleksey Vitebskiy,2021-Q2,0,0,0
 Aleksey Vitebskiy,2021-Q1,0,0,0
 Aleksey Vitebskiy,2020-Q4,19,321,125
@@ -8799,8 +7699,6 @@ Aleksey Vitebskiy,2018-Q4,0,0,0
 Aleksey Vitebskiy,2018-Q3,0,0,0
 Aleksey Vitebskiy,2018-Q2,0,0,0
 Aleksey Vitebskiy,2018-Q1,0,0,0
-Sungmann Cho,2021-Q4,0,0,0
-Sungmann Cho,2021-Q3,0,0,0
 Sungmann Cho,2021-Q2,0,0,0
 Sungmann Cho,2021-Q1,0,0,0
 Sungmann Cho,2020-Q4,1,0,0
@@ -8815,8 +7713,6 @@ Sungmann Cho,2018-Q4,0,0,0
 Sungmann Cho,2018-Q3,0,0,0
 Sungmann Cho,2018-Q2,0,0,0
 Sungmann Cho,2018-Q1,0,0,0
-I Wayan Dharmana,2021-Q4,0,0,0
-I Wayan Dharmana,2021-Q3,0,0,0
 I Wayan Dharmana,2021-Q2,0,0,0
 I Wayan Dharmana,2021-Q1,0,0,0
 I Wayan Dharmana,2020-Q4,1,0,0
@@ -8831,8 +7727,6 @@ I Wayan Dharmana,2018-Q4,0,0,0
 I Wayan Dharmana,2018-Q3,0,0,0
 I Wayan Dharmana,2018-Q2,0,0,0
 I Wayan Dharmana,2018-Q1,0,0,0
-marload,2021-Q4,0,0,0
-marload,2021-Q3,0,0,0
 marload,2021-Q2,0,0,0
 marload,2021-Q1,0,0,0
 marload,2020-Q4,8,57,7
@@ -8847,8 +7741,6 @@ marload,2018-Q4,0,0,0
 marload,2018-Q3,0,0,0
 marload,2018-Q2,0,0,0
 marload,2018-Q1,0,0,0
-Anjali Sridhar,2021-Q4,0,0,0
-Anjali Sridhar,2021-Q3,0,0,0
 Anjali Sridhar,2021-Q2,0,0,0
 Anjali Sridhar,2021-Q1,0,0,0
 Anjali Sridhar,2020-Q4,36,312,60
@@ -8863,8 +7755,6 @@ Anjali Sridhar,2018-Q4,54,847,414
 Anjali Sridhar,2018-Q3,141,13298,744
 Anjali Sridhar,2018-Q2,48,2837,930
 Anjali Sridhar,2018-Q1,46,2169,358
-Nicolas Vasilache,2021-Q4,0,0,0
-Nicolas Vasilache,2021-Q3,0,0,0
 Nicolas Vasilache,2021-Q2,0,0,0
 Nicolas Vasilache,2021-Q1,0,0,0
 Nicolas Vasilache,2020-Q4,1,0,3
@@ -8879,8 +7769,6 @@ Nicolas Vasilache,2018-Q4,318,14126,5902
 Nicolas Vasilache,2018-Q3,20,211,46
 Nicolas Vasilache,2018-Q2,0,0,0
 Nicolas Vasilache,2018-Q1,0,0,0
-Elena Zhelezina,2021-Q4,0,0,0
-Elena Zhelezina,2021-Q3,0,0,0
 Elena Zhelezina,2021-Q2,0,0,0
 Elena Zhelezina,2021-Q1,0,0,0
 Elena Zhelezina,2020-Q4,2,0,0
@@ -8895,8 +7783,6 @@ Elena Zhelezina,2018-Q4,0,0,0
 Elena Zhelezina,2018-Q3,0,0,0
 Elena Zhelezina,2018-Q2,0,0,0
 Elena Zhelezina,2018-Q1,0,0,0
-oujiafan,2021-Q4,0,0,0
-oujiafan,2021-Q3,0,0,0
 oujiafan,2021-Q2,0,0,0
 oujiafan,2021-Q1,0,0,0
 oujiafan,2020-Q4,1,0,7
@@ -8911,8 +7797,6 @@ oujiafan,2018-Q4,0,0,0
 oujiafan,2018-Q3,0,0,0
 oujiafan,2018-Q2,0,0,0
 oujiafan,2018-Q1,0,0,0
-Mateusz Holenko,2021-Q4,0,0,0
-Mateusz Holenko,2021-Q3,0,0,0
 Mateusz Holenko,2021-Q2,0,0,0
 Mateusz Holenko,2021-Q1,0,0,0
 Mateusz Holenko,2020-Q4,1,0,0
@@ -8927,8 +7811,6 @@ Mateusz Holenko,2018-Q4,0,0,0
 Mateusz Holenko,2018-Q3,0,0,0
 Mateusz Holenko,2018-Q2,0,0,0
 Mateusz Holenko,2018-Q1,0,0,0
-Lequn Chen,2021-Q4,0,0,0
-Lequn Chen,2021-Q3,0,0,0
 Lequn Chen,2021-Q2,0,0,0
 Lequn Chen,2021-Q1,0,0,0
 Lequn Chen,2020-Q4,1,0,0
@@ -8943,8 +7825,6 @@ Lequn Chen,2018-Q4,0,0,0
 Lequn Chen,2018-Q3,0,0,0
 Lequn Chen,2018-Q2,0,0,0
 Lequn Chen,2018-Q1,0,0,0
-ahmedsabie,2021-Q4,0,0,0
-ahmedsabie,2021-Q3,0,0,0
 ahmedsabie,2021-Q2,0,0,0
 ahmedsabie,2021-Q1,0,0,0
 ahmedsabie,2020-Q4,16,203,145
@@ -8959,8 +7839,6 @@ ahmedsabie,2018-Q4,0,0,0
 ahmedsabie,2018-Q3,0,0,0
 ahmedsabie,2018-Q2,0,0,0
 ahmedsabie,2018-Q1,0,0,0
-Chenliang Xu,2021-Q4,0,0,0
-Chenliang Xu,2021-Q3,0,0,0
 Chenliang Xu,2021-Q2,0,0,0
 Chenliang Xu,2021-Q1,0,0,0
 Chenliang Xu,2020-Q4,3,12,4
@@ -8975,8 +7853,6 @@ Chenliang Xu,2018-Q4,0,0,0
 Chenliang Xu,2018-Q3,0,0,0
 Chenliang Xu,2018-Q2,0,0,0
 Chenliang Xu,2018-Q1,0,0,0
-James Keeling,2021-Q4,0,0,0
-James Keeling,2021-Q3,0,0,0
 James Keeling,2021-Q2,0,0,0
 James Keeling,2021-Q1,0,0,0
 James Keeling,2020-Q4,1,185,180
@@ -8991,8 +7867,6 @@ James Keeling,2018-Q4,37,1057,168
 James Keeling,2018-Q3,37,416,54
 James Keeling,2018-Q2,19,530,0
 James Keeling,2018-Q1,2,68,0
-rhdong,2021-Q4,0,0,0
-rhdong,2021-Q3,0,0,0
 rhdong,2021-Q2,0,0,0
 rhdong,2021-Q1,0,0,0
 rhdong,2020-Q4,7,124,16
@@ -9007,8 +7881,6 @@ rhdong,2018-Q4,0,0,0
 rhdong,2018-Q3,0,0,0
 rhdong,2018-Q2,0,0,0
 rhdong,2018-Q1,0,0,0
-dushuai,2021-Q4,0,0,0
-dushuai,2021-Q3,0,0,0
 dushuai,2021-Q2,0,0,0
 dushuai,2021-Q1,0,0,0
 dushuai,2020-Q4,1,0,2
@@ -9023,8 +7895,6 @@ dushuai,2018-Q4,0,0,0
 dushuai,2018-Q3,0,0,0
 dushuai,2018-Q2,0,0,0
 dushuai,2018-Q1,0,0,0
-Kristian Hartikainen,2021-Q4,0,0,0
-Kristian Hartikainen,2021-Q3,0,0,0
 Kristian Hartikainen,2021-Q2,0,0,0
 Kristian Hartikainen,2021-Q1,0,0,0
 Kristian Hartikainen,2020-Q4,3,6,4
@@ -9039,8 +7909,6 @@ Kristian Hartikainen,2018-Q4,0,0,0
 Kristian Hartikainen,2018-Q3,0,0,0
 Kristian Hartikainen,2018-Q2,0,0,0
 Kristian Hartikainen,2018-Q1,0,0,0
-Akshay Modi,2021-Q4,0,0,0
-Akshay Modi,2021-Q3,0,0,0
 Akshay Modi,2021-Q2,0,0,0
 Akshay Modi,2021-Q1,0,0,0
 Akshay Modi,2020-Q4,34,639,876
@@ -9055,8 +7923,6 @@ Akshay Modi,2018-Q4,158,2881,556
 Akshay Modi,2018-Q3,147,2775,1315
 Akshay Modi,2018-Q2,929,15986,9589
 Akshay Modi,2018-Q1,86,2948,1073
-Pawel Piskorski,2021-Q4,0,0,0
-Pawel Piskorski,2021-Q3,0,0,0
 Pawel Piskorski,2021-Q2,0,0,0
 Pawel Piskorski,2021-Q1,0,0,0
 Pawel Piskorski,2020-Q4,0,0,0
@@ -9071,8 +7937,6 @@ Pawel Piskorski,2018-Q4,0,0,0
 Pawel Piskorski,2018-Q3,0,0,0
 Pawel Piskorski,2018-Q2,0,0,0
 Pawel Piskorski,2018-Q1,0,0,0
-Abhishek Kulkarni,2021-Q4,0,0,0
-Abhishek Kulkarni,2021-Q3,0,0,0
 Abhishek Kulkarni,2021-Q2,0,0,0
 Abhishek Kulkarni,2021-Q1,0,0,0
 Abhishek Kulkarni,2020-Q4,0,0,0
@@ -9087,8 +7951,6 @@ Abhishek Kulkarni,2018-Q4,0,0,0
 Abhishek Kulkarni,2018-Q3,0,0,0
 Abhishek Kulkarni,2018-Q2,0,0,0
 Abhishek Kulkarni,2018-Q1,0,0,0
-Reed,2021-Q4,0,0,0
-Reed,2021-Q3,0,0,0
 Reed,2021-Q2,0,0,0
 Reed,2021-Q1,0,0,0
 Reed,2020-Q4,6,24,6
@@ -9103,8 +7965,6 @@ Reed,2018-Q4,0,0,0
 Reed,2018-Q3,0,0,0
 Reed,2018-Q2,0,0,0
 Reed,2018-Q1,0,0,0
-Liam Miller-Cushon,2021-Q4,0,0,0
-Liam Miller-Cushon,2021-Q3,0,0,0
 Liam Miller-Cushon,2021-Q2,0,0,0
 Liam Miller-Cushon,2021-Q1,0,0,0
 Liam Miller-Cushon,2020-Q4,1,25,24
@@ -9119,8 +7979,6 @@ Liam Miller-Cushon,2018-Q4,0,0,0
 Liam Miller-Cushon,2018-Q3,0,0,0
 Liam Miller-Cushon,2018-Q2,0,0,0
 Liam Miller-Cushon,2018-Q1,0,0,0
-yuanbopeng,2021-Q4,0,0,0
-yuanbopeng,2021-Q3,0,0,0
 yuanbopeng,2021-Q2,0,0,0
 yuanbopeng,2021-Q1,0,0,0
 yuanbopeng,2020-Q4,9,35,28
@@ -9135,8 +7993,6 @@ yuanbopeng,2018-Q4,0,0,0
 yuanbopeng,2018-Q3,0,0,0
 yuanbopeng,2018-Q2,0,0,0
 yuanbopeng,2018-Q1,0,0,0
-Tyler Davis,2021-Q4,0,0,0
-Tyler Davis,2021-Q3,0,0,0
 Tyler Davis,2021-Q2,0,0,0
 Tyler Davis,2021-Q1,0,0,0
 Tyler Davis,2020-Q4,7,12,14
@@ -9151,8 +8007,6 @@ Tyler Davis,2018-Q4,0,0,0
 Tyler Davis,2018-Q3,0,0,0
 Tyler Davis,2018-Q2,0,0,0
 Tyler Davis,2018-Q1,0,0,0
-OscarVanL,2021-Q4,0,0,0
-OscarVanL,2021-Q3,0,0,0
 OscarVanL,2021-Q2,0,0,0
 OscarVanL,2021-Q1,0,0,0
 OscarVanL,2020-Q4,1,0,0
@@ -9167,8 +8021,6 @@ OscarVanL,2018-Q4,0,0,0
 OscarVanL,2018-Q3,0,0,0
 OscarVanL,2018-Q2,0,0,0
 OscarVanL,2018-Q1,0,0,0
-Gunhan Gulsoy,2021-Q4,0,0,0
-Gunhan Gulsoy,2021-Q3,0,0,0
 Gunhan Gulsoy,2021-Q2,0,0,0
 Gunhan Gulsoy,2021-Q1,0,0,0
 Gunhan Gulsoy,2020-Q4,102,976,1157
@@ -9183,8 +8035,6 @@ Gunhan Gulsoy,2018-Q4,308,59626,2586
 Gunhan Gulsoy,2018-Q3,116,2559,3239
 Gunhan Gulsoy,2018-Q2,119,896,990
 Gunhan Gulsoy,2018-Q1,194,1008,2564
-Jianwei Xie,2021-Q4,0,0,0
-Jianwei Xie,2021-Q3,0,0,0
 Jianwei Xie,2021-Q2,0,0,0
 Jianwei Xie,2021-Q1,0,0,0
 Jianwei Xie,2020-Q4,1,0,0
@@ -9199,8 +8049,6 @@ Jianwei Xie,2018-Q4,25,1282,754
 Jianwei Xie,2018-Q3,20,487,105
 Jianwei Xie,2018-Q2,19,663,150
 Jianwei Xie,2018-Q1,447,14022,5348
-evaderan-lab,2021-Q4,0,0,0
-evaderan-lab,2021-Q3,0,0,0
 evaderan-lab,2021-Q2,0,0,0
 evaderan-lab,2021-Q1,0,0,0
 evaderan-lab,2020-Q4,1,0,0
@@ -9215,8 +8063,6 @@ evaderan-lab,2018-Q4,0,0,0
 evaderan-lab,2018-Q3,0,0,0
 evaderan-lab,2018-Q2,0,0,0
 evaderan-lab,2018-Q1,0,0,0
-Michelle Casbon,2021-Q4,0,0,0
-Michelle Casbon,2021-Q3,0,0,0
 Michelle Casbon,2021-Q2,0,0,0
 Michelle Casbon,2021-Q1,0,0,0
 Michelle Casbon,2020-Q4,7,215,0
@@ -9231,8 +8077,6 @@ Michelle Casbon,2018-Q4,0,0,0
 Michelle Casbon,2018-Q3,0,0,0
 Michelle Casbon,2018-Q2,0,0,0
 Michelle Casbon,2018-Q1,0,0,0
-Long M. Lưu,2021-Q4,0,0,0
-Long M. Lưu,2021-Q3,0,0,0
 Long M. Lưu,2021-Q2,0,0,0
 Long M. Lưu,2021-Q1,0,0,0
 Long M. Lưu,2020-Q4,1,0,0
@@ -9247,8 +8091,6 @@ Long M. Lưu,2018-Q4,0,0,0
 Long M. Lưu,2018-Q3,0,0,0
 Long M. Lưu,2018-Q2,0,0,0
 Long M. Lưu,2018-Q1,0,0,0
-Abdullah Rashwan,2021-Q4,0,0,0
-Abdullah Rashwan,2021-Q3,0,0,0
 Abdullah Rashwan,2021-Q2,0,0,0
 Abdullah Rashwan,2021-Q1,0,0,0
 Abdullah Rashwan,2020-Q4,1,3,4
@@ -9263,8 +8105,6 @@ Abdullah Rashwan,2018-Q4,0,0,0
 Abdullah Rashwan,2018-Q3,0,0,0
 Abdullah Rashwan,2018-Q2,0,0,0
 Abdullah Rashwan,2018-Q1,0,0,0
-Matthias,2021-Q4,0,0,0
-Matthias,2021-Q3,0,0,0
 Matthias,2021-Q2,0,0,0
 Matthias,2021-Q1,0,0,0
 Matthias,2020-Q4,1,7,9
@@ -9279,8 +8119,6 @@ Matthias,2018-Q4,0,0,0
 Matthias,2018-Q3,0,0,0
 Matthias,2018-Q2,0,0,0
 Matthias,2018-Q1,0,0,0
-Paul B. Isaac's,2021-Q4,0,0,0
-Paul B. Isaac's,2021-Q3,0,0,0
 Paul B. Isaac's,2021-Q2,0,0,0
 Paul B. Isaac's,2021-Q1,0,0,0
 Paul B. Isaac's,2020-Q4,2,11,2
@@ -9295,8 +8133,6 @@ Paul B. Isaac's,2018-Q4,0,0,0
 Paul B. Isaac's,2018-Q3,0,0,0
 Paul B. Isaac's,2018-Q2,0,0,0
 Paul B. Isaac's,2018-Q1,0,0,0
-Robert Szczepanski,2021-Q4,0,0,0
-Robert Szczepanski,2021-Q3,0,0,0
 Robert Szczepanski,2021-Q2,0,0,0
 Robert Szczepanski,2021-Q1,0,0,0
 Robert Szczepanski,2020-Q4,0,0,0
@@ -9311,8 +8147,6 @@ Robert Szczepanski,2018-Q4,0,0,0
 Robert Szczepanski,2018-Q3,0,0,0
 Robert Szczepanski,2018-Q2,0,0,0
 Robert Szczepanski,2018-Q1,0,0,0
-Yoav Ramon,2021-Q4,0,0,0
-Yoav Ramon,2021-Q3,0,0,0
 Yoav Ramon,2021-Q2,0,0,0
 Yoav Ramon,2021-Q1,0,0,0
 Yoav Ramon,2020-Q4,4,7,4
@@ -9327,8 +8161,6 @@ Yoav Ramon,2018-Q4,0,0,0
 Yoav Ramon,2018-Q3,0,0,0
 Yoav Ramon,2018-Q2,0,0,0
 Yoav Ramon,2018-Q1,0,0,0
-piyushdatta,2021-Q4,0,0,0
-piyushdatta,2021-Q3,0,0,0
 piyushdatta,2021-Q2,0,0,0
 piyushdatta,2021-Q1,0,0,0
 piyushdatta,2020-Q4,1,0,0
@@ -9343,8 +8175,6 @@ piyushdatta,2018-Q4,0,0,0
 piyushdatta,2018-Q3,0,0,0
 piyushdatta,2018-Q2,0,0,0
 piyushdatta,2018-Q1,0,0,0
-Ian Beauregard,2021-Q4,0,0,0
-Ian Beauregard,2021-Q3,0,0,0
 Ian Beauregard,2021-Q2,0,0,0
 Ian Beauregard,2021-Q1,0,0,0
 Ian Beauregard,2020-Q4,1,0,0
@@ -9359,8 +8189,6 @@ Ian Beauregard,2018-Q4,0,0,0
 Ian Beauregard,2018-Q3,0,0,0
 Ian Beauregard,2018-Q2,0,0,0
 Ian Beauregard,2018-Q1,0,0,0
-Yiwen Li,2021-Q4,0,0,0
-Yiwen Li,2021-Q3,0,0,0
 Yiwen Li,2021-Q2,0,0,0
 Yiwen Li,2021-Q1,0,0,0
 Yiwen Li,2020-Q4,2,6,3
@@ -9375,8 +8203,6 @@ Yiwen Li,2018-Q4,0,0,0
 Yiwen Li,2018-Q3,0,0,0
 Yiwen Li,2018-Q2,0,0,0
 Yiwen Li,2018-Q1,0,0,0
-Tarandeep Singh,2021-Q4,0,0,0
-Tarandeep Singh,2021-Q3,0,0,0
 Tarandeep Singh,2021-Q2,0,0,0
 Tarandeep Singh,2021-Q1,0,0,0
 Tarandeep Singh,2020-Q4,1,0,0
@@ -9391,8 +8217,6 @@ Tarandeep Singh,2018-Q4,0,0,0
 Tarandeep Singh,2018-Q3,0,0,0
 Tarandeep Singh,2018-Q2,0,0,0
 Tarandeep Singh,2018-Q1,0,0,0
-Henry Tan,2021-Q4,0,0,0
-Henry Tan,2021-Q3,0,0,0
 Henry Tan,2021-Q2,0,0,0
 Henry Tan,2021-Q1,0,0,0
 Henry Tan,2020-Q4,4,0,35
@@ -9407,8 +8231,6 @@ Henry Tan,2018-Q4,0,0,0
 Henry Tan,2018-Q3,0,0,0
 Henry Tan,2018-Q2,0,0,0
 Henry Tan,2018-Q1,0,0,0
-PlusPlusUltra,2021-Q4,0,0,0
-PlusPlusUltra,2021-Q3,0,0,0
 PlusPlusUltra,2021-Q2,0,0,0
 PlusPlusUltra,2021-Q1,0,0,0
 PlusPlusUltra,2020-Q4,3,99,2
@@ -9423,8 +8245,6 @@ PlusPlusUltra,2018-Q4,0,0,0
 PlusPlusUltra,2018-Q3,0,0,0
 PlusPlusUltra,2018-Q2,0,0,0
 PlusPlusUltra,2018-Q1,0,0,0
-Maria Romanenko Vexlard,2021-Q4,0,0,0
-Maria Romanenko Vexlard,2021-Q3,0,0,0
 Maria Romanenko Vexlard,2021-Q2,0,0,0
 Maria Romanenko Vexlard,2021-Q1,0,0,0
 Maria Romanenko Vexlard,2020-Q4,1,0,0
@@ -9439,8 +8259,6 @@ Maria Romanenko Vexlard,2018-Q4,0,0,0
 Maria Romanenko Vexlard,2018-Q3,0,0,0
 Maria Romanenko Vexlard,2018-Q2,0,0,0
 Maria Romanenko Vexlard,2018-Q1,0,0,0
-Philip Pham,2021-Q4,0,0,0
-Philip Pham,2021-Q3,0,0,0
 Philip Pham,2021-Q2,0,0,0
 Philip Pham,2021-Q1,0,0,0
 Philip Pham,2020-Q4,2,51,2
@@ -9455,8 +8273,6 @@ Philip Pham,2018-Q4,1,0,0
 Philip Pham,2018-Q3,1,16,0
 Philip Pham,2018-Q2,0,0,0
 Philip Pham,2018-Q1,0,0,0
-cfRod,2021-Q4,0,0,0
-cfRod,2021-Q3,0,0,0
 cfRod,2021-Q2,0,0,0
 cfRod,2021-Q1,0,0,0
 cfRod,2020-Q4,6,50,0
@@ -9471,8 +8287,6 @@ cfRod,2018-Q4,0,0,0
 cfRod,2018-Q3,0,0,0
 cfRod,2018-Q2,0,0,0
 cfRod,2018-Q1,0,0,0
-Marcos Pereira,2021-Q4,0,0,0
-Marcos Pereira,2021-Q3,0,0,0
 Marcos Pereira,2021-Q2,0,0,0
 Marcos Pereira,2021-Q1,0,0,0
 Marcos Pereira,2020-Q4,1,2,0
@@ -9487,8 +8301,6 @@ Marcos Pereira,2018-Q4,0,0,0
 Marcos Pereira,2018-Q3,0,0,0
 Marcos Pereira,2018-Q2,0,0,0
 Marcos Pereira,2018-Q1,0,0,0
-andreABbauer,2021-Q4,0,0,0
-andreABbauer,2021-Q3,0,0,0
 andreABbauer,2021-Q2,0,0,0
 andreABbauer,2021-Q1,0,0,0
 andreABbauer,2020-Q4,1,5,0
@@ -9503,8 +8315,6 @@ andreABbauer,2018-Q4,0,0,0
 andreABbauer,2018-Q3,0,0,0
 andreABbauer,2018-Q2,0,0,0
 andreABbauer,2018-Q1,0,0,0
-Poedator,2021-Q4,0,0,0
-Poedator,2021-Q3,0,0,0
 Poedator,2021-Q2,0,0,0
 Poedator,2021-Q1,0,0,0
 Poedator,2020-Q4,1,0,0
@@ -9519,8 +8329,6 @@ Poedator,2018-Q4,0,0,0
 Poedator,2018-Q3,0,0,0
 Poedator,2018-Q2,0,0,0
 Poedator,2018-Q1,0,0,0
-Alexey Radul,2021-Q4,0,0,0
-Alexey Radul,2021-Q3,0,0,0
 Alexey Radul,2021-Q2,0,0,0
 Alexey Radul,2021-Q1,0,0,0
 Alexey Radul,2020-Q4,2,15,0
@@ -9535,8 +8343,6 @@ Alexey Radul,2018-Q4,2,24,15
 Alexey Radul,2018-Q3,4,0,622
 Alexey Radul,2018-Q2,0,0,0
 Alexey Radul,2018-Q1,0,0,0
-Brent M. Spell,2021-Q4,0,0,0
-Brent M. Spell,2021-Q3,0,0,0
 Brent M. Spell,2021-Q2,0,0,0
 Brent M. Spell,2021-Q1,0,0,0
 Brent M. Spell,2020-Q4,1,9,11
@@ -9551,8 +8357,6 @@ Brent M. Spell,2018-Q4,0,0,0
 Brent M. Spell,2018-Q3,0,0,0
 Brent M. Spell,2018-Q2,0,0,0
 Brent M. Spell,2018-Q1,0,0,0
-Pavel Krajcevski,2021-Q4,0,0,0
-Pavel Krajcevski,2021-Q3,0,0,0
 Pavel Krajcevski,2021-Q2,0,0,0
 Pavel Krajcevski,2021-Q1,0,0,0
 Pavel Krajcevski,2020-Q4,1,3,2
@@ -9567,8 +8371,6 @@ Pavel Krajcevski,2018-Q4,0,0,0
 Pavel Krajcevski,2018-Q3,0,0,0
 Pavel Krajcevski,2018-Q2,0,0,0
 Pavel Krajcevski,2018-Q1,0,0,0
-Aavishkar Mishra,2021-Q4,0,0,0
-Aavishkar Mishra,2021-Q3,0,0,0
 Aavishkar Mishra,2021-Q2,0,0,0
 Aavishkar Mishra,2021-Q1,0,0,0
 Aavishkar Mishra,2020-Q4,4,12,13
@@ -9583,8 +8385,6 @@ Aavishkar Mishra,2018-Q4,0,0,0
 Aavishkar Mishra,2018-Q3,0,0,0
 Aavishkar Mishra,2018-Q2,0,0,0
 Aavishkar Mishra,2018-Q1,0,0,0
-Marcin Owsiany,2021-Q4,0,0,0
-Marcin Owsiany,2021-Q3,0,0,0
 Marcin Owsiany,2021-Q2,0,0,0
 Marcin Owsiany,2021-Q1,0,0,0
 Marcin Owsiany,2020-Q4,1,4,4
@@ -9599,8 +8399,6 @@ Marcin Owsiany,2018-Q4,0,0,0
 Marcin Owsiany,2018-Q3,0,0,0
 Marcin Owsiany,2018-Q2,0,0,0
 Marcin Owsiany,2018-Q1,0,0,0
-Chen Cen,2021-Q4,0,0,0
-Chen Cen,2021-Q3,0,0,0
 Chen Cen,2021-Q2,0,0,0
 Chen Cen,2021-Q1,0,0,0
 Chen Cen,2020-Q4,4,90,2
@@ -9615,8 +8413,6 @@ Chen Cen,2018-Q4,0,0,0
 Chen Cen,2018-Q3,0,0,0
 Chen Cen,2018-Q2,0,0,0
 Chen Cen,2018-Q1,0,0,0
-Ashwin Phadke,2021-Q4,0,0,0
-Ashwin Phadke,2021-Q3,0,0,0
 Ashwin Phadke,2021-Q2,0,0,0
 Ashwin Phadke,2021-Q1,0,0,0
 Ashwin Phadke,2020-Q4,4,43,21
@@ -9631,8 +8427,6 @@ Ashwin Phadke,2018-Q4,0,0,0
 Ashwin Phadke,2018-Q3,0,0,0
 Ashwin Phadke,2018-Q2,0,0,0
 Ashwin Phadke,2018-Q1,0,0,0
-ml-0,2021-Q4,0,0,0
-ml-0,2021-Q3,0,0,0
 ml-0,2021-Q2,0,0,0
 ml-0,2021-Q1,0,0,0
 ml-0,2020-Q4,4,11,2
@@ -9647,8 +8441,6 @@ ml-0,2018-Q4,0,0,0
 ml-0,2018-Q3,0,0,0
 ml-0,2018-Q2,0,0,0
 ml-0,2018-Q1,0,0,0
-Rohan Lekhwani,2021-Q4,0,0,0
-Rohan Lekhwani,2021-Q3,0,0,0
 Rohan Lekhwani,2021-Q2,0,0,0
 Rohan Lekhwani,2021-Q1,0,0,0
 Rohan Lekhwani,2020-Q4,3,30,7
@@ -9663,8 +8455,6 @@ Rohan Lekhwani,2018-Q4,0,0,0
 Rohan Lekhwani,2018-Q3,0,0,0
 Rohan Lekhwani,2018-Q2,0,0,0
 Rohan Lekhwani,2018-Q1,0,0,0
-Jung Daun,2021-Q4,0,0,0
-Jung Daun,2021-Q3,0,0,0
 Jung Daun,2021-Q2,0,0,0
 Jung Daun,2021-Q1,0,0,0
 Jung Daun,2020-Q4,1,9,8
@@ -9679,8 +8469,6 @@ Jung Daun,2018-Q4,0,0,0
 Jung Daun,2018-Q3,0,0,0
 Jung Daun,2018-Q2,0,0,0
 Jung Daun,2018-Q1,0,0,0
-Kasra Bigdeli,2021-Q4,0,0,0
-Kasra Bigdeli,2021-Q3,0,0,0
 Kasra Bigdeli,2021-Q2,0,0,0
 Kasra Bigdeli,2021-Q1,0,0,0
 Kasra Bigdeli,2020-Q4,1,5,5
@@ -9695,8 +8483,6 @@ Kasra Bigdeli,2018-Q4,0,0,0
 Kasra Bigdeli,2018-Q3,0,0,0
 Kasra Bigdeli,2018-Q2,0,0,0
 Kasra Bigdeli,2018-Q1,0,0,0
-Jakub Beránek,2021-Q4,0,0,0
-Jakub Beránek,2021-Q3,0,0,0
 Jakub Beránek,2021-Q2,0,0,0
 Jakub Beránek,2021-Q1,0,0,0
 Jakub Beránek,2020-Q4,1,0,0
@@ -9711,8 +8497,6 @@ Jakub Beránek,2018-Q4,0,0,0
 Jakub Beránek,2018-Q3,0,0,0
 Jakub Beránek,2018-Q2,0,0,0
 Jakub Beránek,2018-Q1,0,0,0
-Ryan Sepassi,2021-Q4,0,0,0
-Ryan Sepassi,2021-Q3,0,0,0
 Ryan Sepassi,2021-Q2,0,0,0
 Ryan Sepassi,2021-Q1,0,0,0
 Ryan Sepassi,2020-Q4,1,0,0
@@ -9727,8 +8511,6 @@ Ryan Sepassi,2018-Q4,0,0,0
 Ryan Sepassi,2018-Q3,0,0,0
 Ryan Sepassi,2018-Q2,0,0,0
 Ryan Sepassi,2018-Q1,0,0,0
-Adrian Garcia Badaracco,2021-Q4,0,0,0
-Adrian Garcia Badaracco,2021-Q3,0,0,0
 Adrian Garcia Badaracco,2021-Q2,0,0,0
 Adrian Garcia Badaracco,2021-Q1,0,0,0
 Adrian Garcia Badaracco,2020-Q4,1,4,0
@@ -9743,8 +8525,6 @@ Adrian Garcia Badaracco,2018-Q4,0,0,0
 Adrian Garcia Badaracco,2018-Q3,0,0,0
 Adrian Garcia Badaracco,2018-Q2,0,0,0
 Adrian Garcia Badaracco,2018-Q1,0,0,0
-Jonathan DEKHTIAR,2021-Q4,0,0,0
-Jonathan DEKHTIAR,2021-Q3,0,0,0
 Jonathan DEKHTIAR,2021-Q2,0,0,0
 Jonathan DEKHTIAR,2021-Q1,0,0,0
 Jonathan DEKHTIAR,2020-Q4,4,49,10
@@ -9759,8 +8539,6 @@ Jonathan DEKHTIAR,2018-Q4,0,0,0
 Jonathan DEKHTIAR,2018-Q3,0,0,0
 Jonathan DEKHTIAR,2018-Q2,0,0,0
 Jonathan DEKHTIAR,2018-Q1,0,0,0
-Dmitry Tsarkov,2021-Q4,0,0,0
-Dmitry Tsarkov,2021-Q3,0,0,0
 Dmitry Tsarkov,2021-Q2,0,0,0
 Dmitry Tsarkov,2021-Q1,0,0,0
 Dmitry Tsarkov,2020-Q4,2,15,0
@@ -9775,8 +8553,6 @@ Dmitry Tsarkov,2018-Q4,0,0,0
 Dmitry Tsarkov,2018-Q3,0,0,0
 Dmitry Tsarkov,2018-Q2,0,0,0
 Dmitry Tsarkov,2018-Q1,0,0,0
-Chao Xie,2021-Q4,0,0,0
-Chao Xie,2021-Q3,0,0,0
 Chao Xie,2021-Q2,0,0,0
 Chao Xie,2021-Q1,0,0,0
 Chao Xie,2020-Q4,6,2,34
@@ -9791,8 +8567,6 @@ Chao Xie,2018-Q4,0,0,0
 Chao Xie,2018-Q3,0,0,0
 Chao Xie,2018-Q2,0,0,0
 Chao Xie,2018-Q1,0,0,0
-Matt Conley,2021-Q4,0,0,0
-Matt Conley,2021-Q3,0,0,0
 Matt Conley,2021-Q2,0,0,0
 Matt Conley,2021-Q1,0,0,0
 Matt Conley,2020-Q4,0,0,0
@@ -9807,8 +8581,6 @@ Matt Conley,2018-Q4,3,15,10
 Matt Conley,2018-Q3,14,137,387
 Matt Conley,2018-Q2,0,0,0
 Matt Conley,2018-Q1,0,0,0
-Brian Zhao,2021-Q4,0,0,0
-Brian Zhao,2021-Q3,0,0,0
 Brian Zhao,2021-Q2,0,0,0
 Brian Zhao,2021-Q1,0,0,0
 Brian Zhao,2020-Q4,0,0,0
@@ -9823,8 +8595,6 @@ Brian Zhao,2018-Q4,0,0,0
 Brian Zhao,2018-Q3,0,0,0
 Brian Zhao,2018-Q2,0,0,0
 Brian Zhao,2018-Q1,0,0,0
-Rachel Lim,2021-Q4,0,0,0
-Rachel Lim,2021-Q3,0,0,0
 Rachel Lim,2021-Q2,0,0,0
 Rachel Lim,2021-Q1,0,0,0
 Rachel Lim,2020-Q4,0,0,0
@@ -9839,8 +8609,6 @@ Rachel Lim,2018-Q4,177,4943,1867
 Rachel Lim,2018-Q3,182,7453,2438
 Rachel Lim,2018-Q2,34,2945,693
 Rachel Lim,2018-Q1,10,848,105
-Kushan Ahmadian,2021-Q4,0,0,0
-Kushan Ahmadian,2021-Q3,0,0,0
 Kushan Ahmadian,2021-Q2,0,0,0
 Kushan Ahmadian,2021-Q1,0,0,0
 Kushan Ahmadian,2020-Q4,0,0,0
@@ -9855,8 +8623,6 @@ Kushan Ahmadian,2018-Q4,0,0,0
 Kushan Ahmadian,2018-Q3,0,0,0
 Kushan Ahmadian,2018-Q2,0,0,0
 Kushan Ahmadian,2018-Q1,0,0,0
-Paul Tanger,2021-Q4,0,0,0
-Paul Tanger,2021-Q3,0,0,0
 Paul Tanger,2021-Q2,0,0,0
 Paul Tanger,2021-Q1,0,0,0
 Paul Tanger,2020-Q4,0,0,0
@@ -9871,8 +8637,6 @@ Paul Tanger,2018-Q4,0,0,0
 Paul Tanger,2018-Q3,0,0,0
 Paul Tanger,2018-Q2,0,0,0
 Paul Tanger,2018-Q1,0,0,0
-dannyfriar,2021-Q4,0,0,0
-dannyfriar,2021-Q3,0,0,0
 dannyfriar,2021-Q2,0,0,0
 dannyfriar,2021-Q1,0,0,0
 dannyfriar,2020-Q4,0,0,0
@@ -9887,8 +8651,6 @@ dannyfriar,2018-Q4,0,0,0
 dannyfriar,2018-Q3,0,0,0
 dannyfriar,2018-Q2,0,0,0
 dannyfriar,2018-Q1,0,0,0
-Ahmed S. Taei,2021-Q4,0,0,0
-Ahmed S. Taei,2021-Q3,0,0,0
 Ahmed S. Taei,2021-Q2,0,0,0
 Ahmed S. Taei,2021-Q1,0,0,0
 Ahmed S. Taei,2020-Q4,0,0,0
@@ -9903,8 +8665,6 @@ Ahmed S. Taei,2018-Q4,0,0,0
 Ahmed S. Taei,2018-Q3,0,0,0
 Ahmed S. Taei,2018-Q2,0,0,0
 Ahmed S. Taei,2018-Q1,0,0,0
-zmx,2021-Q4,0,0,0
-zmx,2021-Q3,0,0,0
 zmx,2021-Q2,0,0,0
 zmx,2021-Q1,0,0,0
 zmx,2020-Q4,0,0,0
@@ -9919,8 +8679,6 @@ zmx,2018-Q4,0,0,0
 zmx,2018-Q3,0,0,0
 zmx,2018-Q2,0,0,0
 zmx,2018-Q1,0,0,0
-Zheng Xu,2021-Q4,0,0,0
-Zheng Xu,2021-Q3,0,0,0
 Zheng Xu,2021-Q2,0,0,0
 Zheng Xu,2021-Q1,0,0,0
 Zheng Xu,2020-Q4,0,0,0
@@ -9935,8 +8693,6 @@ Zheng Xu,2018-Q4,0,0,0
 Zheng Xu,2018-Q3,0,0,0
 Zheng Xu,2018-Q2,0,0,0
 Zheng Xu,2018-Q1,0,0,0
-Leslie-Fang,2021-Q4,0,0,0
-Leslie-Fang,2021-Q3,0,0,0
 Leslie-Fang,2021-Q2,0,0,0
 Leslie-Fang,2021-Q1,0,0,0
 Leslie-Fang,2020-Q4,0,0,0
@@ -9951,8 +8707,6 @@ Leslie-Fang,2018-Q4,0,0,0
 Leslie-Fang,2018-Q3,0,0,0
 Leslie-Fang,2018-Q2,0,0,0
 Leslie-Fang,2018-Q1,0,0,0
-Felix Johnny,2021-Q4,0,0,0
-Felix Johnny,2021-Q3,0,0,0
 Felix Johnny,2021-Q2,0,0,0
 Felix Johnny,2021-Q1,0,0,0
 Felix Johnny,2020-Q4,0,0,0
@@ -9967,8 +8721,6 @@ Felix Johnny,2018-Q4,0,0,0
 Felix Johnny,2018-Q3,0,0,0
 Felix Johnny,2018-Q2,0,0,0
 Felix Johnny,2018-Q1,0,0,0
-Jan Jongboom,2021-Q4,0,0,0
-Jan Jongboom,2021-Q3,0,0,0
 Jan Jongboom,2021-Q2,0,0,0
 Jan Jongboom,2021-Q1,0,0,0
 Jan Jongboom,2020-Q4,0,0,0
@@ -9983,8 +8735,6 @@ Jan Jongboom,2018-Q4,0,0,0
 Jan Jongboom,2018-Q3,0,0,0
 Jan Jongboom,2018-Q2,0,0,0
 Jan Jongboom,2018-Q1,0,0,0
-Pierre-Antoine Manzagol,2021-Q4,0,0,0
-Pierre-Antoine Manzagol,2021-Q3,0,0,0
 Pierre-Antoine Manzagol,2021-Q2,0,0,0
 Pierre-Antoine Manzagol,2021-Q1,0,0,0
 Pierre-Antoine Manzagol,2020-Q4,0,0,0
@@ -9999,8 +8749,6 @@ Pierre-Antoine Manzagol,2018-Q4,0,0,0
 Pierre-Antoine Manzagol,2018-Q3,0,0,0
 Pierre-Antoine Manzagol,2018-Q2,0,0,0
 Pierre-Antoine Manzagol,2018-Q1,0,0,0
-Todd Lipcon,2021-Q4,0,0,0
-Todd Lipcon,2021-Q3,0,0,0
 Todd Lipcon,2021-Q2,0,0,0
 Todd Lipcon,2021-Q1,0,0,0
 Todd Lipcon,2020-Q4,0,0,0
@@ -10015,8 +8763,6 @@ Todd Lipcon,2018-Q4,0,0,0
 Todd Lipcon,2018-Q3,0,0,0
 Todd Lipcon,2018-Q2,0,0,0
 Todd Lipcon,2018-Q1,0,0,0
-Gaurav Agrawal,2021-Q4,0,0,0
-Gaurav Agrawal,2021-Q3,0,0,0
 Gaurav Agrawal,2021-Q2,0,0,0
 Gaurav Agrawal,2021-Q1,0,0,0
 Gaurav Agrawal,2020-Q4,0,0,0
@@ -10031,8 +8777,6 @@ Gaurav Agrawal,2018-Q4,0,0,0
 Gaurav Agrawal,2018-Q3,0,0,0
 Gaurav Agrawal,2018-Q2,0,0,0
 Gaurav Agrawal,2018-Q1,0,0,0
-jma,2021-Q4,0,0,0
-jma,2021-Q3,0,0,0
 jma,2021-Q2,0,0,0
 jma,2021-Q1,0,0,0
 jma,2020-Q4,0,0,0
@@ -10047,8 +8791,6 @@ jma,2018-Q4,0,0,0
 jma,2018-Q3,0,0,0
 jma,2018-Q2,0,0,0
 jma,2018-Q1,0,0,0
-George Grzegorz Pawelczak,2021-Q4,0,0,0
-George Grzegorz Pawelczak,2021-Q3,0,0,0
 George Grzegorz Pawelczak,2021-Q2,0,0,0
 George Grzegorz Pawelczak,2021-Q1,0,0,0
 George Grzegorz Pawelczak,2020-Q4,0,0,0
@@ -10063,8 +8805,6 @@ George Grzegorz Pawelczak,2018-Q4,0,0,0
 George Grzegorz Pawelczak,2018-Q3,0,0,0
 George Grzegorz Pawelczak,2018-Q2,0,0,0
 George Grzegorz Pawelczak,2018-Q1,0,0,0
-Jonathan Hseu,2021-Q4,0,0,0
-Jonathan Hseu,2021-Q3,0,0,0
 Jonathan Hseu,2021-Q2,0,0,0
 Jonathan Hseu,2021-Q1,0,0,0
 Jonathan Hseu,2020-Q4,0,0,0
@@ -10079,8 +8819,6 @@ Jonathan Hseu,2018-Q4,15,307,32
 Jonathan Hseu,2018-Q3,11,565,29
 Jonathan Hseu,2018-Q2,5,6,12
 Jonathan Hseu,2018-Q1,67,1052,1133
-Vijay Vasudevan,2021-Q4,0,0,0
-Vijay Vasudevan,2021-Q3,0,0,0
 Vijay Vasudevan,2021-Q2,0,0,0
 Vijay Vasudevan,2021-Q1,0,0,0
 Vijay Vasudevan,2020-Q4,0,0,0
@@ -10095,8 +8833,6 @@ Vijay Vasudevan,2018-Q4,1,4,2
 Vijay Vasudevan,2018-Q3,3,85,0
 Vijay Vasudevan,2018-Q2,0,0,0
 Vijay Vasudevan,2018-Q1,3,7,4
-Zhangqiang,2021-Q4,0,0,0
-Zhangqiang,2021-Q3,0,0,0
 Zhangqiang,2021-Q2,0,0,0
 Zhangqiang,2021-Q1,0,0,0
 Zhangqiang,2020-Q4,0,0,0
@@ -10111,8 +8847,6 @@ Zhangqiang,2018-Q4,0,0,0
 Zhangqiang,2018-Q3,0,0,0
 Zhangqiang,2018-Q2,0,0,0
 Zhangqiang,2018-Q1,0,0,0
-Michael137,2021-Q4,0,0,0
-Michael137,2021-Q3,0,0,0
 Michael137,2021-Q2,0,0,0
 Michael137,2021-Q1,0,0,0
 Michael137,2020-Q4,0,0,0
@@ -10127,8 +8861,6 @@ Michael137,2018-Q4,0,0,0
 Michael137,2018-Q3,0,0,0
 Michael137,2018-Q2,0,0,0
 Michael137,2018-Q1,0,0,0
-amturati,2021-Q4,0,0,0
-amturati,2021-Q3,0,0,0
 amturati,2021-Q2,0,0,0
 amturati,2021-Q1,0,0,0
 amturati,2020-Q4,0,0,0
@@ -10143,8 +8875,6 @@ amturati,2018-Q4,0,0,0
 amturati,2018-Q3,0,0,0
 amturati,2018-Q2,0,0,0
 amturati,2018-Q1,0,0,0
-sboshin,2021-Q4,0,0,0
-sboshin,2021-Q3,0,0,0
 sboshin,2021-Q2,0,0,0
 sboshin,2021-Q1,0,0,0
 sboshin,2020-Q4,0,0,0
@@ -10159,8 +8889,6 @@ sboshin,2018-Q4,0,0,0
 sboshin,2018-Q3,0,0,0
 sboshin,2018-Q2,0,0,0
 sboshin,2018-Q1,0,0,0
-Rickard,2021-Q4,0,0,0
-Rickard,2021-Q3,0,0,0
 Rickard,2021-Q2,0,0,0
 Rickard,2021-Q1,0,0,0
 Rickard,2020-Q4,0,0,0
@@ -10175,8 +8903,6 @@ Rickard,2018-Q4,0,0,0
 Rickard,2018-Q3,0,0,0
 Rickard,2018-Q2,0,0,0
 Rickard,2018-Q1,0,0,0
-emlaprise2358,2021-Q4,0,0,0
-emlaprise2358,2021-Q3,0,0,0
 emlaprise2358,2021-Q2,0,0,0
 emlaprise2358,2021-Q1,0,0,0
 emlaprise2358,2020-Q4,0,0,0
@@ -10191,8 +8917,6 @@ emlaprise2358,2018-Q4,0,0,0
 emlaprise2358,2018-Q3,0,0,0
 emlaprise2358,2018-Q2,0,0,0
 emlaprise2358,2018-Q1,0,0,0
-COTASPAR,2021-Q4,0,0,0
-COTASPAR,2021-Q3,0,0,0
 COTASPAR,2021-Q2,0,0,0
 COTASPAR,2021-Q1,0,0,0
 COTASPAR,2020-Q4,0,0,0
@@ -10207,8 +8931,6 @@ COTASPAR,2018-Q4,0,0,0
 COTASPAR,2018-Q3,0,0,0
 COTASPAR,2018-Q2,0,0,0
 COTASPAR,2018-Q1,0,0,0
-jedlimlx,2021-Q4,0,0,0
-jedlimlx,2021-Q3,0,0,0
 jedlimlx,2021-Q2,0,0,0
 jedlimlx,2021-Q1,0,0,0
 jedlimlx,2020-Q4,0,0,0
@@ -10223,8 +8945,6 @@ jedlimlx,2018-Q4,0,0,0
 jedlimlx,2018-Q3,0,0,0
 jedlimlx,2018-Q2,0,0,0
 jedlimlx,2018-Q1,0,0,0
-Vo Van Nghia,2021-Q4,0,0,0
-Vo Van Nghia,2021-Q3,0,0,0
 Vo Van Nghia,2021-Q2,0,0,0
 Vo Van Nghia,2021-Q1,0,0,0
 Vo Van Nghia,2020-Q4,0,0,0
@@ -10239,8 +8959,6 @@ Vo Van Nghia,2018-Q4,0,0,0
 Vo Van Nghia,2018-Q3,0,0,0
 Vo Van Nghia,2018-Q2,0,0,0
 Vo Van Nghia,2018-Q1,0,0,0
-Tomasz Strejczek,2021-Q4,0,0,0
-Tomasz Strejczek,2021-Q3,0,0,0
 Tomasz Strejczek,2021-Q2,0,0,0
 Tomasz Strejczek,2021-Q1,0,0,0
 Tomasz Strejczek,2020-Q4,0,0,0
@@ -10255,8 +8973,6 @@ Tomasz Strejczek,2018-Q4,0,0,0
 Tomasz Strejczek,2018-Q3,0,0,0
 Tomasz Strejczek,2018-Q2,0,0,0
 Tomasz Strejczek,2018-Q1,0,0,0
-Oleg Guba,2021-Q4,0,0,0
-Oleg Guba,2021-Q3,0,0,0
 Oleg Guba,2021-Q2,0,0,0
 Oleg Guba,2021-Q1,0,0,0
 Oleg Guba,2020-Q4,0,0,0
@@ -10271,8 +8987,6 @@ Oleg Guba,2018-Q4,0,0,0
 Oleg Guba,2018-Q3,0,0,0
 Oleg Guba,2018-Q2,0,0,0
 Oleg Guba,2018-Q1,0,0,0
-Ehsan Toosi,2021-Q4,0,0,0
-Ehsan Toosi,2021-Q3,0,0,0
 Ehsan Toosi,2021-Q2,0,0,0
 Ehsan Toosi,2021-Q1,0,0,0
 Ehsan Toosi,2020-Q4,0,0,0
@@ -10287,8 +9001,6 @@ Ehsan Toosi,2018-Q4,0,0,0
 Ehsan Toosi,2018-Q3,0,0,0
 Ehsan Toosi,2018-Q2,0,0,0
 Ehsan Toosi,2018-Q1,0,0,0
-Yasuhiro Matsumoto,2021-Q4,0,0,0
-Yasuhiro Matsumoto,2021-Q3,0,0,0
 Yasuhiro Matsumoto,2021-Q2,0,0,0
 Yasuhiro Matsumoto,2021-Q1,0,0,0
 Yasuhiro Matsumoto,2020-Q4,0,0,0
@@ -10303,8 +9015,6 @@ Yasuhiro Matsumoto,2018-Q4,0,0,0
 Yasuhiro Matsumoto,2018-Q3,0,0,0
 Yasuhiro Matsumoto,2018-Q2,0,0,0
 Yasuhiro Matsumoto,2018-Q1,0,0,0
-Dmitry Zakharov,2021-Q4,0,0,0
-Dmitry Zakharov,2021-Q3,0,0,0
 Dmitry Zakharov,2021-Q2,0,0,0
 Dmitry Zakharov,2021-Q1,0,0,0
 Dmitry Zakharov,2020-Q4,0,0,0
@@ -10319,8 +9029,6 @@ Dmitry Zakharov,2018-Q4,0,0,0
 Dmitry Zakharov,2018-Q3,0,0,0
 Dmitry Zakharov,2018-Q2,0,0,0
 Dmitry Zakharov,2018-Q1,0,0,0
-Fabio Riccardi,2021-Q4,0,0,0
-Fabio Riccardi,2021-Q3,0,0,0
 Fabio Riccardi,2021-Q2,0,0,0
 Fabio Riccardi,2021-Q1,0,0,0
 Fabio Riccardi,2020-Q4,0,0,0
@@ -10335,8 +9043,6 @@ Fabio Riccardi,2018-Q4,0,0,0
 Fabio Riccardi,2018-Q3,0,0,0
 Fabio Riccardi,2018-Q2,0,0,0
 Fabio Riccardi,2018-Q1,0,0,0
-Javier Montalt Tordera,2021-Q4,0,0,0
-Javier Montalt Tordera,2021-Q3,0,0,0
 Javier Montalt Tordera,2021-Q2,0,0,0
 Javier Montalt Tordera,2021-Q1,0,0,0
 Javier Montalt Tordera,2020-Q4,0,0,0
@@ -10351,8 +9057,6 @@ Javier Montalt Tordera,2018-Q4,0,0,0
 Javier Montalt Tordera,2018-Q3,0,0,0
 Javier Montalt Tordera,2018-Q2,0,0,0
 Javier Montalt Tordera,2018-Q1,0,0,0
-Basit Ayantunde,2021-Q4,0,0,0
-Basit Ayantunde,2021-Q3,0,0,0
 Basit Ayantunde,2021-Q2,0,0,0
 Basit Ayantunde,2021-Q1,0,0,0
 Basit Ayantunde,2020-Q4,0,0,0
@@ -10367,8 +9071,6 @@ Basit Ayantunde,2018-Q4,0,0,0
 Basit Ayantunde,2018-Q3,0,0,0
 Basit Ayantunde,2018-Q2,0,0,0
 Basit Ayantunde,2018-Q1,0,0,0
-bigcat-himax,2021-Q4,0,0,0
-bigcat-himax,2021-Q3,0,0,0
 bigcat-himax,2021-Q2,0,0,0
 bigcat-himax,2021-Q1,0,0,0
 bigcat-himax,2020-Q4,0,0,0
@@ -10383,8 +9085,6 @@ bigcat-himax,2018-Q4,0,0,0
 bigcat-himax,2018-Q3,0,0,0
 bigcat-himax,2018-Q2,0,0,0
 bigcat-himax,2018-Q1,0,0,0
-Emily Fertig,2021-Q4,0,0,0
-Emily Fertig,2021-Q3,0,0,0
 Emily Fertig,2021-Q2,0,0,0
 Emily Fertig,2021-Q1,0,0,0
 Emily Fertig,2020-Q4,0,0,0
@@ -10399,8 +9099,6 @@ Emily Fertig,2018-Q4,0,0,0
 Emily Fertig,2018-Q3,0,0,0
 Emily Fertig,2018-Q2,0,0,0
 Emily Fertig,2018-Q1,0,0,0
-DarrenZhang01,2021-Q4,0,0,0
-DarrenZhang01,2021-Q3,0,0,0
 DarrenZhang01,2021-Q2,0,0,0
 DarrenZhang01,2021-Q1,0,0,0
 DarrenZhang01,2020-Q4,0,0,0
@@ -10415,8 +9113,6 @@ DarrenZhang01,2018-Q4,0,0,0
 DarrenZhang01,2018-Q3,0,0,0
 DarrenZhang01,2018-Q2,0,0,0
 DarrenZhang01,2018-Q1,0,0,0
-Martin Hwasser,2021-Q4,0,0,0
-Martin Hwasser,2021-Q3,0,0,0
 Martin Hwasser,2021-Q2,0,0,0
 Martin Hwasser,2021-Q1,0,0,0
 Martin Hwasser,2020-Q4,0,0,0
@@ -10431,8 +9127,6 @@ Martin Hwasser,2018-Q4,0,0,0
 Martin Hwasser,2018-Q3,0,0,0
 Martin Hwasser,2018-Q2,0,0,0
 Martin Hwasser,2018-Q1,0,0,0
-Eugene Burmako,2021-Q4,0,0,0
-Eugene Burmako,2021-Q3,0,0,0
 Eugene Burmako,2021-Q2,0,0,0
 Eugene Burmako,2021-Q1,0,0,0
 Eugene Burmako,2020-Q4,0,0,0
@@ -10447,8 +9141,6 @@ Eugene Burmako,2018-Q4,0,0,0
 Eugene Burmako,2018-Q3,0,0,0
 Eugene Burmako,2018-Q2,0,0,0
 Eugene Burmako,2018-Q1,0,0,0
-Sharada Shiddibhavi,2021-Q4,0,0,0
-Sharada Shiddibhavi,2021-Q3,0,0,0
 Sharada Shiddibhavi,2021-Q2,0,0,0
 Sharada Shiddibhavi,2021-Q1,0,0,0
 Sharada Shiddibhavi,2020-Q4,0,0,0
@@ -10463,8 +9155,6 @@ Sharada Shiddibhavi,2018-Q4,0,0,0
 Sharada Shiddibhavi,2018-Q3,0,0,0
 Sharada Shiddibhavi,2018-Q2,0,0,0
 Sharada Shiddibhavi,2018-Q1,0,0,0
-sshiddib,2021-Q4,0,0,0
-sshiddib,2021-Q3,0,0,0
 sshiddib,2021-Q2,0,0,0
 sshiddib,2021-Q1,0,0,0
 sshiddib,2020-Q4,0,0,0
@@ -10479,8 +9169,6 @@ sshiddib,2018-Q4,0,0,0
 sshiddib,2018-Q3,0,0,0
 sshiddib,2018-Q2,0,0,0
 sshiddib,2018-Q1,0,0,0
-anencore94,2021-Q4,0,0,0
-anencore94,2021-Q3,0,0,0
 anencore94,2021-Q2,0,0,0
 anencore94,2021-Q1,0,0,0
 anencore94,2020-Q4,0,0,0
@@ -10495,8 +9183,6 @@ anencore94,2018-Q4,0,0,0
 anencore94,2018-Q3,0,0,0
 anencore94,2018-Q2,0,0,0
 anencore94,2018-Q1,0,0,0
-Alexey Ivanov,2021-Q4,0,0,0
-Alexey Ivanov,2021-Q3,0,0,0
 Alexey Ivanov,2021-Q2,0,0,0
 Alexey Ivanov,2021-Q1,0,0,0
 Alexey Ivanov,2020-Q4,0,0,0
@@ -10511,8 +9197,6 @@ Alexey Ivanov,2018-Q4,0,0,0
 Alexey Ivanov,2018-Q3,0,0,0
 Alexey Ivanov,2018-Q2,0,0,0
 Alexey Ivanov,2018-Q1,0,0,0
-Johan Nordström,2021-Q4,0,0,0
-Johan Nordström,2021-Q3,0,0,0
 Johan Nordström,2021-Q2,0,0,0
 Johan Nordström,2021-Q1,0,0,0
 Johan Nordström,2020-Q4,0,0,0
@@ -10527,8 +9211,6 @@ Johan Nordström,2018-Q4,0,0,0
 Johan Nordström,2018-Q3,0,0,0
 Johan Nordström,2018-Q2,0,0,0
 Johan Nordström,2018-Q1,0,0,0
-Kushagra Sharma,2021-Q4,0,0,0
-Kushagra Sharma,2021-Q3,0,0,0
 Kushagra Sharma,2021-Q2,0,0,0
 Kushagra Sharma,2021-Q1,0,0,0
 Kushagra Sharma,2020-Q4,0,0,0
@@ -10543,8 +9225,6 @@ Kushagra Sharma,2018-Q4,0,0,0
 Kushagra Sharma,2018-Q3,0,0,0
 Kushagra Sharma,2018-Q2,0,0,0
 Kushagra Sharma,2018-Q1,0,0,0
-ngc92,2021-Q4,0,0,0
-ngc92,2021-Q3,0,0,0
 ngc92,2021-Q2,0,0,0
 ngc92,2021-Q1,0,0,0
 ngc92,2020-Q4,0,0,0
@@ -10559,8 +9239,6 @@ ngc92,2018-Q4,0,0,0
 ngc92,2018-Q3,0,0,0
 ngc92,2018-Q2,1,48,26
 ngc92,2018-Q1,3,59,41
-danielyou0230,2021-Q4,0,0,0
-danielyou0230,2021-Q3,0,0,0
 danielyou0230,2021-Q2,0,0,0
 danielyou0230,2021-Q1,0,0,0
 danielyou0230,2020-Q4,0,0,0
@@ -10575,8 +9253,6 @@ danielyou0230,2018-Q4,0,0,0
 danielyou0230,2018-Q3,0,0,0
 danielyou0230,2018-Q2,0,0,0
 danielyou0230,2018-Q1,0,0,0
-Jongbin Park,2021-Q4,0,0,0
-Jongbin Park,2021-Q3,0,0,0
 Jongbin Park,2021-Q2,0,0,0
 Jongbin Park,2021-Q1,0,0,0
 Jongbin Park,2020-Q4,0,0,0
@@ -10591,8 +9267,6 @@ Jongbin Park,2018-Q4,0,0,0
 Jongbin Park,2018-Q3,0,0,0
 Jongbin Park,2018-Q2,0,0,0
 Jongbin Park,2018-Q1,0,0,0
-Jinjing Zhou,2021-Q4,0,0,0
-Jinjing Zhou,2021-Q3,0,0,0
 Jinjing Zhou,2021-Q2,0,0,0
 Jinjing Zhou,2021-Q1,0,0,0
 Jinjing Zhou,2020-Q4,0,0,0
@@ -10607,8 +9281,6 @@ Jinjing Zhou,2018-Q4,0,0,0
 Jinjing Zhou,2018-Q3,0,0,0
 Jinjing Zhou,2018-Q2,0,0,0
 Jinjing Zhou,2018-Q1,0,0,0
-Suharsh Sivakumar,2021-Q4,0,0,0
-Suharsh Sivakumar,2021-Q3,0,0,0
 Suharsh Sivakumar,2021-Q2,0,0,0
 Suharsh Sivakumar,2021-Q1,0,0,0
 Suharsh Sivakumar,2020-Q4,0,0,0
@@ -10623,8 +9295,6 @@ Suharsh Sivakumar,2018-Q4,75,2392,484
 Suharsh Sivakumar,2018-Q3,112,2559,3390
 Suharsh Sivakumar,2018-Q2,61,1646,428
 Suharsh Sivakumar,2018-Q1,82,3368,2604
-ShuXiang Gao,2021-Q4,0,0,0
-ShuXiang Gao,2021-Q3,0,0,0
 ShuXiang Gao,2021-Q2,0,0,0
 ShuXiang Gao,2021-Q1,0,0,0
 ShuXiang Gao,2020-Q4,0,0,0
@@ -10639,8 +9309,6 @@ ShuXiang Gao,2018-Q4,0,0,0
 ShuXiang Gao,2018-Q3,0,0,0
 ShuXiang Gao,2018-Q2,0,0,0
 ShuXiang Gao,2018-Q1,0,0,0
-Peter Sobot,2021-Q4,0,0,0
-Peter Sobot,2021-Q3,0,0,0
 Peter Sobot,2021-Q2,0,0,0
 Peter Sobot,2021-Q1,0,0,0
 Peter Sobot,2020-Q4,0,0,0
@@ -10655,8 +9323,6 @@ Peter Sobot,2018-Q4,0,0,0
 Peter Sobot,2018-Q3,0,0,0
 Peter Sobot,2018-Q2,0,0,0
 Peter Sobot,2018-Q1,0,0,0
-Maderator,2021-Q4,0,0,0
-Maderator,2021-Q3,0,0,0
 Maderator,2021-Q2,0,0,0
 Maderator,2021-Q1,0,0,0
 Maderator,2020-Q4,0,0,0
@@ -10671,8 +9337,6 @@ Maderator,2018-Q4,0,0,0
 Maderator,2018-Q3,0,0,0
 Maderator,2018-Q2,0,0,0
 Maderator,2018-Q1,0,0,0
-Thibaut Goetghebuer,2021-Q4,0,0,0
-Thibaut Goetghebuer,2021-Q3,0,0,0
 Thibaut Goetghebuer,2021-Q2,0,0,0
 Thibaut Goetghebuer,2021-Q1,0,0,0
 Thibaut Goetghebuer,2020-Q4,0,0,0
@@ -10687,8 +9351,6 @@ Thibaut Goetghebuer,2018-Q4,0,0,0
 Thibaut Goetghebuer,2018-Q3,0,0,0
 Thibaut Goetghebuer,2018-Q2,0,0,0
 Thibaut Goetghebuer,2018-Q1,0,0,0
-nyagato_00,2021-Q4,0,0,0
-nyagato_00,2021-Q3,0,0,0
 nyagato_00,2021-Q2,0,0,0
 nyagato_00,2021-Q1,0,0,0
 nyagato_00,2020-Q4,0,0,0
@@ -10703,8 +9365,6 @@ nyagato_00,2018-Q4,0,0,0
 nyagato_00,2018-Q3,0,0,0
 nyagato_00,2018-Q2,0,0,0
 nyagato_00,2018-Q1,0,0,0
-bzhao,2021-Q4,0,0,0
-bzhao,2021-Q3,0,0,0
 bzhao,2021-Q2,0,0,0
 bzhao,2021-Q1,0,0,0
 bzhao,2020-Q4,0,0,0
@@ -10719,8 +9379,6 @@ bzhao,2018-Q4,0,0,0
 bzhao,2018-Q3,0,0,0
 bzhao,2018-Q2,0,0,0
 bzhao,2018-Q1,0,0,0
-Amir Yazdanbakhsh,2021-Q4,0,0,0
-Amir Yazdanbakhsh,2021-Q3,0,0,0
 Amir Yazdanbakhsh,2021-Q2,0,0,0
 Amir Yazdanbakhsh,2021-Q1,0,0,0
 Amir Yazdanbakhsh,2020-Q4,0,0,0
@@ -10735,8 +9393,6 @@ Amir Yazdanbakhsh,2018-Q4,0,0,0
 Amir Yazdanbakhsh,2018-Q3,0,0,0
 Amir Yazdanbakhsh,2018-Q2,0,0,0
 Amir Yazdanbakhsh,2018-Q1,0,0,0
-Yong Wu,2021-Q4,0,0,0
-Yong Wu,2021-Q3,0,0,0
 Yong Wu,2021-Q2,0,0,0
 Yong Wu,2021-Q1,0,0,0
 Yong Wu,2020-Q4,0,0,0
@@ -10751,8 +9407,6 @@ Yong Wu,2018-Q4,0,0,0
 Yong Wu,2018-Q3,0,0,0
 Yong Wu,2018-Q2,0,0,0
 Yong Wu,2018-Q1,0,0,0
-Eduard Feicho,2021-Q4,0,0,0
-Eduard Feicho,2021-Q3,0,0,0
 Eduard Feicho,2021-Q2,0,0,0
 Eduard Feicho,2021-Q1,0,0,0
 Eduard Feicho,2020-Q4,0,0,0
@@ -10767,8 +9421,6 @@ Eduard Feicho,2018-Q4,0,0,0
 Eduard Feicho,2018-Q3,0,0,0
 Eduard Feicho,2018-Q2,0,0,0
 Eduard Feicho,2018-Q1,0,0,0
-John Poole,2021-Q4,0,0,0
-John Poole,2021-Q3,0,0,0
 John Poole,2021-Q2,0,0,0
 John Poole,2021-Q1,0,0,0
 John Poole,2020-Q4,0,0,0
@@ -10783,8 +9435,6 @@ John Poole,2018-Q4,0,0,0
 John Poole,2018-Q3,0,0,0
 John Poole,2018-Q2,0,0,0
 John Poole,2018-Q1,0,0,0
-Ongun Kanat,2021-Q4,0,0,0
-Ongun Kanat,2021-Q3,0,0,0
 Ongun Kanat,2021-Q2,0,0,0
 Ongun Kanat,2021-Q1,0,0,0
 Ongun Kanat,2020-Q4,0,0,0
@@ -10799,8 +9449,6 @@ Ongun Kanat,2018-Q4,0,0,0
 Ongun Kanat,2018-Q3,0,0,0
 Ongun Kanat,2018-Q2,0,0,0
 Ongun Kanat,2018-Q1,0,0,0
-Leicong Li,2021-Q4,0,0,0
-Leicong Li,2021-Q3,0,0,0
 Leicong Li,2021-Q2,0,0,0
 Leicong Li,2021-Q1,0,0,0
 Leicong Li,2020-Q4,0,0,0
@@ -10815,8 +9463,6 @@ Leicong Li,2018-Q4,0,0,0
 Leicong Li,2018-Q3,0,0,0
 Leicong Li,2018-Q2,0,0,0
 Leicong Li,2018-Q1,0,0,0
-SiCong Li,2021-Q4,0,0,0
-SiCong Li,2021-Q3,0,0,0
 SiCong Li,2021-Q2,0,0,0
 SiCong Li,2021-Q1,0,0,0
 SiCong Li,2020-Q4,0,0,0
@@ -10831,8 +9477,6 @@ SiCong Li,2018-Q4,0,0,0
 SiCong Li,2018-Q3,0,0,0
 SiCong Li,2018-Q2,0,0,0
 SiCong Li,2018-Q1,0,0,0
-retonym,2021-Q4,0,0,0
-retonym,2021-Q3,0,0,0
 retonym,2021-Q2,0,0,0
 retonym,2021-Q1,0,0,0
 retonym,2020-Q4,0,0,0
@@ -10847,8 +9491,6 @@ retonym,2018-Q4,0,0,0
 retonym,2018-Q3,0,0,0
 retonym,2018-Q2,0,0,0
 retonym,2018-Q1,0,0,0
-levinxo,2021-Q4,0,0,0
-levinxo,2021-Q3,0,0,0
 levinxo,2021-Q2,0,0,0
 levinxo,2021-Q1,0,0,0
 levinxo,2020-Q4,0,0,0
@@ -10863,8 +9505,6 @@ levinxo,2018-Q4,0,0,0
 levinxo,2018-Q3,0,0,0
 levinxo,2018-Q2,0,0,0
 levinxo,2018-Q1,0,0,0
-Kamil Rakoczy,2021-Q4,0,0,0
-Kamil Rakoczy,2021-Q3,0,0,0
 Kamil Rakoczy,2021-Q2,0,0,0
 Kamil Rakoczy,2021-Q1,0,0,0
 Kamil Rakoczy,2020-Q4,0,0,0
@@ -10879,8 +9519,6 @@ Kamil Rakoczy,2018-Q4,0,0,0
 Kamil Rakoczy,2018-Q3,0,0,0
 Kamil Rakoczy,2018-Q2,0,0,0
 Kamil Rakoczy,2018-Q1,0,0,0
-drebain,2021-Q4,0,0,0
-drebain,2021-Q3,0,0,0
 drebain,2021-Q2,0,0,0
 drebain,2021-Q1,0,0,0
 drebain,2020-Q4,0,0,0
@@ -10895,8 +9533,6 @@ drebain,2018-Q4,0,0,0
 drebain,2018-Q3,0,0,0
 drebain,2018-Q2,0,0,0
 drebain,2018-Q1,0,0,0
-Yixing,2021-Q4,0,0,0
-Yixing,2021-Q3,0,0,0
 Yixing,2021-Q2,0,0,0
 Yixing,2021-Q1,0,0,0
 Yixing,2020-Q4,0,0,0
@@ -10911,8 +9547,6 @@ Yixing,2018-Q4,0,0,0
 Yixing,2018-Q3,0,0,0
 Yixing,2018-Q2,0,0,0
 Yixing,2018-Q1,0,0,0
-danielknobe,2021-Q4,0,0,0
-danielknobe,2021-Q3,0,0,0
 danielknobe,2021-Q2,0,0,0
 danielknobe,2021-Q1,0,0,0
 danielknobe,2020-Q4,0,0,0
@@ -10927,8 +9561,6 @@ danielknobe,2018-Q4,0,0,0
 danielknobe,2018-Q3,0,0,0
 danielknobe,2018-Q2,0,0,0
 danielknobe,2018-Q1,0,0,0
-VoVAllen,2021-Q4,0,0,0
-VoVAllen,2021-Q3,0,0,0
 VoVAllen,2021-Q2,0,0,0
 VoVAllen,2021-Q1,0,0,0
 VoVAllen,2020-Q4,0,0,0
@@ -10943,8 +9575,6 @@ VoVAllen,2018-Q4,0,0,0
 VoVAllen,2018-Q3,0,0,0
 VoVAllen,2018-Q2,0,0,0
 VoVAllen,2018-Q1,0,0,0
-Natasha Kononenko,2021-Q4,0,0,0
-Natasha Kononenko,2021-Q3,0,0,0
 Natasha Kononenko,2021-Q2,0,0,0
 Natasha Kononenko,2021-Q1,0,0,0
 Natasha Kononenko,2020-Q4,0,0,0
@@ -10959,8 +9589,6 @@ Natasha Kononenko,2018-Q4,0,0,0
 Natasha Kononenko,2018-Q3,0,0,0
 Natasha Kononenko,2018-Q2,0,0,0
 Natasha Kononenko,2018-Q1,0,0,0
-Jonathan Chu,2021-Q4,0,0,0
-Jonathan Chu,2021-Q3,0,0,0
 Jonathan Chu,2021-Q2,0,0,0
 Jonathan Chu,2021-Q1,0,0,0
 Jonathan Chu,2020-Q4,0,0,0
@@ -10975,8 +9603,6 @@ Jonathan Chu,2018-Q4,0,0,0
 Jonathan Chu,2018-Q3,0,0,0
 Jonathan Chu,2018-Q2,0,0,0
 Jonathan Chu,2018-Q1,0,0,0
-Benjamin Chetioui,2021-Q4,0,0,0
-Benjamin Chetioui,2021-Q3,0,0,0
 Benjamin Chetioui,2021-Q2,0,0,0
 Benjamin Chetioui,2021-Q1,0,0,0
 Benjamin Chetioui,2020-Q4,0,0,0
@@ -10991,8 +9617,6 @@ Benjamin Chetioui,2018-Q4,0,0,0
 Benjamin Chetioui,2018-Q3,0,0,0
 Benjamin Chetioui,2018-Q2,0,0,0
 Benjamin Chetioui,2018-Q1,0,0,0
-Stephan Hoyer,2021-Q4,0,0,0
-Stephan Hoyer,2021-Q3,0,0,0
 Stephan Hoyer,2021-Q2,0,0,0
 Stephan Hoyer,2021-Q1,0,0,0
 Stephan Hoyer,2020-Q4,0,0,0
@@ -11007,8 +9631,6 @@ Stephan Hoyer,2018-Q4,0,0,0
 Stephan Hoyer,2018-Q3,0,0,0
 Stephan Hoyer,2018-Q2,2,0,0
 Stephan Hoyer,2018-Q1,0,0,0
-Uday Bondhugula,2021-Q4,0,0,0
-Uday Bondhugula,2021-Q3,0,0,0
 Uday Bondhugula,2021-Q2,0,0,0
 Uday Bondhugula,2021-Q1,0,0,0
 Uday Bondhugula,2020-Q4,0,0,0
@@ -11023,8 +9645,6 @@ Uday Bondhugula,2018-Q4,316,9049,3656
 Uday Bondhugula,2018-Q3,263,9039,2940
 Uday Bondhugula,2018-Q2,13,616,40
 Uday Bondhugula,2018-Q1,0,0,0
-Steven Clarkson,2021-Q4,0,0,0
-Steven Clarkson,2021-Q3,0,0,0
 Steven Clarkson,2021-Q2,0,0,0
 Steven Clarkson,2021-Q1,0,0,0
 Steven Clarkson,2020-Q4,0,0,0
@@ -11039,8 +9659,6 @@ Steven Clarkson,2018-Q4,0,0,0
 Steven Clarkson,2018-Q3,0,0,0
 Steven Clarkson,2018-Q2,0,0,0
 Steven Clarkson,2018-Q1,0,0,0
-Kai Katsumata,2021-Q4,0,0,0
-Kai Katsumata,2021-Q3,0,0,0
 Kai Katsumata,2021-Q2,0,0,0
 Kai Katsumata,2021-Q1,0,0,0
 Kai Katsumata,2020-Q4,0,0,0
@@ -11055,8 +9673,6 @@ Kai Katsumata,2018-Q4,0,0,0
 Kai Katsumata,2018-Q3,0,0,0
 Kai Katsumata,2018-Q2,0,0,0
 Kai Katsumata,2018-Q1,0,0,0
-Katherine Tian,2021-Q4,0,0,0
-Katherine Tian,2021-Q3,0,0,0
 Katherine Tian,2021-Q2,0,0,0
 Katherine Tian,2021-Q1,0,0,0
 Katherine Tian,2020-Q4,0,0,0
@@ -11071,8 +9687,6 @@ Katherine Tian,2018-Q4,0,0,0
 Katherine Tian,2018-Q3,0,0,0
 Katherine Tian,2018-Q2,0,0,0
 Katherine Tian,2018-Q1,0,0,0
-markf,2021-Q4,0,0,0
-markf,2021-Q3,0,0,0
 markf,2021-Q2,0,0,0
 markf,2021-Q1,0,0,0
 markf,2020-Q4,0,0,0
@@ -11087,8 +9701,6 @@ markf,2018-Q4,0,0,0
 markf,2018-Q3,0,0,0
 markf,2018-Q2,0,0,0
 markf,2018-Q1,0,0,0
-Evgeniy Polyakov,2021-Q4,0,0,0
-Evgeniy Polyakov,2021-Q3,0,0,0
 Evgeniy Polyakov,2021-Q2,0,0,0
 Evgeniy Polyakov,2021-Q1,0,0,0
 Evgeniy Polyakov,2020-Q4,0,0,0
@@ -11103,8 +9715,6 @@ Evgeniy Polyakov,2018-Q4,14,119,77
 Evgeniy Polyakov,2018-Q3,8,58,51
 Evgeniy Polyakov,2018-Q2,3,27,0
 Evgeniy Polyakov,2018-Q1,0,0,0
-Xingyu Long,2021-Q4,0,0,0
-Xingyu Long,2021-Q3,0,0,0
 Xingyu Long,2021-Q2,0,0,0
 Xingyu Long,2021-Q1,0,0,0
 Xingyu Long,2020-Q4,0,0,0
@@ -11119,8 +9729,6 @@ Xingyu Long,2018-Q4,0,0,0
 Xingyu Long,2018-Q3,0,0,0
 Xingyu Long,2018-Q2,0,0,0
 Xingyu Long,2018-Q1,0,0,0
-PiyushDatta,2021-Q4,0,0,0
-PiyushDatta,2021-Q3,0,0,0
 PiyushDatta,2021-Q2,0,0,0
 PiyushDatta,2021-Q1,0,0,0
 PiyushDatta,2020-Q4,0,0,0
@@ -11135,8 +9743,6 @@ PiyushDatta,2018-Q4,0,0,0
 PiyushDatta,2018-Q3,0,0,0
 PiyushDatta,2018-Q2,0,0,0
 PiyushDatta,2018-Q1,0,0,0
-Aniket Kumar Singh,2021-Q4,0,0,0
-Aniket Kumar Singh,2021-Q3,0,0,0
 Aniket Kumar Singh,2021-Q2,0,0,0
 Aniket Kumar Singh,2021-Q1,0,0,0
 Aniket Kumar Singh,2020-Q4,0,0,0
@@ -11151,8 +9757,6 @@ Aniket Kumar Singh,2018-Q4,0,0,0
 Aniket Kumar Singh,2018-Q3,0,0,0
 Aniket Kumar Singh,2018-Q2,0,0,0
 Aniket Kumar Singh,2018-Q1,0,0,0
-Ilya Persky,2021-Q4,0,0,0
-Ilya Persky,2021-Q3,0,0,0
 Ilya Persky,2021-Q2,0,0,0
 Ilya Persky,2021-Q1,0,0,0
 Ilya Persky,2020-Q4,0,0,0
@@ -11167,8 +9771,6 @@ Ilya Persky,2018-Q4,0,0,0
 Ilya Persky,2018-Q3,0,0,0
 Ilya Persky,2018-Q2,0,0,0
 Ilya Persky,2018-Q1,0,0,0
-Yunmo Koo,2021-Q4,0,0,0
-Yunmo Koo,2021-Q3,0,0,0
 Yunmo Koo,2021-Q2,0,0,0
 Yunmo Koo,2021-Q1,0,0,0
 Yunmo Koo,2020-Q4,0,0,0
@@ -11183,8 +9785,6 @@ Yunmo Koo,2018-Q4,0,0,0
 Yunmo Koo,2018-Q3,0,0,0
 Yunmo Koo,2018-Q2,0,0,0
 Yunmo Koo,2018-Q1,0,0,0
-Pulkit Bhuwalka,2021-Q4,0,0,0
-Pulkit Bhuwalka,2021-Q3,0,0,0
 Pulkit Bhuwalka,2021-Q2,0,0,0
 Pulkit Bhuwalka,2021-Q1,0,0,0
 Pulkit Bhuwalka,2020-Q4,0,0,0
@@ -11199,8 +9799,6 @@ Pulkit Bhuwalka,2018-Q4,4,15,8
 Pulkit Bhuwalka,2018-Q3,0,0,0
 Pulkit Bhuwalka,2018-Q2,0,0,0
 Pulkit Bhuwalka,2018-Q1,0,0,0
-Steven Hickson,2021-Q4,0,0,0
-Steven Hickson,2021-Q3,0,0,0
 Steven Hickson,2021-Q2,0,0,0
 Steven Hickson,2021-Q1,0,0,0
 Steven Hickson,2020-Q4,0,0,0
@@ -11215,8 +9813,6 @@ Steven Hickson,2018-Q4,0,0,0
 Steven Hickson,2018-Q3,0,0,0
 Steven Hickson,2018-Q2,0,0,0
 Steven Hickson,2018-Q1,1,8,0
-Josip Djolonga,2021-Q4,0,0,0
-Josip Djolonga,2021-Q3,0,0,0
 Josip Djolonga,2021-Q2,0,0,0
 Josip Djolonga,2021-Q1,0,0,0
 Josip Djolonga,2020-Q4,0,0,0
@@ -11231,8 +9827,6 @@ Josip Djolonga,2018-Q4,0,0,0
 Josip Djolonga,2018-Q3,0,0,0
 Josip Djolonga,2018-Q2,0,0,0
 Josip Djolonga,2018-Q1,0,0,0
-codeadmin_peritiae,2021-Q4,0,0,0
-codeadmin_peritiae,2021-Q3,0,0,0
 codeadmin_peritiae,2021-Q2,0,0,0
 codeadmin_peritiae,2021-Q1,0,0,0
 codeadmin_peritiae,2020-Q4,0,0,0
@@ -11247,8 +9841,6 @@ codeadmin_peritiae,2018-Q4,0,0,0
 codeadmin_peritiae,2018-Q3,0,0,0
 codeadmin_peritiae,2018-Q2,0,0,0
 codeadmin_peritiae,2018-Q1,0,0,0
-HarisWang,2021-Q4,0,0,0
-HarisWang,2021-Q3,0,0,0
 HarisWang,2021-Q2,0,0,0
 HarisWang,2021-Q1,0,0,0
 HarisWang,2020-Q4,0,0,0
@@ -11263,8 +9855,6 @@ HarisWang,2018-Q4,0,0,0
 HarisWang,2018-Q3,0,0,0
 HarisWang,2018-Q2,0,0,0
 HarisWang,2018-Q1,0,0,0
-Denis Vnukov,2021-Q4,0,0,0
-Denis Vnukov,2021-Q3,0,0,0
 Denis Vnukov,2021-Q2,0,0,0
 Denis Vnukov,2021-Q1,0,0,0
 Denis Vnukov,2020-Q4,0,0,0
@@ -11279,8 +9869,6 @@ Denis Vnukov,2018-Q4,13,113,29
 Denis Vnukov,2018-Q3,0,0,0
 Denis Vnukov,2018-Q2,0,0,0
 Denis Vnukov,2018-Q1,0,0,0
-Gmc2,2021-Q4,0,0,0
-Gmc2,2021-Q3,0,0,0
 Gmc2,2021-Q2,0,0,0
 Gmc2,2021-Q1,0,0,0
 Gmc2,2020-Q4,0,0,0
@@ -11295,8 +9883,6 @@ Gmc2,2018-Q4,0,0,0
 Gmc2,2018-Q3,0,0,0
 Gmc2,2018-Q2,0,0,0
 Gmc2,2018-Q1,0,0,0
-Hideto Ueno,2021-Q4,0,0,0
-Hideto Ueno,2021-Q3,0,0,0
 Hideto Ueno,2021-Q2,0,0,0
 Hideto Ueno,2021-Q1,0,0,0
 Hideto Ueno,2020-Q4,0,0,0
@@ -11311,8 +9897,6 @@ Hideto Ueno,2018-Q4,0,0,0
 Hideto Ueno,2018-Q3,0,0,0
 Hideto Ueno,2018-Q2,0,0,0
 Hideto Ueno,2018-Q1,0,0,0
-Yixing Fu,2021-Q4,0,0,0
-Yixing Fu,2021-Q3,0,0,0
 Yixing Fu,2021-Q2,0,0,0
 Yixing Fu,2021-Q1,0,0,0
 Yixing Fu,2020-Q4,0,0,0
@@ -11327,8 +9911,6 @@ Yixing Fu,2018-Q4,0,0,0
 Yixing Fu,2018-Q3,0,0,0
 Yixing Fu,2018-Q2,0,0,0
 Yixing Fu,2018-Q1,0,0,0
-Mikhail Startsev,2021-Q4,0,0,0
-Mikhail Startsev,2021-Q3,0,0,0
 Mikhail Startsev,2021-Q2,0,0,0
 Mikhail Startsev,2021-Q1,0,0,0
 Mikhail Startsev,2020-Q4,0,0,0
@@ -11343,8 +9925,6 @@ Mikhail Startsev,2018-Q4,0,0,0
 Mikhail Startsev,2018-Q3,0,0,0
 Mikhail Startsev,2018-Q2,0,0,0
 Mikhail Startsev,2018-Q1,0,0,0
-jerryyin,2021-Q4,0,0,0
-jerryyin,2021-Q3,0,0,0
 jerryyin,2021-Q2,0,0,0
 jerryyin,2021-Q1,0,0,0
 jerryyin,2020-Q4,0,0,0
@@ -11359,8 +9939,6 @@ jerryyin,2018-Q4,0,0,0
 jerryyin,2018-Q3,0,0,0
 jerryyin,2018-Q2,0,0,0
 jerryyin,2018-Q1,0,0,0
-Daniel Nguyen,2021-Q4,0,0,0
-Daniel Nguyen,2021-Q3,0,0,0
 Daniel Nguyen,2021-Q2,0,0,0
 Daniel Nguyen,2021-Q1,0,0,0
 Daniel Nguyen,2020-Q4,0,0,0
@@ -11375,8 +9953,6 @@ Daniel Nguyen,2018-Q4,0,0,0
 Daniel Nguyen,2018-Q3,0,0,0
 Daniel Nguyen,2018-Q2,0,0,0
 Daniel Nguyen,2018-Q1,0,0,0
-Biagio Montaruli,2021-Q4,0,0,0
-Biagio Montaruli,2021-Q3,0,0,0
 Biagio Montaruli,2021-Q2,0,0,0
 Biagio Montaruli,2021-Q1,0,0,0
 Biagio Montaruli,2020-Q4,0,0,0
@@ -11391,8 +9967,6 @@ Biagio Montaruli,2018-Q4,0,0,0
 Biagio Montaruli,2018-Q3,0,0,0
 Biagio Montaruli,2018-Q2,0,0,0
 Biagio Montaruli,2018-Q1,0,0,0
-acxz,2021-Q4,0,0,0
-acxz,2021-Q3,0,0,0
 acxz,2021-Q2,0,0,0
 acxz,2021-Q1,0,0,0
 acxz,2020-Q4,0,0,0
@@ -11407,8 +9981,6 @@ acxz,2018-Q4,0,0,0
 acxz,2018-Q3,0,0,0
 acxz,2018-Q2,0,0,0
 acxz,2018-Q1,0,0,0
-Kedar Sovani,2021-Q4,0,0,0
-Kedar Sovani,2021-Q3,0,0,0
 Kedar Sovani,2021-Q2,0,0,0
 Kedar Sovani,2021-Q1,0,0,0
 Kedar Sovani,2020-Q4,0,0,0
@@ -11423,8 +9995,6 @@ Kedar Sovani,2018-Q4,0,0,0
 Kedar Sovani,2018-Q3,0,0,0
 Kedar Sovani,2018-Q2,0,0,0
 Kedar Sovani,2018-Q1,0,0,0
-Christian,2021-Q4,0,0,0
-Christian,2021-Q3,0,0,0
 Christian,2021-Q2,0,0,0
 Christian,2021-Q1,0,0,0
 Christian,2020-Q4,0,0,0
@@ -11439,8 +10009,6 @@ Christian,2018-Q4,0,0,0
 Christian,2018-Q3,0,0,0
 Christian,2018-Q2,0,0,0
 Christian,2018-Q1,0,0,0
-Paul Wankadia,2021-Q4,0,0,0
-Paul Wankadia,2021-Q3,0,0,0
 Paul Wankadia,2021-Q2,0,0,0
 Paul Wankadia,2021-Q1,0,0,0
 Paul Wankadia,2020-Q4,0,0,0
@@ -11455,8 +10023,6 @@ Paul Wankadia,2018-Q4,0,0,0
 Paul Wankadia,2018-Q3,0,0,0
 Paul Wankadia,2018-Q2,0,0,0
 Paul Wankadia,2018-Q1,0,0,0
-Abhineet Choudhary,2021-Q4,0,0,0
-Abhineet Choudhary,2021-Q3,0,0,0
 Abhineet Choudhary,2021-Q2,0,0,0
 Abhineet Choudhary,2021-Q1,0,0,0
 Abhineet Choudhary,2020-Q4,0,0,0
@@ -11471,8 +10037,6 @@ Abhineet Choudhary,2018-Q4,0,0,0
 Abhineet Choudhary,2018-Q3,0,0,0
 Abhineet Choudhary,2018-Q2,0,0,0
 Abhineet Choudhary,2018-Q1,0,0,0
-Myung-Hyun Kim,2021-Q4,0,0,0
-Myung-Hyun Kim,2021-Q3,0,0,0
 Myung-Hyun Kim,2021-Q2,0,0,0
 Myung-Hyun Kim,2021-Q1,0,0,0
 Myung-Hyun Kim,2020-Q4,0,0,0
@@ -11487,8 +10051,6 @@ Myung-Hyun Kim,2018-Q4,0,0,0
 Myung-Hyun Kim,2018-Q3,0,0,0
 Myung-Hyun Kim,2018-Q2,0,0,0
 Myung-Hyun Kim,2018-Q1,0,0,0
-Sandeep Giri,2021-Q4,0,0,0
-Sandeep Giri,2021-Q3,0,0,0
 Sandeep Giri,2021-Q2,0,0,0
 Sandeep Giri,2021-Q1,0,0,0
 Sandeep Giri,2020-Q4,0,0,0
@@ -11503,8 +10065,6 @@ Sandeep Giri,2018-Q4,0,0,0
 Sandeep Giri,2018-Q3,0,0,0
 Sandeep Giri,2018-Q2,0,0,0
 Sandeep Giri,2018-Q1,0,0,0
-Steve Chien,2021-Q4,0,0,0
-Steve Chien,2021-Q3,0,0,0
 Steve Chien,2021-Q2,0,0,0
 Steve Chien,2021-Q1,0,0,0
 Steve Chien,2020-Q4,0,0,0
@@ -11519,8 +10079,6 @@ Steve Chien,2018-Q4,0,0,0
 Steve Chien,2018-Q3,0,0,0
 Steve Chien,2018-Q2,0,0,0
 Steve Chien,2018-Q1,0,0,0
-Alexandre Passos,2021-Q4,0,0,0
-Alexandre Passos,2021-Q3,0,0,0
 Alexandre Passos,2021-Q2,0,0,0
 Alexandre Passos,2021-Q1,0,0,0
 Alexandre Passos,2020-Q4,0,0,0
@@ -11535,8 +10093,6 @@ Alexandre Passos,2018-Q4,476,5466,9206
 Alexandre Passos,2018-Q3,261,4822,2048
 Alexandre Passos,2018-Q2,153,3996,694
 Alexandre Passos,2018-Q1,475,13596,8162
-Balint Cristian,2021-Q4,0,0,0
-Balint Cristian,2021-Q3,0,0,0
 Balint Cristian,2021-Q2,0,0,0
 Balint Cristian,2021-Q1,0,0,0
 Balint Cristian,2020-Q4,0,0,0
@@ -11551,8 +10107,6 @@ Balint Cristian,2018-Q4,4,107,76
 Balint Cristian,2018-Q3,3,177,0
 Balint Cristian,2018-Q2,0,0,0
 Balint Cristian,2018-Q1,0,0,0
-Jan Pfeiffer,2021-Q4,0,0,0
-Jan Pfeiffer,2021-Q3,0,0,0
 Jan Pfeiffer,2021-Q2,0,0,0
 Jan Pfeiffer,2021-Q1,0,0,0
 Jan Pfeiffer,2020-Q4,0,0,0
@@ -11567,8 +10121,6 @@ Jan Pfeiffer,2018-Q4,0,0,0
 Jan Pfeiffer,2018-Q3,0,0,0
 Jan Pfeiffer,2018-Q2,0,0,0
 Jan Pfeiffer,2018-Q1,0,0,0
-Anthony Platanios,2021-Q4,0,0,0
-Anthony Platanios,2021-Q3,0,0,0
 Anthony Platanios,2021-Q2,0,0,0
 Anthony Platanios,2021-Q1,0,0,0
 Anthony Platanios,2020-Q4,0,0,0
@@ -11583,8 +10135,6 @@ Anthony Platanios,2018-Q4,0,0,0
 Anthony Platanios,2018-Q3,0,0,0
 Anthony Platanios,2018-Q2,0,0,0
 Anthony Platanios,2018-Q1,1,0,0
-Krzysztof Laskowski,2021-Q4,0,0,0
-Krzysztof Laskowski,2021-Q3,0,0,0
 Krzysztof Laskowski,2021-Q2,0,0,0
 Krzysztof Laskowski,2021-Q1,0,0,0
 Krzysztof Laskowski,2020-Q4,0,0,0
@@ -11599,8 +10149,6 @@ Krzysztof Laskowski,2018-Q4,0,0,0
 Krzysztof Laskowski,2018-Q3,0,0,0
 Krzysztof Laskowski,2018-Q2,0,0,0
 Krzysztof Laskowski,2018-Q1,0,0,0
-HyoukJoong Lee,2021-Q4,0,0,0
-HyoukJoong Lee,2021-Q3,0,0,0
 HyoukJoong Lee,2021-Q2,0,0,0
 HyoukJoong Lee,2021-Q1,0,0,0
 HyoukJoong Lee,2020-Q4,0,0,0
@@ -11615,8 +10163,6 @@ HyoukJoong Lee,2018-Q4,7,15,10
 HyoukJoong Lee,2018-Q3,26,316,104
 HyoukJoong Lee,2018-Q2,20,155,41
 HyoukJoong Lee,2018-Q1,17,1455,160
-Lakshay Tokas,2021-Q4,0,0,0
-Lakshay Tokas,2021-Q3,0,0,0
 Lakshay Tokas,2021-Q2,0,0,0
 Lakshay Tokas,2021-Q1,0,0,0
 Lakshay Tokas,2020-Q4,0,0,0
@@ -11631,8 +10177,6 @@ Lakshay Tokas,2018-Q4,0,0,0
 Lakshay Tokas,2018-Q3,0,0,0
 Lakshay Tokas,2018-Q2,0,0,0
 Lakshay Tokas,2018-Q1,0,0,0
-Shawn Presser,2021-Q4,0,0,0
-Shawn Presser,2021-Q3,0,0,0
 Shawn Presser,2021-Q2,0,0,0
 Shawn Presser,2021-Q1,0,0,0
 Shawn Presser,2020-Q4,0,0,0
@@ -11647,8 +10191,6 @@ Shawn Presser,2018-Q4,0,0,0
 Shawn Presser,2018-Q3,0,0,0
 Shawn Presser,2018-Q2,0,0,0
 Shawn Presser,2018-Q1,0,0,0
-Steenu Johnson,2021-Q4,0,0,0
-Steenu Johnson,2021-Q3,0,0,0
 Steenu Johnson,2021-Q2,0,0,0
 Steenu Johnson,2021-Q1,0,0,0
 Steenu Johnson,2020-Q4,0,0,0
@@ -11663,8 +10205,6 @@ Steenu Johnson,2018-Q4,0,0,0
 Steenu Johnson,2018-Q3,0,0,0
 Steenu Johnson,2018-Q2,0,0,0
 Steenu Johnson,2018-Q1,0,0,0
-Terry Huang,2021-Q4,0,0,0
-Terry Huang,2021-Q3,0,0,0
 Terry Huang,2021-Q2,0,0,0
 Terry Huang,2021-Q1,0,0,0
 Terry Huang,2020-Q4,0,0,0
@@ -11679,8 +10219,6 @@ Terry Huang,2018-Q4,0,0,0
 Terry Huang,2018-Q3,0,0,0
 Terry Huang,2018-Q2,0,0,0
 Terry Huang,2018-Q1,0,0,0
-Tamas Nyiri,2021-Q4,0,0,0
-Tamas Nyiri,2021-Q3,0,0,0
 Tamas Nyiri,2021-Q2,0,0,0
 Tamas Nyiri,2021-Q1,0,0,0
 Tamas Nyiri,2020-Q4,0,0,0
@@ -11695,8 +10233,6 @@ Tamas Nyiri,2018-Q4,0,0,0
 Tamas Nyiri,2018-Q3,0,0,0
 Tamas Nyiri,2018-Q2,0,0,0
 Tamas Nyiri,2018-Q1,0,0,0
-Souradeep Nanda,2021-Q4,0,0,0
-Souradeep Nanda,2021-Q3,0,0,0
 Souradeep Nanda,2021-Q2,0,0,0
 Souradeep Nanda,2021-Q1,0,0,0
 Souradeep Nanda,2020-Q4,0,0,0
@@ -11711,8 +10247,6 @@ Souradeep Nanda,2018-Q4,0,0,0
 Souradeep Nanda,2018-Q3,0,0,0
 Souradeep Nanda,2018-Q2,0,0,0
 Souradeep Nanda,2018-Q1,0,0,0
-bbbboom,2021-Q4,0,0,0
-bbbboom,2021-Q3,0,0,0
 bbbboom,2021-Q2,0,0,0
 bbbboom,2021-Q1,0,0,0
 bbbboom,2020-Q4,0,0,0
@@ -11727,8 +10261,6 @@ bbbboom,2018-Q4,0,0,0
 bbbboom,2018-Q3,0,0,0
 bbbboom,2018-Q2,0,0,0
 bbbboom,2018-Q1,0,0,0
-Andy Lou,2021-Q4,0,0,0
-Andy Lou,2021-Q3,0,0,0
 Andy Lou,2021-Q2,0,0,0
 Andy Lou,2021-Q1,0,0,0
 Andy Lou,2020-Q4,0,0,0
@@ -11743,8 +10275,6 @@ Andy Lou,2018-Q4,0,0,0
 Andy Lou,2018-Q3,0,0,0
 Andy Lou,2018-Q2,0,0,0
 Andy Lou,2018-Q1,0,0,0
-Cheng CHEN,2021-Q4,0,0,0
-Cheng CHEN,2021-Q3,0,0,0
 Cheng CHEN,2021-Q2,0,0,0
 Cheng CHEN,2021-Q1,0,0,0
 Cheng CHEN,2020-Q4,0,0,0
@@ -11759,8 +10289,6 @@ Cheng CHEN,2018-Q4,0,0,0
 Cheng CHEN,2018-Q3,1,0,0
 Cheng CHEN,2018-Q2,0,0,0
 Cheng CHEN,2018-Q1,0,0,0
-Amy Skerry-Ryan,2021-Q4,0,0,0
-Amy Skerry-Ryan,2021-Q3,0,0,0
 Amy Skerry-Ryan,2021-Q2,0,0,0
 Amy Skerry-Ryan,2021-Q1,0,0,0
 Amy Skerry-Ryan,2020-Q4,0,0,0
@@ -11775,8 +10303,6 @@ Amy Skerry-Ryan,2018-Q4,0,0,0
 Amy Skerry-Ryan,2018-Q3,0,0,0
 Amy Skerry-Ryan,2018-Q2,0,0,0
 Amy Skerry-Ryan,2018-Q1,0,0,0
-Alexandre Lissy,2021-Q4,0,0,0
-Alexandre Lissy,2021-Q3,0,0,0
 Alexandre Lissy,2021-Q2,0,0,0
 Alexandre Lissy,2021-Q1,0,0,0
 Alexandre Lissy,2020-Q4,0,0,0
@@ -11791,8 +10317,6 @@ Alexandre Lissy,2018-Q4,0,0,0
 Alexandre Lissy,2018-Q3,0,0,0
 Alexandre Lissy,2018-Q2,0,0,0
 Alexandre Lissy,2018-Q1,0,0,0
-daria,2021-Q4,0,0,0
-daria,2021-Q3,0,0,0
 daria,2021-Q2,0,0,0
 daria,2021-Q1,0,0,0
 daria,2020-Q4,0,0,0
@@ -11807,8 +10331,6 @@ daria,2018-Q4,0,0,0
 daria,2018-Q3,0,0,0
 daria,2018-Q2,0,0,0
 daria,2018-Q1,0,0,0
-Taré Gaskin,2021-Q4,0,0,0
-Taré Gaskin,2021-Q3,0,0,0
 Taré Gaskin,2021-Q2,0,0,0
 Taré Gaskin,2021-Q1,0,0,0
 Taré Gaskin,2020-Q4,0,0,0
@@ -11823,8 +10345,6 @@ Taré Gaskin,2018-Q4,0,0,0
 Taré Gaskin,2018-Q3,0,0,0
 Taré Gaskin,2018-Q2,0,0,0
 Taré Gaskin,2018-Q1,0,0,0
-Karmel Allison,2021-Q4,0,0,0
-Karmel Allison,2021-Q3,0,0,0
 Karmel Allison,2021-Q2,0,0,0
 Karmel Allison,2021-Q1,0,0,0
 Karmel Allison,2020-Q4,0,0,0
@@ -11839,8 +10359,6 @@ Karmel Allison,2018-Q4,52,1686,850
 Karmel Allison,2018-Q3,46,529,319
 Karmel Allison,2018-Q2,50,3681,520
 Karmel Allison,2018-Q1,7,207,0
-tg-at-google,2021-Q4,0,0,0
-tg-at-google,2021-Q3,0,0,0
 tg-at-google,2021-Q2,0,0,0
 tg-at-google,2021-Q1,0,0,0
 tg-at-google,2020-Q4,0,0,0
@@ -11855,8 +10373,6 @@ tg-at-google,2018-Q4,0,0,0
 tg-at-google,2018-Q3,0,0,0
 tg-at-google,2018-Q2,0,0,0
 tg-at-google,2018-Q1,0,0,0
-Benoit Jacob,2021-Q4,0,0,0
-Benoit Jacob,2021-Q3,0,0,0
 Benoit Jacob,2021-Q2,0,0,0
 Benoit Jacob,2021-Q1,0,0,0
 Benoit Jacob,2020-Q4,0,0,0
@@ -11871,8 +10387,6 @@ Benoit Jacob,2018-Q4,0,0,0
 Benoit Jacob,2018-Q3,0,0,0
 Benoit Jacob,2018-Q2,0,0,0
 Benoit Jacob,2018-Q1,0,0,0
-Niranjan Hasabnis,2021-Q4,0,0,0
-Niranjan Hasabnis,2021-Q3,0,0,0
 Niranjan Hasabnis,2021-Q2,0,0,0
 Niranjan Hasabnis,2021-Q1,0,0,0
 Niranjan Hasabnis,2020-Q4,0,0,0
@@ -11887,8 +10401,6 @@ Niranjan Hasabnis,2018-Q4,16,679,95
 Niranjan Hasabnis,2018-Q3,13,267,88
 Niranjan Hasabnis,2018-Q2,9,343,36
 Niranjan Hasabnis,2018-Q1,9,117,28
-Gabriel Rasskin,2021-Q4,0,0,0
-Gabriel Rasskin,2021-Q3,0,0,0
 Gabriel Rasskin,2021-Q2,0,0,0
 Gabriel Rasskin,2021-Q1,0,0,0
 Gabriel Rasskin,2020-Q4,0,0,0
@@ -11903,8 +10415,6 @@ Gabriel Rasskin,2018-Q4,0,0,0
 Gabriel Rasskin,2018-Q3,0,0,0
 Gabriel Rasskin,2018-Q2,0,0,0
 Gabriel Rasskin,2018-Q1,0,0,0
-Alan Anderson,2021-Q4,0,0,0
-Alan Anderson,2021-Q3,0,0,0
 Alan Anderson,2021-Q2,0,0,0
 Alan Anderson,2021-Q1,0,0,0
 Alan Anderson,2020-Q4,0,0,0
@@ -11919,8 +10429,6 @@ Alan Anderson,2018-Q4,0,0,0
 Alan Anderson,2018-Q3,0,0,0
 Alan Anderson,2018-Q2,0,0,0
 Alan Anderson,2018-Q1,0,0,0
-Hemal Mamtora,2021-Q4,0,0,0
-Hemal Mamtora,2021-Q3,0,0,0
 Hemal Mamtora,2021-Q2,0,0,0
 Hemal Mamtora,2021-Q1,0,0,0
 Hemal Mamtora,2020-Q4,0,0,0
@@ -11935,8 +10443,6 @@ Hemal Mamtora,2018-Q4,0,0,0
 Hemal Mamtora,2018-Q3,0,0,0
 Hemal Mamtora,2018-Q2,0,0,0
 Hemal Mamtora,2018-Q1,0,0,0
-Hubert Eichner,2021-Q4,0,0,0
-Hubert Eichner,2021-Q3,0,0,0
 Hubert Eichner,2021-Q2,0,0,0
 Hubert Eichner,2021-Q1,0,0,0
 Hubert Eichner,2020-Q4,0,0,0
@@ -11951,8 +10457,6 @@ Hubert Eichner,2018-Q4,0,0,0
 Hubert Eichner,2018-Q3,0,0,0
 Hubert Eichner,2018-Q2,0,0,0
 Hubert Eichner,2018-Q1,0,0,0
-Vividha,2021-Q4,0,0,0
-Vividha,2021-Q3,0,0,0
 Vividha,2021-Q2,0,0,0
 Vividha,2021-Q1,0,0,0
 Vividha,2020-Q4,0,0,0
@@ -11967,8 +10471,6 @@ Vividha,2018-Q4,0,0,0
 Vividha,2018-Q3,0,0,0
 Vividha,2018-Q2,0,0,0
 Vividha,2018-Q1,0,0,0
-Haifeng Jin,2021-Q4,0,0,0
-Haifeng Jin,2021-Q3,0,0,0
 Haifeng Jin,2021-Q2,0,0,0
 Haifeng Jin,2021-Q1,0,0,0
 Haifeng Jin,2020-Q4,0,0,0
@@ -11983,8 +10485,6 @@ Haifeng Jin,2018-Q4,0,0,0
 Haifeng Jin,2018-Q3,0,0,0
 Haifeng Jin,2018-Q2,0,0,0
 Haifeng Jin,2018-Q1,0,0,0
-Pablo Samuel Castro,2021-Q4,0,0,0
-Pablo Samuel Castro,2021-Q3,0,0,0
 Pablo Samuel Castro,2021-Q2,0,0,0
 Pablo Samuel Castro,2021-Q1,0,0,0
 Pablo Samuel Castro,2020-Q4,0,0,0
@@ -11999,8 +10499,6 @@ Pablo Samuel Castro,2018-Q4,0,0,0
 Pablo Samuel Castro,2018-Q3,0,0,0
 Pablo Samuel Castro,2018-Q2,0,0,0
 Pablo Samuel Castro,2018-Q1,0,0,0
-Hannes Achleitner,2021-Q4,0,0,0
-Hannes Achleitner,2021-Q3,0,0,0
 Hannes Achleitner,2021-Q2,0,0,0
 Hannes Achleitner,2021-Q1,0,0,0
 Hannes Achleitner,2020-Q4,0,0,0
@@ -12015,8 +10513,6 @@ Hannes Achleitner,2018-Q4,0,0,0
 Hannes Achleitner,2018-Q3,0,0,0
 Hannes Achleitner,2018-Q2,0,0,0
 Hannes Achleitner,2018-Q1,0,0,0
-Jonah Kohn,2021-Q4,0,0,0
-Jonah Kohn,2021-Q3,0,0,0
 Jonah Kohn,2021-Q2,0,0,0
 Jonah Kohn,2021-Q1,0,0,0
 Jonah Kohn,2020-Q4,0,0,0
@@ -12031,8 +10527,6 @@ Jonah Kohn,2018-Q4,0,0,0
 Jonah Kohn,2018-Q3,0,0,0
 Jonah Kohn,2018-Q2,0,0,0
 Jonah Kohn,2018-Q1,0,0,0
-abhichou4,2021-Q4,0,0,0
-abhichou4,2021-Q3,0,0,0
 abhichou4,2021-Q2,0,0,0
 abhichou4,2021-Q1,0,0,0
 abhichou4,2020-Q4,0,0,0
@@ -12047,8 +10541,6 @@ abhichou4,2018-Q4,0,0,0
 abhichou4,2018-Q3,0,0,0
 abhichou4,2018-Q2,0,0,0
 abhichou4,2018-Q1,0,0,0
-Sayed Hadi Hashemi,2021-Q4,0,0,0
-Sayed Hadi Hashemi,2021-Q3,0,0,0
 Sayed Hadi Hashemi,2021-Q2,0,0,0
 Sayed Hadi Hashemi,2021-Q1,0,0,0
 Sayed Hadi Hashemi,2020-Q4,0,0,0
@@ -12063,8 +10555,6 @@ Sayed Hadi Hashemi,2018-Q4,0,0,0
 Sayed Hadi Hashemi,2018-Q3,0,0,0
 Sayed Hadi Hashemi,2018-Q2,0,0,0
 Sayed Hadi Hashemi,2018-Q1,6,115,2
-Ty Mick,2021-Q4,0,0,0
-Ty Mick,2021-Q3,0,0,0
 Ty Mick,2021-Q2,0,0,0
 Ty Mick,2021-Q1,0,0,0
 Ty Mick,2020-Q4,0,0,0
@@ -12079,8 +10569,6 @@ Ty Mick,2018-Q4,0,0,0
 Ty Mick,2018-Q3,0,0,0
 Ty Mick,2018-Q2,0,0,0
 Ty Mick,2018-Q1,0,0,0
-Fausto Morales,2021-Q4,0,0,0
-Fausto Morales,2021-Q3,0,0,0
 Fausto Morales,2021-Q2,0,0,0
 Fausto Morales,2021-Q1,0,0,0
 Fausto Morales,2020-Q4,0,0,0
@@ -12095,8 +10583,6 @@ Fausto Morales,2018-Q4,0,0,0
 Fausto Morales,2018-Q3,0,0,0
 Fausto Morales,2018-Q2,0,0,0
 Fausto Morales,2018-Q1,0,0,0
-redwrasse,2021-Q4,0,0,0
-redwrasse,2021-Q3,0,0,0
 redwrasse,2021-Q2,0,0,0
 redwrasse,2021-Q1,0,0,0
 redwrasse,2020-Q4,0,0,0
@@ -12111,8 +10597,6 @@ redwrasse,2018-Q4,0,0,0
 redwrasse,2018-Q3,0,0,0
 redwrasse,2018-Q2,0,0,0
 redwrasse,2018-Q1,0,0,0
-R. Alex hofer,2021-Q4,0,0,0
-R. Alex hofer,2021-Q3,0,0,0
 R. Alex hofer,2021-Q2,0,0,0
 R. Alex hofer,2021-Q1,0,0,0
 R. Alex hofer,2020-Q4,0,0,0
@@ -12127,8 +10611,6 @@ R. Alex hofer,2018-Q4,0,0,0
 R. Alex hofer,2018-Q3,0,0,0
 R. Alex hofer,2018-Q2,0,0,0
 R. Alex hofer,2018-Q1,0,0,0
-Koki Ibukuro,2021-Q4,0,0,0
-Koki Ibukuro,2021-Q3,0,0,0
 Koki Ibukuro,2021-Q2,0,0,0
 Koki Ibukuro,2021-Q1,0,0,0
 Koki Ibukuro,2020-Q4,0,0,0
@@ -12143,8 +10625,6 @@ Koki Ibukuro,2018-Q4,0,0,0
 Koki Ibukuro,2018-Q3,0,0,0
 Koki Ibukuro,2018-Q2,0,0,0
 Koki Ibukuro,2018-Q1,0,0,0
-Jakob Buchgraber,2021-Q4,0,0,0
-Jakob Buchgraber,2021-Q3,0,0,0
 Jakob Buchgraber,2021-Q2,0,0,0
 Jakob Buchgraber,2021-Q1,0,0,0
 Jakob Buchgraber,2020-Q4,0,0,0
@@ -12159,8 +10639,6 @@ Jakob Buchgraber,2018-Q4,0,0,0
 Jakob Buchgraber,2018-Q3,0,0,0
 Jakob Buchgraber,2018-Q2,0,0,0
 Jakob Buchgraber,2018-Q1,0,0,0
-Benjamin Peterson,2021-Q4,0,0,0
-Benjamin Peterson,2021-Q3,0,0,0
 Benjamin Peterson,2021-Q2,0,0,0
 Benjamin Peterson,2021-Q1,0,0,0
 Benjamin Peterson,2020-Q4,0,0,0
@@ -12175,8 +10653,6 @@ Benjamin Peterson,2018-Q4,0,0,0
 Benjamin Peterson,2018-Q3,0,0,0
 Benjamin Peterson,2018-Q2,0,0,0
 Benjamin Peterson,2018-Q1,0,0,0
-902449@58880@bigcat_chen@ASIC,2021-Q4,0,0,0
-902449@58880@bigcat_chen@ASIC,2021-Q3,0,0,0
 902449@58880@bigcat_chen@ASIC,2021-Q2,0,0,0
 902449@58880@bigcat_chen@ASIC,2021-Q1,0,0,0
 902449@58880@bigcat_chen@ASIC,2020-Q4,0,0,0
@@ -12191,8 +10667,6 @@ Benjamin Peterson,2018-Q1,0,0,0
 902449@58880@bigcat_chen@ASIC,2018-Q3,0,0,0
 902449@58880@bigcat_chen@ASIC,2018-Q2,0,0,0
 902449@58880@bigcat_chen@ASIC,2018-Q1,0,0,0
-bubblebooy,2021-Q4,0,0,0
-bubblebooy,2021-Q3,0,0,0
 bubblebooy,2021-Q2,0,0,0
 bubblebooy,2021-Q1,0,0,0
 bubblebooy,2020-Q4,0,0,0
@@ -12207,8 +10681,6 @@ bubblebooy,2018-Q4,0,0,0
 bubblebooy,2018-Q3,0,0,0
 bubblebooy,2018-Q2,0,0,0
 bubblebooy,2018-Q1,0,0,0
-Prasad Nikam,2021-Q4,0,0,0
-Prasad Nikam,2021-Q3,0,0,0
 Prasad Nikam,2021-Q2,0,0,0
 Prasad Nikam,2021-Q1,0,0,0
 Prasad Nikam,2020-Q4,0,0,0
@@ -12223,8 +10695,6 @@ Prasad Nikam,2018-Q4,0,0,0
 Prasad Nikam,2018-Q3,0,0,0
 Prasad Nikam,2018-Q2,0,0,0
 Prasad Nikam,2018-Q1,0,0,0
-Marcel Hlopko,2021-Q4,0,0,0
-Marcel Hlopko,2021-Q3,0,0,0
 Marcel Hlopko,2021-Q2,0,0,0
 Marcel Hlopko,2021-Q1,0,0,0
 Marcel Hlopko,2020-Q4,0,0,0
@@ -12239,8 +10709,6 @@ Marcel Hlopko,2018-Q4,0,0,0
 Marcel Hlopko,2018-Q3,0,0,0
 Marcel Hlopko,2018-Q2,0,0,0
 Marcel Hlopko,2018-Q1,0,0,0
-CuiYifeng,2021-Q4,0,0,0
-CuiYifeng,2021-Q3,0,0,0
 CuiYifeng,2021-Q2,0,0,0
 CuiYifeng,2021-Q1,0,0,0
 CuiYifeng,2020-Q4,0,0,0
@@ -12255,8 +10723,6 @@ CuiYifeng,2018-Q4,0,0,0
 CuiYifeng,2018-Q3,0,0,0
 CuiYifeng,2018-Q2,0,0,0
 CuiYifeng,2018-Q1,0,0,0
-tenglu,2021-Q4,0,0,0
-tenglu,2021-Q3,0,0,0
 tenglu,2021-Q2,0,0,0
 tenglu,2021-Q1,0,0,0
 tenglu,2020-Q4,0,0,0
@@ -12271,8 +10737,6 @@ tenglu,2018-Q4,0,0,0
 tenglu,2018-Q3,0,0,0
 tenglu,2018-Q2,0,0,0
 tenglu,2018-Q1,0,0,0
-Zachary Deane-Mayer,2021-Q4,0,0,0
-Zachary Deane-Mayer,2021-Q3,0,0,0
 Zachary Deane-Mayer,2021-Q2,0,0,0
 Zachary Deane-Mayer,2021-Q1,0,0,0
 Zachary Deane-Mayer,2020-Q4,0,0,0
@@ -12287,8 +10751,6 @@ Zachary Deane-Mayer,2018-Q4,0,0,0
 Zachary Deane-Mayer,2018-Q3,0,0,0
 Zachary Deane-Mayer,2018-Q2,0,0,0
 Zachary Deane-Mayer,2018-Q1,0,0,0
-Tare Gaskin,2021-Q4,0,0,0
-Tare Gaskin,2021-Q3,0,0,0
 Tare Gaskin,2021-Q2,0,0,0
 Tare Gaskin,2021-Q1,0,0,0
 Tare Gaskin,2020-Q4,0,0,0
@@ -12303,8 +10765,6 @@ Tare Gaskin,2018-Q4,0,0,0
 Tare Gaskin,2018-Q3,0,0,0
 Tare Gaskin,2018-Q2,0,0,0
 Tare Gaskin,2018-Q1,0,0,0
-Toby Boyd,2021-Q4,0,0,0
-Toby Boyd,2021-Q3,0,0,0
 Toby Boyd,2021-Q2,0,0,0
 Toby Boyd,2021-Q1,0,0,0
 Toby Boyd,2020-Q4,0,0,0
@@ -12319,8 +10779,6 @@ Toby Boyd,2018-Q4,10,137,165
 Toby Boyd,2018-Q3,10,367,393
 Toby Boyd,2018-Q2,0,0,0
 Toby Boyd,2018-Q1,0,0,0
-Aart Bik,2021-Q4,0,0,0
-Aart Bik,2021-Q3,0,0,0
 Aart Bik,2021-Q2,0,0,0
 Aart Bik,2021-Q1,0,0,0
 Aart Bik,2020-Q4,0,0,0
@@ -12335,8 +10793,6 @@ Aart Bik,2018-Q4,0,0,0
 Aart Bik,2018-Q3,0,0,0
 Aart Bik,2018-Q2,0,0,0
 Aart Bik,2018-Q1,0,0,0
-rahul-kamat,2021-Q4,0,0,0
-rahul-kamat,2021-Q3,0,0,0
 rahul-kamat,2021-Q2,0,0,0
 rahul-kamat,2021-Q1,0,0,0
 rahul-kamat,2020-Q4,0,0,0
@@ -12351,8 +10807,6 @@ rahul-kamat,2018-Q4,0,0,0
 rahul-kamat,2018-Q3,0,0,0
 rahul-kamat,2018-Q2,0,0,0
 rahul-kamat,2018-Q1,0,0,0
-bzhaoopenstack,2021-Q4,0,0,0
-bzhaoopenstack,2021-Q3,0,0,0
 bzhaoopenstack,2021-Q2,0,0,0
 bzhaoopenstack,2021-Q1,0,0,0
 bzhaoopenstack,2020-Q4,0,0,0
@@ -12367,8 +10821,6 @@ bzhaoopenstack,2018-Q4,0,0,0
 bzhaoopenstack,2018-Q3,0,0,0
 bzhaoopenstack,2018-Q2,0,0,0
 bzhaoopenstack,2018-Q1,0,0,0
-Martin Wicke,2021-Q4,0,0,0
-Martin Wicke,2021-Q3,0,0,0
 Martin Wicke,2021-Q2,0,0,0
 Martin Wicke,2021-Q1,0,0,0
 Martin Wicke,2020-Q4,0,0,0
@@ -12383,8 +10835,6 @@ Martin Wicke,2018-Q4,104,1238,1042
 Martin Wicke,2018-Q3,7,29,13
 Martin Wicke,2018-Q2,15,108,29
 Martin Wicke,2018-Q1,471,2714,4161
-ZhuBaohe,2021-Q4,0,0,0
-ZhuBaohe,2021-Q3,0,0,0
 ZhuBaohe,2021-Q2,0,0,0
 ZhuBaohe,2021-Q1,0,0,0
 ZhuBaohe,2020-Q4,0,0,0
@@ -12399,8 +10849,6 @@ ZhuBaohe,2018-Q4,0,0,0
 ZhuBaohe,2018-Q3,0,0,0
 ZhuBaohe,2018-Q2,0,0,0
 ZhuBaohe,2018-Q1,0,0,0
-Gaurav Singh,2021-Q4,0,0,0
-Gaurav Singh,2021-Q3,0,0,0
 Gaurav Singh,2021-Q2,0,0,0
 Gaurav Singh,2021-Q1,0,0,0
 Gaurav Singh,2020-Q4,0,0,0
@@ -12415,8 +10863,6 @@ Gaurav Singh,2018-Q4,0,0,0
 Gaurav Singh,2018-Q3,0,0,0
 Gaurav Singh,2018-Q2,0,0,0
 Gaurav Singh,2018-Q1,0,0,0
-Vladimir Menshakov,2021-Q4,0,0,0
-Vladimir Menshakov,2021-Q3,0,0,0
 Vladimir Menshakov,2021-Q2,0,0,0
 Vladimir Menshakov,2021-Q1,0,0,0
 Vladimir Menshakov,2020-Q4,0,0,0
@@ -12431,8 +10877,6 @@ Vladimir Menshakov,2018-Q4,0,0,0
 Vladimir Menshakov,2018-Q3,0,0,0
 Vladimir Menshakov,2018-Q2,0,0,0
 Vladimir Menshakov,2018-Q1,0,0,0
-aaa.jq,2021-Q4,0,0,0
-aaa.jq,2021-Q3,0,0,0
 aaa.jq,2021-Q2,0,0,0
 aaa.jq,2021-Q1,0,0,0
 aaa.jq,2020-Q4,0,0,0
@@ -12447,8 +10891,6 @@ aaa.jq,2018-Q4,0,0,0
 aaa.jq,2018-Q3,0,0,0
 aaa.jq,2018-Q2,0,0,0
 aaa.jq,2018-Q1,0,0,0
-Vishal Subbiah,2021-Q4,0,0,0
-Vishal Subbiah,2021-Q3,0,0,0
 Vishal Subbiah,2021-Q2,0,0,0
 Vishal Subbiah,2021-Q1,0,0,0
 Vishal Subbiah,2020-Q4,0,0,0
@@ -12463,8 +10905,6 @@ Vishal Subbiah,2018-Q4,0,0,0
 Vishal Subbiah,2018-Q3,0,0,0
 Vishal Subbiah,2018-Q2,0,0,0
 Vishal Subbiah,2018-Q1,0,0,0
-MichelBr,2021-Q4,0,0,0
-MichelBr,2021-Q3,0,0,0
 MichelBr,2021-Q2,0,0,0
 MichelBr,2021-Q1,0,0,0
 MichelBr,2020-Q4,0,0,0
@@ -12479,8 +10919,6 @@ MichelBr,2018-Q4,0,0,0
 MichelBr,2018-Q3,0,0,0
 MichelBr,2018-Q2,0,0,0
 MichelBr,2018-Q1,0,0,0
-ANSHUMAN TRIPATHY,2021-Q4,0,0,0
-ANSHUMAN TRIPATHY,2021-Q3,0,0,0
 ANSHUMAN TRIPATHY,2021-Q2,0,0,0
 ANSHUMAN TRIPATHY,2021-Q1,0,0,0
 ANSHUMAN TRIPATHY,2020-Q4,0,0,0
@@ -12495,8 +10933,6 @@ ANSHUMAN TRIPATHY,2018-Q4,0,0,0
 ANSHUMAN TRIPATHY,2018-Q3,0,0,0
 ANSHUMAN TRIPATHY,2018-Q2,0,0,0
 ANSHUMAN TRIPATHY,2018-Q1,0,0,0
-Harirai,2021-Q4,0,0,0
-Harirai,2021-Q3,0,0,0
 Harirai,2021-Q2,0,0,0
 Harirai,2021-Q1,0,0,0
 Harirai,2020-Q4,0,0,0
@@ -12511,8 +10947,6 @@ Harirai,2018-Q4,0,0,0
 Harirai,2018-Q3,0,0,0
 Harirai,2018-Q2,0,0,0
 Harirai,2018-Q1,0,0,0
-qhduan,2021-Q4,0,0,0
-qhduan,2021-Q3,0,0,0
 qhduan,2021-Q2,0,0,0
 qhduan,2021-Q1,0,0,0
 qhduan,2020-Q4,0,0,0
@@ -12527,8 +10961,6 @@ qhduan,2018-Q4,0,0,0
 qhduan,2018-Q3,0,0,0
 qhduan,2018-Q2,0,0,0
 qhduan,2018-Q1,0,0,0
-Torsten Rudolf,2021-Q4,0,0,0
-Torsten Rudolf,2021-Q3,0,0,0
 Torsten Rudolf,2021-Q2,0,0,0
 Torsten Rudolf,2021-Q1,0,0,0
 Torsten Rudolf,2020-Q4,0,0,0
@@ -12543,8 +10975,6 @@ Torsten Rudolf,2018-Q4,0,0,0
 Torsten Rudolf,2018-Q3,0,0,0
 Torsten Rudolf,2018-Q2,0,0,0
 Torsten Rudolf,2018-Q1,0,0,0
-XingyuLong,2021-Q4,0,0,0
-XingyuLong,2021-Q3,0,0,0
 XingyuLong,2021-Q2,0,0,0
 XingyuLong,2021-Q1,0,0,0
 XingyuLong,2020-Q4,0,0,0
@@ -12559,8 +10989,6 @@ XingyuLong,2018-Q4,0,0,0
 XingyuLong,2018-Q3,0,0,0
 XingyuLong,2018-Q2,0,0,0
 XingyuLong,2018-Q1,0,0,0
-Rishit Dagli,2021-Q4,0,0,0
-Rishit Dagli,2021-Q3,0,0,0
 Rishit Dagli,2021-Q2,0,0,0
 Rishit Dagli,2021-Q1,0,0,0
 Rishit Dagli,2020-Q4,0,0,0
@@ -12575,8 +11003,6 @@ Rishit Dagli,2018-Q4,0,0,0
 Rishit Dagli,2018-Q3,0,0,0
 Rishit Dagli,2018-Q2,0,0,0
 Rishit Dagli,2018-Q1,0,0,0
-Davide Libenzi,2021-Q4,0,0,0
-Davide Libenzi,2021-Q3,0,0,0
 Davide Libenzi,2021-Q2,0,0,0
 Davide Libenzi,2021-Q1,0,0,0
 Davide Libenzi,2020-Q4,0,0,0
@@ -12591,8 +11017,6 @@ Davide Libenzi,2018-Q4,16,161,23
 Davide Libenzi,2018-Q3,0,0,0
 Davide Libenzi,2018-Q2,0,0,0
 Davide Libenzi,2018-Q1,0,0,0
-Gauri1 Deshpande,2021-Q4,0,0,0
-Gauri1 Deshpande,2021-Q3,0,0,0
 Gauri1 Deshpande,2021-Q2,0,0,0
 Gauri1 Deshpande,2021-Q1,0,0,0
 Gauri1 Deshpande,2020-Q4,0,0,0
@@ -12607,8 +11031,6 @@ Gauri1 Deshpande,2018-Q4,0,0,0
 Gauri1 Deshpande,2018-Q3,0,0,0
 Gauri1 Deshpande,2018-Q2,0,0,0
 Gauri1 Deshpande,2018-Q1,0,0,0
-settle,2021-Q4,0,0,0
-settle,2021-Q3,0,0,0
 settle,2021-Q2,0,0,0
 settle,2021-Q1,0,0,0
 settle,2020-Q4,0,0,0
@@ -12623,8 +11045,6 @@ settle,2018-Q4,0,0,0
 settle,2018-Q3,0,0,0
 settle,2018-Q2,0,0,0
 settle,2018-Q1,0,0,0
-Chris Gorgolewski,2021-Q4,0,0,0
-Chris Gorgolewski,2021-Q3,0,0,0
 Chris Gorgolewski,2021-Q2,0,0,0
 Chris Gorgolewski,2021-Q1,0,0,0
 Chris Gorgolewski,2020-Q4,0,0,0
@@ -12639,8 +11059,6 @@ Chris Gorgolewski,2018-Q4,0,0,0
 Chris Gorgolewski,2018-Q3,0,0,0
 Chris Gorgolewski,2018-Q2,0,0,0
 Chris Gorgolewski,2018-Q1,0,0,0
-Ashwin Murthy,2021-Q4,0,0,0
-Ashwin Murthy,2021-Q3,0,0,0
 Ashwin Murthy,2021-Q2,0,0,0
 Ashwin Murthy,2021-Q1,0,0,0
 Ashwin Murthy,2020-Q4,0,0,0
@@ -12655,8 +11073,6 @@ Ashwin Murthy,2018-Q4,0,0,0
 Ashwin Murthy,2018-Q3,0,0,0
 Ashwin Murthy,2018-Q2,0,0,0
 Ashwin Murthy,2018-Q1,0,0,0
-Jack Hessel,2021-Q4,0,0,0
-Jack Hessel,2021-Q3,0,0,0
 Jack Hessel,2021-Q2,0,0,0
 Jack Hessel,2021-Q1,0,0,0
 Jack Hessel,2020-Q4,0,0,0
@@ -12671,8 +11087,6 @@ Jack Hessel,2018-Q4,0,0,0
 Jack Hessel,2018-Q3,0,0,0
 Jack Hessel,2018-Q2,0,0,0
 Jack Hessel,2018-Q1,0,0,0
-Tony,2021-Q4,0,0,0
-Tony,2021-Q3,0,0,0
 Tony,2021-Q2,0,0,0
 Tony,2021-Q1,0,0,0
 Tony,2020-Q4,0,0,0
@@ -12687,8 +11101,6 @@ Tony,2018-Q4,0,0,0
 Tony,2018-Q3,0,0,0
 Tony,2018-Q2,0,0,0
 Tony,2018-Q1,0,0,0
-Giorgio Arena,2021-Q4,0,0,0
-Giorgio Arena,2021-Q3,0,0,0
 Giorgio Arena,2021-Q2,0,0,0
 Giorgio Arena,2021-Q1,0,0,0
 Giorgio Arena,2020-Q4,0,0,0
@@ -12703,8 +11115,6 @@ Giorgio Arena,2018-Q4,0,0,0
 Giorgio Arena,2018-Q3,0,0,0
 Giorgio Arena,2018-Q2,0,0,0
 Giorgio Arena,2018-Q1,0,0,0
-Srihari Humbarwadi,2021-Q4,0,0,0
-Srihari Humbarwadi,2021-Q3,0,0,0
 Srihari Humbarwadi,2021-Q2,0,0,0
 Srihari Humbarwadi,2021-Q1,0,0,0
 Srihari Humbarwadi,2020-Q4,0,0,0
@@ -12719,8 +11129,6 @@ Srihari Humbarwadi,2018-Q4,0,0,0
 Srihari Humbarwadi,2018-Q3,0,0,0
 Srihari Humbarwadi,2018-Q2,0,0,0
 Srihari Humbarwadi,2018-Q1,0,0,0
-hedgehog91,2021-Q4,0,0,0
-hedgehog91,2021-Q3,0,0,0
 hedgehog91,2021-Q2,0,0,0
 hedgehog91,2021-Q1,0,0,0
 hedgehog91,2020-Q4,0,0,0
@@ -12735,8 +11143,6 @@ hedgehog91,2018-Q4,0,0,0
 hedgehog91,2018-Q3,0,0,0
 hedgehog91,2018-Q2,0,0,0
 hedgehog91,2018-Q1,0,0,0
-Phil Pearl,2021-Q4,0,0,0
-Phil Pearl,2021-Q3,0,0,0
 Phil Pearl,2021-Q2,0,0,0
 Phil Pearl,2021-Q1,0,0,0
 Phil Pearl,2020-Q4,0,0,0
@@ -12751,8 +11157,6 @@ Phil Pearl,2018-Q4,0,0,0
 Phil Pearl,2018-Q3,0,0,0
 Phil Pearl,2018-Q2,0,0,0
 Phil Pearl,2018-Q1,0,0,0
-Lluis-Miquel Munguia,2021-Q4,0,0,0
-Lluis-Miquel Munguia,2021-Q3,0,0,0
 Lluis-Miquel Munguia,2021-Q2,0,0,0
 Lluis-Miquel Munguia,2021-Q1,0,0,0
 Lluis-Miquel Munguia,2020-Q4,0,0,0
@@ -12767,8 +11171,6 @@ Lluis-Miquel Munguia,2018-Q4,0,0,0
 Lluis-Miquel Munguia,2018-Q3,0,0,0
 Lluis-Miquel Munguia,2018-Q2,0,0,0
 Lluis-Miquel Munguia,2018-Q1,0,0,0
-Nupur Garg,2021-Q4,0,0,0
-Nupur Garg,2021-Q3,0,0,0
 Nupur Garg,2021-Q2,0,0,0
 Nupur Garg,2021-Q1,0,0,0
 Nupur Garg,2020-Q4,0,0,0
@@ -12783,8 +11185,6 @@ Nupur Garg,2018-Q4,72,1042,599
 Nupur Garg,2018-Q3,149,3278,910
 Nupur Garg,2018-Q2,120,3715,2840
 Nupur Garg,2018-Q1,116,3679,1270
-chuanqiw,2021-Q4,0,0,0
-chuanqiw,2021-Q3,0,0,0
 chuanqiw,2021-Q2,0,0,0
 chuanqiw,2021-Q1,0,0,0
 chuanqiw,2020-Q4,0,0,0
@@ -12799,8 +11199,6 @@ chuanqiw,2018-Q4,0,0,0
 chuanqiw,2018-Q3,0,0,0
 chuanqiw,2018-Q2,0,0,0
 chuanqiw,2018-Q1,0,0,0
-Tamara Norman,2021-Q4,0,0,0
-Tamara Norman,2021-Q3,0,0,0
 Tamara Norman,2021-Q2,0,0,0
 Tamara Norman,2021-Q1,0,0,0
 Tamara Norman,2020-Q4,0,0,0
@@ -12815,8 +11213,6 @@ Tamara Norman,2018-Q4,94,2114,965
 Tamara Norman,2018-Q3,0,0,0
 Tamara Norman,2018-Q2,0,0,0
 Tamara Norman,2018-Q1,0,0,0
-Samuel Holt,2021-Q4,0,0,0
-Samuel Holt,2021-Q3,0,0,0
 Samuel Holt,2021-Q2,0,0,0
 Samuel Holt,2021-Q1,0,0,0
 Samuel Holt,2020-Q4,0,0,0
@@ -12831,8 +11227,6 @@ Samuel Holt,2018-Q4,0,0,0
 Samuel Holt,2018-Q3,0,0,0
 Samuel Holt,2018-Q2,0,0,0
 Samuel Holt,2018-Q1,0,0,0
-Devi Sandeep Endluri,2021-Q4,0,0,0
-Devi Sandeep Endluri,2021-Q3,0,0,0
 Devi Sandeep Endluri,2021-Q2,0,0,0
 Devi Sandeep Endluri,2021-Q1,0,0,0
 Devi Sandeep Endluri,2020-Q4,0,0,0
@@ -12847,8 +11241,6 @@ Devi Sandeep Endluri,2018-Q4,0,0,0
 Devi Sandeep Endluri,2018-Q3,0,0,0
 Devi Sandeep Endluri,2018-Q2,0,0,0
 Devi Sandeep Endluri,2018-Q1,0,0,0
-peng,2021-Q4,0,0,0
-peng,2021-Q3,0,0,0
 peng,2021-Q2,0,0,0
 peng,2021-Q1,0,0,0
 peng,2020-Q4,0,0,0
@@ -12863,8 +11255,6 @@ peng,2018-Q4,0,0,0
 peng,2018-Q3,0,0,0
 peng,2018-Q2,0,0,0
 peng,2018-Q1,0,0,0
-jonah-kohn,2021-Q4,0,0,0
-jonah-kohn,2021-Q3,0,0,0
 jonah-kohn,2021-Q2,0,0,0
 jonah-kohn,2021-Q1,0,0,0
 jonah-kohn,2020-Q4,0,0,0
@@ -12879,8 +11269,6 @@ jonah-kohn,2018-Q4,0,0,0
 jonah-kohn,2018-Q3,0,0,0
 jonah-kohn,2018-Q2,0,0,0
 jonah-kohn,2018-Q1,0,0,0
-Thomas Raoux,2021-Q4,0,0,0
-Thomas Raoux,2021-Q3,0,0,0
 Thomas Raoux,2021-Q2,0,0,0
 Thomas Raoux,2021-Q1,0,0,0
 Thomas Raoux,2020-Q4,0,0,0
@@ -12895,8 +11283,6 @@ Thomas Raoux,2018-Q4,0,0,0
 Thomas Raoux,2018-Q3,0,0,0
 Thomas Raoux,2018-Q2,0,0,0
 Thomas Raoux,2018-Q1,0,0,0
-Sam Holt,2021-Q4,0,0,0
-Sam Holt,2021-Q3,0,0,0
 Sam Holt,2021-Q2,0,0,0
 Sam Holt,2021-Q1,0,0,0
 Sam Holt,2020-Q4,0,0,0
@@ -12911,8 +11297,6 @@ Sam Holt,2018-Q4,0,0,0
 Sam Holt,2018-Q3,0,0,0
 Sam Holt,2018-Q2,0,0,0
 Sam Holt,2018-Q1,0,0,0
-Lukasz Kaiser,2021-Q4,0,0,0
-Lukasz Kaiser,2021-Q3,0,0,0
 Lukasz Kaiser,2021-Q2,0,0,0
 Lukasz Kaiser,2021-Q1,0,0,0
 Lukasz Kaiser,2020-Q4,0,0,0
@@ -12927,8 +11311,6 @@ Lukasz Kaiser,2018-Q4,1,4,2
 Lukasz Kaiser,2018-Q3,0,0,0
 Lukasz Kaiser,2018-Q2,5,188,206
 Lukasz Kaiser,2018-Q1,2,11,138
-Agoniii,2021-Q4,0,0,0
-Agoniii,2021-Q3,0,0,0
 Agoniii,2021-Q2,0,0,0
 Agoniii,2021-Q1,0,0,0
 Agoniii,2020-Q4,0,0,0
@@ -12943,8 +11325,6 @@ Agoniii,2018-Q4,0,0,0
 Agoniii,2018-Q3,0,0,0
 Agoniii,2018-Q2,0,0,0
 Agoniii,2018-Q1,0,0,0
-Nishidha Panpaliya,2021-Q4,0,0,0
-Nishidha Panpaliya,2021-Q3,0,0,0
 Nishidha Panpaliya,2021-Q2,0,0,0
 Nishidha Panpaliya,2021-Q1,0,0,0
 Nishidha Panpaliya,2020-Q4,0,0,0
@@ -12959,8 +11339,6 @@ Nishidha Panpaliya,2018-Q4,0,0,0
 Nishidha Panpaliya,2018-Q3,1,12,12
 Nishidha Panpaliya,2018-Q2,1,8,0
 Nishidha Panpaliya,2018-Q1,0,0,0
-Lutz Roeder,2021-Q4,0,0,0
-Lutz Roeder,2021-Q3,0,0,0
 Lutz Roeder,2021-Q2,0,0,0
 Lutz Roeder,2021-Q1,0,0,0
 Lutz Roeder,2020-Q4,0,0,0
@@ -12975,8 +11353,6 @@ Lutz Roeder,2018-Q4,0,0,0
 Lutz Roeder,2018-Q3,0,0,0
 Lutz Roeder,2018-Q2,0,0,0
 Lutz Roeder,2018-Q1,0,0,0
-Meteorix,2021-Q4,0,0,0
-Meteorix,2021-Q3,0,0,0
 Meteorix,2021-Q2,0,0,0
 Meteorix,2021-Q1,0,0,0
 Meteorix,2020-Q4,0,0,0
@@ -12991,8 +11367,6 @@ Meteorix,2018-Q4,0,0,0
 Meteorix,2018-Q3,0,0,0
 Meteorix,2018-Q2,0,0,0
 Meteorix,2018-Q1,0,0,0
-Chen Lei,2021-Q4,0,0,0
-Chen Lei,2021-Q3,0,0,0
 Chen Lei,2021-Q2,0,0,0
 Chen Lei,2021-Q1,0,0,0
 Chen Lei,2020-Q4,0,0,0
@@ -13007,8 +11381,6 @@ Chen Lei,2018-Q4,0,0,0
 Chen Lei,2018-Q3,0,0,0
 Chen Lei,2018-Q2,0,0,0
 Chen Lei,2018-Q1,0,0,0
-Amedeo Cavallo,2021-Q4,0,0,0
-Amedeo Cavallo,2021-Q3,0,0,0
 Amedeo Cavallo,2021-Q2,0,0,0
 Amedeo Cavallo,2021-Q1,0,0,0
 Amedeo Cavallo,2020-Q4,0,0,0
@@ -13023,8 +11395,6 @@ Amedeo Cavallo,2018-Q4,0,0,0
 Amedeo Cavallo,2018-Q3,0,0,0
 Amedeo Cavallo,2018-Q2,0,0,0
 Amedeo Cavallo,2018-Q1,0,0,0
-Gaurav Menghani,2021-Q4,0,0,0
-Gaurav Menghani,2021-Q3,0,0,0
 Gaurav Menghani,2021-Q2,0,0,0
 Gaurav Menghani,2021-Q1,0,0,0
 Gaurav Menghani,2020-Q4,0,0,0
@@ -13039,8 +11409,6 @@ Gaurav Menghani,2018-Q4,0,0,0
 Gaurav Menghani,2018-Q3,0,0,0
 Gaurav Menghani,2018-Q2,0,0,0
 Gaurav Menghani,2018-Q1,0,0,0
-stjohnso98,2021-Q4,0,0,0
-stjohnso98,2021-Q3,0,0,0
 stjohnso98,2021-Q2,0,0,0
 stjohnso98,2021-Q1,0,0,0
 stjohnso98,2020-Q4,0,0,0
@@ -13055,8 +11423,6 @@ stjohnso98,2018-Q4,0,0,0
 stjohnso98,2018-Q3,0,0,0
 stjohnso98,2018-Q2,0,0,0
 stjohnso98,2018-Q1,0,0,0
-Anthony Scherba,2021-Q4,0,0,0
-Anthony Scherba,2021-Q3,0,0,0
 Anthony Scherba,2021-Q2,0,0,0
 Anthony Scherba,2021-Q1,0,0,0
 Anthony Scherba,2020-Q4,0,0,0
@@ -13071,8 +11437,6 @@ Anthony Scherba,2018-Q4,0,0,0
 Anthony Scherba,2018-Q3,0,0,0
 Anthony Scherba,2018-Q2,0,0,0
 Anthony Scherba,2018-Q1,0,0,0
-Yifei Feng,2021-Q4,0,0,0
-Yifei Feng,2021-Q3,0,0,0
 Yifei Feng,2021-Q2,0,0,0
 Yifei Feng,2021-Q1,0,0,0
 Yifei Feng,2020-Q4,0,0,0
@@ -13087,8 +11451,6 @@ Yifei Feng,2018-Q4,68,989,670
 Yifei Feng,2018-Q3,322,14138,2767
 Yifei Feng,2018-Q2,644,8945,2628
 Yifei Feng,2018-Q1,433,14228,7492
-Chris Knorowski,2021-Q4,0,0,0
-Chris Knorowski,2021-Q3,0,0,0
 Chris Knorowski,2021-Q2,0,0,0
 Chris Knorowski,2021-Q1,0,0,0
 Chris Knorowski,2020-Q4,0,0,0
@@ -13103,8 +11465,6 @@ Chris Knorowski,2018-Q4,0,0,0
 Chris Knorowski,2018-Q3,0,0,0
 Chris Knorowski,2018-Q2,0,0,0
 Chris Knorowski,2018-Q1,0,0,0
-Joshua Chia,2021-Q4,0,0,0
-Joshua Chia,2021-Q3,0,0,0
 Joshua Chia,2021-Q2,0,0,0
 Joshua Chia,2021-Q1,0,0,0
 Joshua Chia,2020-Q4,0,0,0
@@ -13119,8 +11479,6 @@ Joshua Chia,2018-Q4,0,0,0
 Joshua Chia,2018-Q3,0,0,0
 Joshua Chia,2018-Q2,0,0,0
 Joshua Chia,2018-Q1,0,0,0
-Christian Clauss,2021-Q4,0,0,0
-Christian Clauss,2021-Q3,0,0,0
 Christian Clauss,2021-Q2,0,0,0
 Christian Clauss,2021-Q1,0,0,0
 Christian Clauss,2020-Q4,0,0,0
@@ -13135,8 +11493,6 @@ Christian Clauss,2018-Q4,0,0,0
 Christian Clauss,2018-Q3,0,0,0
 Christian Clauss,2018-Q2,0,0,0
 Christian Clauss,2018-Q1,0,0,0
-Sean Settle,2021-Q4,0,0,0
-Sean Settle,2021-Q3,0,0,0
 Sean Settle,2021-Q2,0,0,0
 Sean Settle,2021-Q1,0,0,0
 Sean Settle,2020-Q4,0,0,0
@@ -13151,8 +11507,6 @@ Sean Settle,2018-Q4,0,0,0
 Sean Settle,2018-Q3,0,0,0
 Sean Settle,2018-Q2,0,0,0
 Sean Settle,2018-Q1,0,0,0
-Carlos Hernandez-Vaquero,2021-Q4,0,0,0
-Carlos Hernandez-Vaquero,2021-Q3,0,0,0
 Carlos Hernandez-Vaquero,2021-Q2,0,0,0
 Carlos Hernandez-Vaquero,2021-Q1,0,0,0
 Carlos Hernandez-Vaquero,2020-Q4,0,0,0
@@ -13167,8 +11521,6 @@ Carlos Hernandez-Vaquero,2018-Q4,0,0,0
 Carlos Hernandez-Vaquero,2018-Q3,0,0,0
 Carlos Hernandez-Vaquero,2018-Q2,0,0,0
 Carlos Hernandez-Vaquero,2018-Q1,0,0,0
-cclauss,2021-Q4,0,0,0
-cclauss,2021-Q3,0,0,0
 cclauss,2021-Q2,0,0,0
 cclauss,2021-Q1,0,0,0
 cclauss,2020-Q4,0,0,0
@@ -13183,8 +11535,6 @@ cclauss,2018-Q4,0,0,0
 cclauss,2018-Q3,1,2,2
 cclauss,2018-Q2,1,6,8
 cclauss,2018-Q1,19,29,8
-frreiss,2021-Q4,0,0,0
-frreiss,2021-Q3,0,0,0
 frreiss,2021-Q2,0,0,0
 frreiss,2021-Q1,0,0,0
 frreiss,2020-Q4,0,0,0
@@ -13199,8 +11549,6 @@ frreiss,2018-Q4,46,753,643
 frreiss,2018-Q3,2,14,0
 frreiss,2018-Q2,0,0,0
 frreiss,2018-Q1,0,0,0
-wyzhao,2021-Q4,0,0,0
-wyzhao,2021-Q3,0,0,0
 wyzhao,2021-Q2,0,0,0
 wyzhao,2021-Q1,0,0,0
 wyzhao,2020-Q4,0,0,0
@@ -13215,8 +11563,6 @@ wyzhao,2018-Q4,0,0,0
 wyzhao,2018-Q3,0,0,0
 wyzhao,2018-Q2,0,0,0
 wyzhao,2018-Q1,0,0,0
-nihui,2021-Q4,0,0,0
-nihui,2021-Q3,0,0,0
 nihui,2021-Q2,0,0,0
 nihui,2021-Q1,0,0,0
 nihui,2020-Q4,0,0,0
@@ -13231,8 +11577,6 @@ nihui,2018-Q4,0,0,0
 nihui,2018-Q3,0,0,0
 nihui,2018-Q2,0,0,0
 nihui,2018-Q1,0,0,0
-Urs Koster,2021-Q4,0,0,0
-Urs Koster,2021-Q3,0,0,0
 Urs Koster,2021-Q2,0,0,0
 Urs Koster,2021-Q1,0,0,0
 Urs Koster,2020-Q4,0,0,0
@@ -13247,8 +11591,6 @@ Urs Koster,2018-Q4,0,0,0
 Urs Koster,2018-Q3,0,0,0
 Urs Koster,2018-Q2,0,0,0
 Urs Koster,2018-Q1,0,0,0
-M\u00e5ns Nilsson,2021-Q4,0,0,0
-M\u00e5ns Nilsson,2021-Q3,0,0,0
 M\u00e5ns Nilsson,2021-Q2,0,0,0
 M\u00e5ns Nilsson,2021-Q1,0,0,0
 M\u00e5ns Nilsson,2020-Q4,0,0,0
@@ -13263,8 +11605,6 @@ M\u00e5ns Nilsson,2018-Q4,0,0,0
 M\u00e5ns Nilsson,2018-Q3,0,0,0
 M\u00e5ns Nilsson,2018-Q2,0,0,0
 M\u00e5ns Nilsson,2018-Q1,0,0,0
-Hugh Ku,2021-Q4,0,0,0
-Hugh Ku,2021-Q3,0,0,0
 Hugh Ku,2021-Q2,0,0,0
 Hugh Ku,2021-Q1,0,0,0
 Hugh Ku,2020-Q4,0,0,0
@@ -13279,8 +11619,6 @@ Hugh Ku,2018-Q4,0,0,0
 Hugh Ku,2018-Q3,0,0,0
 Hugh Ku,2018-Q2,0,0,0
 Hugh Ku,2018-Q1,0,0,0
-Alexander Gorban,2021-Q4,0,0,0
-Alexander Gorban,2021-Q3,0,0,0
 Alexander Gorban,2021-Q2,0,0,0
 Alexander Gorban,2021-Q1,0,0,0
 Alexander Gorban,2020-Q4,0,0,0
@@ -13295,8 +11633,6 @@ Alexander Gorban,2018-Q4,0,0,0
 Alexander Gorban,2018-Q3,0,0,0
 Alexander Gorban,2018-Q2,3,252,0
 Alexander Gorban,2018-Q1,2,16,5
-Tongzhou Wang,2021-Q4,0,0,0
-Tongzhou Wang,2021-Q3,0,0,0
 Tongzhou Wang,2021-Q2,0,0,0
 Tongzhou Wang,2021-Q1,0,0,0
 Tongzhou Wang,2020-Q4,0,0,0
@@ -13311,8 +11647,6 @@ Tongzhou Wang,2018-Q4,0,0,0
 Tongzhou Wang,2018-Q3,0,0,0
 Tongzhou Wang,2018-Q2,0,0,0
 Tongzhou Wang,2018-Q1,0,0,0
-Gregory Clark,2021-Q4,0,0,0
-Gregory Clark,2021-Q3,0,0,0
 Gregory Clark,2021-Q2,0,0,0
 Gregory Clark,2021-Q1,0,0,0
 Gregory Clark,2020-Q4,0,0,0
@@ -13327,8 +11661,6 @@ Gregory Clark,2018-Q4,0,0,0
 Gregory Clark,2018-Q3,0,0,0
 Gregory Clark,2018-Q2,0,0,0
 Gregory Clark,2018-Q1,0,0,0
-Abdul Baseer Khan,2021-Q4,0,0,0
-Abdul Baseer Khan,2021-Q3,0,0,0
 Abdul Baseer Khan,2021-Q2,0,0,0
 Abdul Baseer Khan,2021-Q1,0,0,0
 Abdul Baseer Khan,2020-Q4,0,0,0
@@ -13343,8 +11675,6 @@ Abdul Baseer Khan,2018-Q4,0,0,0
 Abdul Baseer Khan,2018-Q3,0,0,0
 Abdul Baseer Khan,2018-Q2,0,0,0
 Abdul Baseer Khan,2018-Q1,0,0,0
-Alexey Rogachevskiy,2021-Q4,0,0,0
-Alexey Rogachevskiy,2021-Q3,0,0,0
 Alexey Rogachevskiy,2021-Q2,0,0,0
 Alexey Rogachevskiy,2021-Q1,0,0,0
 Alexey Rogachevskiy,2020-Q4,0,0,0
@@ -13359,8 +11689,6 @@ Alexey Rogachevskiy,2018-Q4,0,0,0
 Alexey Rogachevskiy,2018-Q3,0,0,0
 Alexey Rogachevskiy,2018-Q2,0,0,0
 Alexey Rogachevskiy,2018-Q1,0,0,0
-Keith Smiley,2021-Q4,0,0,0
-Keith Smiley,2021-Q3,0,0,0
 Keith Smiley,2021-Q2,0,0,0
 Keith Smiley,2021-Q1,0,0,0
 Keith Smiley,2020-Q4,0,0,0
@@ -13375,8 +11703,6 @@ Keith Smiley,2018-Q4,0,0,0
 Keith Smiley,2018-Q3,0,0,0
 Keith Smiley,2018-Q2,0,0,0
 Keith Smiley,2018-Q1,0,0,0
-Xiaoquan Kong,2021-Q4,0,0,0
-Xiaoquan Kong,2021-Q3,0,0,0
 Xiaoquan Kong,2021-Q2,0,0,0
 Xiaoquan Kong,2021-Q1,0,0,0
 Xiaoquan Kong,2020-Q4,0,0,0
@@ -13391,8 +11717,6 @@ Xiaoquan Kong,2018-Q4,1,0,0
 Xiaoquan Kong,2018-Q3,0,0,0
 Xiaoquan Kong,2018-Q2,0,0,0
 Xiaoquan Kong,2018-Q1,0,0,0
-Sreeni Kesavarapu,2021-Q4,0,0,0
-Sreeni Kesavarapu,2021-Q3,0,0,0
 Sreeni Kesavarapu,2021-Q2,0,0,0
 Sreeni Kesavarapu,2021-Q1,0,0,0
 Sreeni Kesavarapu,2020-Q4,0,0,0
@@ -13407,8 +11731,6 @@ Sreeni Kesavarapu,2018-Q4,16,410,46
 Sreeni Kesavarapu,2018-Q3,0,0,0
 Sreeni Kesavarapu,2018-Q2,0,0,0
 Sreeni Kesavarapu,2018-Q1,0,0,0
-Gregory Keith,2021-Q4,0,0,0
-Gregory Keith,2021-Q3,0,0,0
 Gregory Keith,2021-Q2,0,0,0
 Gregory Keith,2021-Q1,0,0,0
 Gregory Keith,2020-Q4,0,0,0
@@ -13423,8 +11745,6 @@ Gregory Keith,2018-Q4,0,0,0
 Gregory Keith,2018-Q3,0,0,0
 Gregory Keith,2018-Q2,0,0,0
 Gregory Keith,2018-Q1,0,0,0
-Semun Lee,2021-Q4,0,0,0
-Semun Lee,2021-Q3,0,0,0
 Semun Lee,2021-Q2,0,0,0
 Semun Lee,2021-Q1,0,0,0
 Semun Lee,2020-Q4,0,0,0
@@ -13439,8 +11759,6 @@ Semun Lee,2018-Q4,0,0,0
 Semun Lee,2018-Q3,0,0,0
 Semun Lee,2018-Q2,0,0,0
 Semun Lee,2018-Q1,0,0,0
-Anudhyan Boral,2021-Q4,0,0,0
-Anudhyan Boral,2021-Q3,0,0,0
 Anudhyan Boral,2021-Q2,0,0,0
 Anudhyan Boral,2021-Q1,0,0,0
 Anudhyan Boral,2020-Q4,0,0,0
@@ -13455,8 +11773,6 @@ Anudhyan Boral,2018-Q4,12,900,0
 Anudhyan Boral,2018-Q3,0,0,0
 Anudhyan Boral,2018-Q2,0,0,0
 Anudhyan Boral,2018-Q1,0,0,0
-Vaibhav Jade,2021-Q4,0,0,0
-Vaibhav Jade,2021-Q3,0,0,0
 Vaibhav Jade,2021-Q2,0,0,0
 Vaibhav Jade,2021-Q1,0,0,0
 Vaibhav Jade,2020-Q4,0,0,0
@@ -13471,8 +11787,6 @@ Vaibhav Jade,2018-Q4,0,0,0
 Vaibhav Jade,2018-Q3,0,0,0
 Vaibhav Jade,2018-Q2,0,0,0
 Vaibhav Jade,2018-Q1,0,0,0
-Harjyot Bagga,2021-Q4,0,0,0
-Harjyot Bagga,2021-Q3,0,0,0
 Harjyot Bagga,2021-Q2,0,0,0
 Harjyot Bagga,2021-Q1,0,0,0
 Harjyot Bagga,2020-Q4,0,0,0
@@ -13487,8 +11801,6 @@ Harjyot Bagga,2018-Q4,0,0,0
 Harjyot Bagga,2018-Q3,0,0,0
 Harjyot Bagga,2018-Q2,0,0,0
 Harjyot Bagga,2018-Q1,0,0,0
-wondertx,2021-Q4,0,0,0
-wondertx,2021-Q3,0,0,0
 wondertx,2021-Q2,0,0,0
 wondertx,2021-Q1,0,0,0
 wondertx,2020-Q4,0,0,0
@@ -13503,8 +11815,6 @@ wondertx,2018-Q4,0,0,0
 wondertx,2018-Q3,0,0,0
 wondertx,2018-Q2,0,0,0
 wondertx,2018-Q1,0,0,0
-seo-inyoung,2021-Q4,0,0,0
-seo-inyoung,2021-Q3,0,0,0
 seo-inyoung,2021-Q2,0,0,0
 seo-inyoung,2021-Q1,0,0,0
 seo-inyoung,2020-Q4,0,0,0
@@ -13519,8 +11829,6 @@ seo-inyoung,2018-Q4,0,0,0
 seo-inyoung,2018-Q3,0,0,0
 seo-inyoung,2018-Q2,0,0,0
 seo-inyoung,2018-Q1,0,0,0
-Sergey Mironov,2021-Q4,0,0,0
-Sergey Mironov,2021-Q3,0,0,0
 Sergey Mironov,2021-Q2,0,0,0
 Sergey Mironov,2021-Q1,0,0,0
 Sergey Mironov,2020-Q4,0,0,0
@@ -13535,8 +11843,6 @@ Sergey Mironov,2018-Q4,0,0,0
 Sergey Mironov,2018-Q3,0,0,0
 Sergey Mironov,2018-Q2,0,0,0
 Sergey Mironov,2018-Q1,0,0,0
-Kilaru Yasaswi Sri Chandra Gandhi,2021-Q4,0,0,0
-Kilaru Yasaswi Sri Chandra Gandhi,2021-Q3,0,0,0
 Kilaru Yasaswi Sri Chandra Gandhi,2021-Q2,0,0,0
 Kilaru Yasaswi Sri Chandra Gandhi,2021-Q1,0,0,0
 Kilaru Yasaswi Sri Chandra Gandhi,2020-Q4,0,0,0
@@ -13551,8 +11857,6 @@ Kilaru Yasaswi Sri Chandra Gandhi,2018-Q4,0,0,0
 Kilaru Yasaswi Sri Chandra Gandhi,2018-Q3,0,0,0
 Kilaru Yasaswi Sri Chandra Gandhi,2018-Q2,0,0,0
 Kilaru Yasaswi Sri Chandra Gandhi,2018-Q1,0,0,0
-storypku,2021-Q4,0,0,0
-storypku,2021-Q3,0,0,0
 storypku,2021-Q2,0,0,0
 storypku,2021-Q1,0,0,0
 storypku,2020-Q4,0,0,0
@@ -13567,8 +11871,6 @@ storypku,2018-Q4,0,0,0
 storypku,2018-Q3,0,0,0
 storypku,2018-Q2,0,0,0
 storypku,2018-Q1,0,0,0
-Karol Gugala,2021-Q4,0,0,0
-Karol Gugala,2021-Q3,0,0,0
 Karol Gugala,2021-Q2,0,0,0
 Karol Gugala,2021-Q1,0,0,0
 Karol Gugala,2020-Q4,0,0,0
@@ -13583,8 +11885,6 @@ Karol Gugala,2018-Q4,0,0,0
 Karol Gugala,2018-Q3,0,0,0
 Karol Gugala,2018-Q2,0,0,0
 Karol Gugala,2018-Q1,0,0,0
-Alan Chiao,2021-Q4,0,0,0
-Alan Chiao,2021-Q3,0,0,0
 Alan Chiao,2021-Q2,0,0,0
 Alan Chiao,2021-Q1,0,0,0
 Alan Chiao,2020-Q4,0,0,0
@@ -13599,8 +11899,6 @@ Alan Chiao,2018-Q4,6,417,3
 Alan Chiao,2018-Q3,30,782,268
 Alan Chiao,2018-Q2,24,1283,256
 Alan Chiao,2018-Q1,0,0,0
-stevensa,2021-Q4,0,0,0
-stevensa,2021-Q3,0,0,0
 stevensa,2021-Q2,0,0,0
 stevensa,2021-Q1,0,0,0
 stevensa,2020-Q4,0,0,0
@@ -13615,8 +11913,6 @@ stevensa,2018-Q4,0,0,0
 stevensa,2018-Q3,0,0,0
 stevensa,2018-Q2,0,0,0
 stevensa,2018-Q1,0,0,0
-Jake Tae,2021-Q4,0,0,0
-Jake Tae,2021-Q3,0,0,0
 Jake Tae,2021-Q2,0,0,0
 Jake Tae,2021-Q1,0,0,0
 Jake Tae,2020-Q4,0,0,0
@@ -13631,8 +11927,6 @@ Jake Tae,2018-Q4,0,0,0
 Jake Tae,2018-Q3,0,0,0
 Jake Tae,2018-Q2,0,0,0
 Jake Tae,2018-Q1,0,0,0
-Sam Kaufman,2021-Q4,0,0,0
-Sam Kaufman,2021-Q3,0,0,0
 Sam Kaufman,2021-Q2,0,0,0
 Sam Kaufman,2021-Q1,0,0,0
 Sam Kaufman,2020-Q4,0,0,0
@@ -13647,8 +11941,6 @@ Sam Kaufman,2018-Q4,0,0,0
 Sam Kaufman,2018-Q3,0,0,0
 Sam Kaufman,2018-Q2,0,0,0
 Sam Kaufman,2018-Q1,0,0,0
-rangjiaheng,2021-Q4,0,0,0
-rangjiaheng,2021-Q3,0,0,0
 rangjiaheng,2021-Q2,0,0,0
 rangjiaheng,2021-Q1,0,0,0
 rangjiaheng,2020-Q4,0,0,0
@@ -13663,8 +11955,6 @@ rangjiaheng,2018-Q4,0,0,0
 rangjiaheng,2018-Q3,0,0,0
 rangjiaheng,2018-Q2,0,0,0
 rangjiaheng,2018-Q1,0,0,0
-Will Battel,2021-Q4,0,0,0
-Will Battel,2021-Q3,0,0,0
 Will Battel,2021-Q2,0,0,0
 Will Battel,2021-Q1,0,0,0
 Will Battel,2020-Q4,0,0,0
@@ -13679,8 +11969,6 @@ Will Battel,2018-Q4,0,0,0
 Will Battel,2018-Q3,0,0,0
 Will Battel,2018-Q2,0,0,0
 Will Battel,2018-Q1,0,0,0
-Rahul Huilgol,2021-Q4,0,0,0
-Rahul Huilgol,2021-Q3,0,0,0
 Rahul Huilgol,2021-Q2,0,0,0
 Rahul Huilgol,2021-Q1,0,0,0
 Rahul Huilgol,2020-Q4,0,0,0
@@ -13695,8 +11983,6 @@ Rahul Huilgol,2018-Q4,0,0,0
 Rahul Huilgol,2018-Q3,0,0,0
 Rahul Huilgol,2018-Q2,0,0,0
 Rahul Huilgol,2018-Q1,0,0,0
-Ajay P,2021-Q4,0,0,0
-Ajay P,2021-Q3,0,0,0
 Ajay P,2021-Q2,0,0,0
 Ajay P,2021-Q1,0,0,0
 Ajay P,2020-Q4,0,0,0
@@ -13711,8 +11997,6 @@ Ajay P,2018-Q4,0,0,0
 Ajay P,2018-Q3,0,0,0
 Ajay P,2018-Q2,0,0,0
 Ajay P,2018-Q1,0,0,0
-Ben Arnao,2021-Q4,0,0,0
-Ben Arnao,2021-Q3,0,0,0
 Ben Arnao,2021-Q2,0,0,0
 Ben Arnao,2021-Q1,0,0,0
 Ben Arnao,2020-Q4,0,0,0
@@ -13727,8 +12011,6 @@ Ben Arnao,2018-Q4,0,0,0
 Ben Arnao,2018-Q3,0,0,0
 Ben Arnao,2018-Q2,0,0,0
 Ben Arnao,2018-Q1,0,0,0
-Gian Marco Iodice,2021-Q4,0,0,0
-Gian Marco Iodice,2021-Q3,0,0,0
 Gian Marco Iodice,2021-Q2,0,0,0
 Gian Marco Iodice,2021-Q1,0,0,0
 Gian Marco Iodice,2020-Q4,0,0,0
@@ -13743,8 +12025,6 @@ Gian Marco Iodice,2018-Q4,0,0,0
 Gian Marco Iodice,2018-Q3,0,0,0
 Gian Marco Iodice,2018-Q2,0,0,0
 Gian Marco Iodice,2018-Q1,0,0,0
-Swapnil Parekh,2021-Q4,0,0,0
-Swapnil Parekh,2021-Q3,0,0,0
 Swapnil Parekh,2021-Q2,0,0,0
 Swapnil Parekh,2021-Q1,0,0,0
 Swapnil Parekh,2020-Q4,0,0,0
@@ -13759,8 +12039,6 @@ Swapnil Parekh,2018-Q4,0,0,0
 Swapnil Parekh,2018-Q3,0,0,0
 Swapnil Parekh,2018-Q2,0,0,0
 Swapnil Parekh,2018-Q1,0,0,0
-Janosh Riebesell,2021-Q4,0,0,0
-Janosh Riebesell,2021-Q3,0,0,0
 Janosh Riebesell,2021-Q2,0,0,0
 Janosh Riebesell,2021-Q1,0,0,0
 Janosh Riebesell,2020-Q4,0,0,0
@@ -13775,8 +12053,6 @@ Janosh Riebesell,2018-Q4,0,0,0
 Janosh Riebesell,2018-Q3,0,0,0
 Janosh Riebesell,2018-Q2,0,0,0
 Janosh Riebesell,2018-Q1,0,0,0
-Ryohei Ikegami,2021-Q4,0,0,0
-Ryohei Ikegami,2021-Q3,0,0,0
 Ryohei Ikegami,2021-Q2,0,0,0
 Ryohei Ikegami,2021-Q1,0,0,0
 Ryohei Ikegami,2020-Q4,0,0,0
@@ -13791,8 +12067,6 @@ Ryohei Ikegami,2018-Q4,0,0,0
 Ryohei Ikegami,2018-Q3,0,0,0
 Ryohei Ikegami,2018-Q2,0,0,0
 Ryohei Ikegami,2018-Q1,0,0,0
-Marcin Sielski,2021-Q4,0,0,0
-Marcin Sielski,2021-Q3,0,0,0
 Marcin Sielski,2021-Q2,0,0,0
 Marcin Sielski,2021-Q1,0,0,0
 Marcin Sielski,2020-Q4,0,0,0
@@ -13807,8 +12081,6 @@ Marcin Sielski,2018-Q4,0,0,0
 Marcin Sielski,2018-Q3,0,0,0
 Marcin Sielski,2018-Q2,0,0,0
 Marcin Sielski,2018-Q1,0,0,0
-Guozhong Zhuang,2021-Q4,0,0,0
-Guozhong Zhuang,2021-Q3,0,0,0
 Guozhong Zhuang,2021-Q2,0,0,0
 Guozhong Zhuang,2021-Q1,0,0,0
 Guozhong Zhuang,2020-Q4,0,0,0
@@ -13823,8 +12095,6 @@ Guozhong Zhuang,2018-Q4,12,184,1439
 Guozhong Zhuang,2018-Q3,46,1453,585
 Guozhong Zhuang,2018-Q2,49,5172,2780
 Guozhong Zhuang,2018-Q1,6,333,154
-Michael Moffitt,2021-Q4,0,0,0
-Michael Moffitt,2021-Q3,0,0,0
 Michael Moffitt,2021-Q2,0,0,0
 Michael Moffitt,2021-Q1,0,0,0
 Michael Moffitt,2020-Q4,0,0,0
@@ -13839,8 +12109,6 @@ Michael Moffitt,2018-Q4,0,0,0
 Michael Moffitt,2018-Q3,0,0,0
 Michael Moffitt,2018-Q2,0,0,0
 Michael Moffitt,2018-Q1,0,0,0
-Felix E. Klee,2021-Q4,0,0,0
-Felix E. Klee,2021-Q3,0,0,0
 Felix E. Klee,2021-Q2,0,0,0
 Felix E. Klee,2021-Q1,0,0,0
 Felix E. Klee,2020-Q4,0,0,0
@@ -13855,8 +12123,6 @@ Felix E. Klee,2018-Q4,0,0,0
 Felix E. Klee,2018-Q3,0,0,0
 Felix E. Klee,2018-Q2,0,0,0
 Felix E. Klee,2018-Q1,0,0,0
-amoitra,2021-Q4,0,0,0
-amoitra,2021-Q3,0,0,0
 amoitra,2021-Q2,0,0,0
 amoitra,2021-Q1,0,0,0
 amoitra,2020-Q4,0,0,0
@@ -13871,8 +12137,6 @@ amoitra,2018-Q4,0,0,0
 amoitra,2018-Q3,0,0,0
 amoitra,2018-Q2,0,0,0
 amoitra,2018-Q1,0,0,0
-Andrew Stevens,2021-Q4,0,0,0
-Andrew Stevens,2021-Q3,0,0,0
 Andrew Stevens,2021-Q2,0,0,0
 Andrew Stevens,2021-Q1,0,0,0
 Andrew Stevens,2020-Q4,0,0,0
@@ -13887,8 +12151,6 @@ Andrew Stevens,2018-Q4,0,0,0
 Andrew Stevens,2018-Q3,0,0,0
 Andrew Stevens,2018-Q2,0,0,0
 Andrew Stevens,2018-Q1,0,0,0
-Peng Sun,2021-Q4,0,0,0
-Peng Sun,2021-Q3,0,0,0
 Peng Sun,2021-Q2,0,0,0
 Peng Sun,2021-Q1,0,0,0
 Peng Sun,2020-Q4,0,0,0
@@ -13903,8 +12165,6 @@ Peng Sun,2018-Q4,0,0,0
 Peng Sun,2018-Q3,0,0,0
 Peng Sun,2018-Q2,0,0,0
 Peng Sun,2018-Q1,0,0,0
-Shunya Ueta,2021-Q4,0,0,0
-Shunya Ueta,2021-Q3,0,0,0
 Shunya Ueta,2021-Q2,0,0,0
 Shunya Ueta,2021-Q1,0,0,0
 Shunya Ueta,2020-Q4,0,0,0
@@ -13919,8 +12179,6 @@ Shunya Ueta,2018-Q4,0,0,0
 Shunya Ueta,2018-Q3,0,0,0
 Shunya Ueta,2018-Q2,0,0,0
 Shunya Ueta,2018-Q1,0,0,0
-Shraiysh Vaishay,2021-Q4,0,0,0
-Shraiysh Vaishay,2021-Q3,0,0,0
 Shraiysh Vaishay,2021-Q2,0,0,0
 Shraiysh Vaishay,2021-Q1,0,0,0
 Shraiysh Vaishay,2020-Q4,0,0,0
@@ -13935,8 +12193,6 @@ Shraiysh Vaishay,2018-Q4,0,0,0
 Shraiysh Vaishay,2018-Q3,0,0,0
 Shraiysh Vaishay,2018-Q2,0,0,0
 Shraiysh Vaishay,2018-Q1,0,0,0
-Derek Murray,2021-Q4,0,0,0
-Derek Murray,2021-Q3,0,0,0
 Derek Murray,2021-Q2,0,0,0
 Derek Murray,2021-Q1,0,0,0
 Derek Murray,2020-Q4,0,0,0
@@ -13951,8 +12207,6 @@ Derek Murray,2018-Q4,796,17972,13178
 Derek Murray,2018-Q3,398,6415,2964
 Derek Murray,2018-Q2,260,6789,2388
 Derek Murray,2018-Q1,379,7340,8913
-Andrew Cavanaugh,2021-Q4,0,0,0
-Andrew Cavanaugh,2021-Q3,0,0,0
 Andrew Cavanaugh,2021-Q2,0,0,0
 Andrew Cavanaugh,2021-Q1,0,0,0
 Andrew Cavanaugh,2020-Q4,0,0,0
@@ -13967,8 +12221,6 @@ Andrew Cavanaugh,2018-Q4,0,0,0
 Andrew Cavanaugh,2018-Q3,0,0,0
 Andrew Cavanaugh,2018-Q2,0,0,0
 Andrew Cavanaugh,2018-Q1,0,0,0
-josh meyer,2021-Q4,0,0,0
-josh meyer,2021-Q3,0,0,0
 josh meyer,2021-Q2,0,0,0
 josh meyer,2021-Q1,0,0,0
 josh meyer,2020-Q4,0,0,0
@@ -13983,8 +12235,6 @@ josh meyer,2018-Q4,0,0,0
 josh meyer,2018-Q3,0,0,0
 josh meyer,2018-Q2,0,0,0
 josh meyer,2018-Q1,0,0,0
-leslie-fang-intel,2021-Q4,0,0,0
-leslie-fang-intel,2021-Q3,0,0,0
 leslie-fang-intel,2021-Q2,0,0,0
 leslie-fang-intel,2021-Q1,0,0,0
 leslie-fang-intel,2020-Q4,0,0,0
@@ -13999,8 +12249,6 @@ leslie-fang-intel,2018-Q4,0,0,0
 leslie-fang-intel,2018-Q3,0,0,0
 leslie-fang-intel,2018-Q2,0,0,0
 leslie-fang-intel,2018-Q1,0,0,0
-tongxuan.ltx,2021-Q4,0,0,0
-tongxuan.ltx,2021-Q3,0,0,0
 tongxuan.ltx,2021-Q2,0,0,0
 tongxuan.ltx,2021-Q1,0,0,0
 tongxuan.ltx,2020-Q4,0,0,0
@@ -14015,8 +12263,6 @@ tongxuan.ltx,2018-Q4,0,0,0
 tongxuan.ltx,2018-Q3,0,0,0
 tongxuan.ltx,2018-Q2,0,0,0
 tongxuan.ltx,2018-Q1,0,0,0
-Bryan Cutler,2021-Q4,0,0,0
-Bryan Cutler,2021-Q3,0,0,0
 Bryan Cutler,2021-Q2,0,0,0
 Bryan Cutler,2021-Q1,0,0,0
 Bryan Cutler,2020-Q4,0,0,0
@@ -14031,8 +12277,6 @@ Bryan Cutler,2018-Q4,3,17,17
 Bryan Cutler,2018-Q3,0,0,0
 Bryan Cutler,2018-Q2,0,0,0
 Bryan Cutler,2018-Q1,0,0,0
-Hahn Anselm,2021-Q4,0,0,0
-Hahn Anselm,2021-Q3,0,0,0
 Hahn Anselm,2021-Q2,0,0,0
 Hahn Anselm,2021-Q1,0,0,0
 Hahn Anselm,2020-Q4,0,0,0
@@ -14047,8 +12291,6 @@ Hahn Anselm,2018-Q4,0,0,0
 Hahn Anselm,2018-Q3,0,0,0
 Hahn Anselm,2018-Q2,0,0,0
 Hahn Anselm,2018-Q1,0,0,0
-Bastian Eichenberger,2021-Q4,0,0,0
-Bastian Eichenberger,2021-Q3,0,0,0
 Bastian Eichenberger,2021-Q2,0,0,0
 Bastian Eichenberger,2021-Q1,0,0,0
 Bastian Eichenberger,2020-Q4,0,0,0
@@ -14063,8 +12305,6 @@ Bastian Eichenberger,2018-Q4,0,0,0
 Bastian Eichenberger,2018-Q3,0,0,0
 Bastian Eichenberger,2018-Q2,0,0,0
 Bastian Eichenberger,2018-Q1,0,0,0
-Chris Tessum,2021-Q4,0,0,0
-Chris Tessum,2021-Q3,0,0,0
 Chris Tessum,2021-Q2,0,0,0
 Chris Tessum,2021-Q1,0,0,0
 Chris Tessum,2020-Q4,0,0,0
@@ -14079,8 +12319,6 @@ Chris Tessum,2018-Q4,0,0,0
 Chris Tessum,2018-Q3,0,0,0
 Chris Tessum,2018-Q2,0,0,0
 Chris Tessum,2018-Q1,0,0,0
-jacco,2021-Q4,0,0,0
-jacco,2021-Q3,0,0,0
 jacco,2021-Q2,0,0,0
 jacco,2021-Q1,0,0,0
 jacco,2020-Q4,0,0,0
@@ -14095,8 +12333,6 @@ jacco,2018-Q4,0,0,0
 jacco,2018-Q3,0,0,0
 jacco,2018-Q2,0,0,0
 jacco,2018-Q1,0,0,0
-naumkin,2021-Q4,0,0,0
-naumkin,2021-Q3,0,0,0
 naumkin,2021-Q2,0,0,0
 naumkin,2021-Q1,0,0,0
 naumkin,2020-Q4,0,0,0
@@ -14111,8 +12347,6 @@ naumkin,2018-Q4,0,0,0
 naumkin,2018-Q3,0,0,0
 naumkin,2018-Q2,0,0,0
 naumkin,2018-Q1,0,0,0
-Daria Zhuravleva,2021-Q4,0,0,0
-Daria Zhuravleva,2021-Q3,0,0,0
 Daria Zhuravleva,2021-Q2,0,0,0
 Daria Zhuravleva,2021-Q1,0,0,0
 Daria Zhuravleva,2020-Q4,0,0,0
@@ -14127,8 +12361,6 @@ Daria Zhuravleva,2018-Q4,0,0,0
 Daria Zhuravleva,2018-Q3,0,0,0
 Daria Zhuravleva,2018-Q2,0,0,0
 Daria Zhuravleva,2018-Q1,0,0,0
-Christopher Suter,2021-Q4,0,0,0
-Christopher Suter,2021-Q3,0,0,0
 Christopher Suter,2021-Q2,0,0,0
 Christopher Suter,2021-Q1,0,0,0
 Christopher Suter,2020-Q4,0,0,0
@@ -14143,8 +12375,6 @@ Christopher Suter,2018-Q4,0,0,0
 Christopher Suter,2018-Q3,0,0,0
 Christopher Suter,2018-Q2,4,47,58
 Christopher Suter,2018-Q1,1,2,2
-Richard Levasseur,2021-Q4,0,0,0
-Richard Levasseur,2021-Q3,0,0,0
 Richard Levasseur,2021-Q2,0,0,0
 Richard Levasseur,2021-Q1,0,0,0
 Richard Levasseur,2020-Q4,0,0,0
@@ -14159,8 +12389,6 @@ Richard Levasseur,2018-Q4,0,0,0
 Richard Levasseur,2018-Q3,0,0,0
 Richard Levasseur,2018-Q2,0,0,0
 Richard Levasseur,2018-Q1,0,0,0
-Brian Lee,2021-Q4,0,0,0
-Brian Lee,2021-Q3,0,0,0
 Brian Lee,2021-Q2,0,0,0
 Brian Lee,2021-Q1,0,0,0
 Brian Lee,2020-Q4,0,0,0
@@ -14175,8 +12403,6 @@ Brian Lee,2018-Q4,0,0,0
 Brian Lee,2018-Q3,0,0,0
 Brian Lee,2018-Q2,0,0,0
 Brian Lee,2018-Q1,0,0,0
-Neeraj Bhadani,2021-Q4,0,0,0
-Neeraj Bhadani,2021-Q3,0,0,0
 Neeraj Bhadani,2021-Q2,0,0,0
 Neeraj Bhadani,2021-Q1,0,0,0
 Neeraj Bhadani,2020-Q4,0,0,0
@@ -14191,8 +12417,6 @@ Neeraj Bhadani,2018-Q4,0,0,0
 Neeraj Bhadani,2018-Q3,0,0,0
 Neeraj Bhadani,2018-Q2,0,0,0
 Neeraj Bhadani,2018-Q1,0,0,0
-mshr-h,2021-Q4,0,0,0
-mshr-h,2021-Q3,0,0,0
 mshr-h,2021-Q2,0,0,0
 mshr-h,2021-Q1,0,0,0
 mshr-h,2020-Q4,0,0,0
@@ -14207,8 +12431,6 @@ mshr-h,2018-Q4,0,0,0
 mshr-h,2018-Q3,0,0,0
 mshr-h,2018-Q2,0,0,0
 mshr-h,2018-Q1,0,0,0
-902449@58880@bigcat_chen,2021-Q4,0,0,0
-902449@58880@bigcat_chen,2021-Q3,0,0,0
 902449@58880@bigcat_chen,2021-Q2,0,0,0
 902449@58880@bigcat_chen,2021-Q1,0,0,0
 902449@58880@bigcat_chen,2020-Q4,0,0,0
@@ -14223,8 +12445,6 @@ mshr-h,2018-Q1,0,0,0
 902449@58880@bigcat_chen,2018-Q3,0,0,0
 902449@58880@bigcat_chen,2018-Q2,0,0,0
 902449@58880@bigcat_chen,2018-Q1,0,0,0
-Fei Sun,2021-Q4,0,0,0
-Fei Sun,2021-Q3,0,0,0
 Fei Sun,2021-Q2,0,0,0
 Fei Sun,2021-Q1,0,0,0
 Fei Sun,2020-Q4,0,0,0
@@ -14239,8 +12459,6 @@ Fei Sun,2018-Q4,0,0,0
 Fei Sun,2018-Q3,0,0,0
 Fei Sun,2018-Q2,0,0,0
 Fei Sun,2018-Q1,0,0,0
-Bharat123rox,2021-Q4,0,0,0
-Bharat123rox,2021-Q3,0,0,0
 Bharat123rox,2021-Q2,0,0,0
 Bharat123rox,2021-Q1,0,0,0
 Bharat123rox,2020-Q4,0,0,0
@@ -14255,8 +12473,6 @@ Bharat123rox,2018-Q4,0,0,0
 Bharat123rox,2018-Q3,0,0,0
 Bharat123rox,2018-Q2,0,0,0
 Bharat123rox,2018-Q1,0,0,0
-Tzu-Wei Huang,2021-Q4,0,0,0
-Tzu-Wei Huang,2021-Q3,0,0,0
 Tzu-Wei Huang,2021-Q2,0,0,0
 Tzu-Wei Huang,2021-Q1,0,0,0
 Tzu-Wei Huang,2020-Q4,0,0,0
@@ -14271,8 +12487,6 @@ Tzu-Wei Huang,2018-Q4,0,0,0
 Tzu-Wei Huang,2018-Q3,0,0,0
 Tzu-Wei Huang,2018-Q2,0,0,0
 Tzu-Wei Huang,2018-Q1,0,0,0
-ouyang jin,2021-Q4,0,0,0
-ouyang jin,2021-Q3,0,0,0
 ouyang jin,2021-Q2,0,0,0
 ouyang jin,2021-Q1,0,0,0
 ouyang jin,2020-Q4,0,0,0
@@ -14287,8 +12501,6 @@ ouyang jin,2018-Q4,0,0,0
 ouyang jin,2018-Q3,0,0,0
 ouyang jin,2018-Q2,0,0,0
 ouyang jin,2018-Q1,0,0,0
-Kayou,2021-Q4,0,0,0
-Kayou,2021-Q3,0,0,0
 Kayou,2021-Q2,0,0,0
 Kayou,2021-Q1,0,0,0
 Kayou,2020-Q4,0,0,0
@@ -14303,8 +12515,6 @@ Kayou,2018-Q4,0,0,0
 Kayou,2018-Q3,0,0,0
 Kayou,2018-Q2,0,0,0
 Kayou,2018-Q1,0,0,0
-Mirko Visontai,2021-Q4,0,0,0
-Mirko Visontai,2021-Q3,0,0,0
 Mirko Visontai,2021-Q2,0,0,0
 Mirko Visontai,2021-Q1,0,0,0
 Mirko Visontai,2020-Q4,0,0,0
@@ -14319,8 +12529,6 @@ Mirko Visontai,2018-Q4,0,0,0
 Mirko Visontai,2018-Q3,0,0,0
 Mirko Visontai,2018-Q2,0,0,0
 Mirko Visontai,2018-Q1,0,0,0
-Logan Chien,2021-Q4,0,0,0
-Logan Chien,2021-Q3,0,0,0
 Logan Chien,2021-Q2,0,0,0
 Logan Chien,2021-Q1,0,0,0
 Logan Chien,2020-Q4,0,0,0
@@ -14335,8 +12543,6 @@ Logan Chien,2018-Q4,0,0,0
 Logan Chien,2018-Q3,0,0,0
 Logan Chien,2018-Q2,0,0,0
 Logan Chien,2018-Q1,0,0,0
-Rushabh Vasani,2021-Q4,0,0,0
-Rushabh Vasani,2021-Q3,0,0,0
 Rushabh Vasani,2021-Q2,0,0,0
 Rushabh Vasani,2021-Q1,0,0,0
 Rushabh Vasani,2020-Q4,0,0,0
@@ -14351,8 +12557,6 @@ Rushabh Vasani,2018-Q4,0,0,0
 Rushabh Vasani,2018-Q3,0,0,0
 Rushabh Vasani,2018-Q2,0,0,0
 Rushabh Vasani,2018-Q1,0,0,0
-Evan Rosen,2021-Q4,0,0,0
-Evan Rosen,2021-Q3,0,0,0
 Evan Rosen,2021-Q2,0,0,0
 Evan Rosen,2021-Q1,0,0,0
 Evan Rosen,2020-Q4,0,0,0
@@ -14367,8 +12571,6 @@ Evan Rosen,2018-Q4,0,0,0
 Evan Rosen,2018-Q3,0,0,0
 Evan Rosen,2018-Q2,0,0,0
 Evan Rosen,2018-Q1,0,0,0
-Mia Roh,2021-Q4,0,0,0
-Mia Roh,2021-Q3,0,0,0
 Mia Roh,2021-Q2,0,0,0
 Mia Roh,2021-Q1,0,0,0
 Mia Roh,2020-Q4,0,0,0
@@ -14383,8 +12585,6 @@ Mia Roh,2018-Q4,0,0,0
 Mia Roh,2018-Q3,0,0,0
 Mia Roh,2018-Q2,0,0,0
 Mia Roh,2018-Q1,0,0,0
-periannath,2021-Q4,0,0,0
-periannath,2021-Q3,0,0,0
 periannath,2021-Q2,0,0,0
 periannath,2021-Q1,0,0,0
 periannath,2020-Q4,0,0,0
@@ -14399,8 +12599,6 @@ periannath,2018-Q4,0,0,0
 periannath,2018-Q3,0,0,0
 periannath,2018-Q2,0,0,0
 periannath,2018-Q1,0,0,0
-Edgar Liberis,2021-Q4,0,0,0
-Edgar Liberis,2021-Q3,0,0,0
 Edgar Liberis,2021-Q2,0,0,0
 Edgar Liberis,2021-Q1,0,0,0
 Edgar Liberis,2020-Q4,0,0,0
@@ -14415,8 +12613,6 @@ Edgar Liberis,2018-Q4,0,0,0
 Edgar Liberis,2018-Q3,0,0,0
 Edgar Liberis,2018-Q2,0,0,0
 Edgar Liberis,2018-Q1,0,0,0
-Ashutosh Hathidara,2021-Q4,0,0,0
-Ashutosh Hathidara,2021-Q3,0,0,0
 Ashutosh Hathidara,2021-Q2,0,0,0
 Ashutosh Hathidara,2021-Q1,0,0,0
 Ashutosh Hathidara,2020-Q4,0,0,0
@@ -14431,8 +12627,6 @@ Ashutosh Hathidara,2018-Q4,0,0,0
 Ashutosh Hathidara,2018-Q3,0,0,0
 Ashutosh Hathidara,2018-Q2,0,0,0
 Ashutosh Hathidara,2018-Q1,0,0,0
-Patrick Hemmer,2021-Q4,0,0,0
-Patrick Hemmer,2021-Q3,0,0,0
 Patrick Hemmer,2021-Q2,0,0,0
 Patrick Hemmer,2021-Q1,0,0,0
 Patrick Hemmer,2020-Q4,0,0,0
@@ -14447,8 +12641,6 @@ Patrick Hemmer,2018-Q4,0,0,0
 Patrick Hemmer,2018-Q3,0,0,0
 Patrick Hemmer,2018-Q2,0,0,0
 Patrick Hemmer,2018-Q1,0,0,0
-Eugene Mikhantiev,2021-Q4,0,0,0
-Eugene Mikhantiev,2021-Q3,0,0,0
 Eugene Mikhantiev,2021-Q2,0,0,0
 Eugene Mikhantiev,2021-Q1,0,0,0
 Eugene Mikhantiev,2020-Q4,0,0,0
@@ -14463,8 +12655,6 @@ Eugene Mikhantiev,2018-Q4,0,0,0
 Eugene Mikhantiev,2018-Q3,0,0,0
 Eugene Mikhantiev,2018-Q2,0,0,0
 Eugene Mikhantiev,2018-Q1,0,0,0
-feihugis,2021-Q4,0,0,0
-feihugis,2021-Q3,0,0,0
 feihugis,2021-Q2,0,0,0
 feihugis,2021-Q1,0,0,0
 feihugis,2020-Q4,0,0,0
@@ -14479,8 +12669,6 @@ feihugis,2018-Q4,0,0,0
 feihugis,2018-Q3,0,0,0
 feihugis,2018-Q2,0,0,0
 feihugis,2018-Q1,0,0,0
-Evgenii Zheltonozhskii,2021-Q4,0,0,0
-Evgenii Zheltonozhskii,2021-Q3,0,0,0
 Evgenii Zheltonozhskii,2021-Q2,0,0,0
 Evgenii Zheltonozhskii,2021-Q1,0,0,0
 Evgenii Zheltonozhskii,2020-Q4,0,0,0
@@ -14495,8 +12683,6 @@ Evgenii Zheltonozhskii,2018-Q4,0,0,0
 Evgenii Zheltonozhskii,2018-Q3,0,0,0
 Evgenii Zheltonozhskii,2018-Q2,0,0,0
 Evgenii Zheltonozhskii,2018-Q1,0,0,0
-Adam Roberts,2021-Q4,0,0,0
-Adam Roberts,2021-Q3,0,0,0
 Adam Roberts,2021-Q2,0,0,0
 Adam Roberts,2021-Q1,0,0,0
 Adam Roberts,2020-Q4,0,0,0
@@ -14511,8 +12697,6 @@ Adam Roberts,2018-Q4,0,0,0
 Adam Roberts,2018-Q3,0,0,0
 Adam Roberts,2018-Q2,1,0,0
 Adam Roberts,2018-Q1,5,49,38
-Evgeniy Zheltonozhskiy,2021-Q4,0,0,0
-Evgeniy Zheltonozhskiy,2021-Q3,0,0,0
 Evgeniy Zheltonozhskiy,2021-Q2,0,0,0
 Evgeniy Zheltonozhskiy,2021-Q1,0,0,0
 Evgeniy Zheltonozhskiy,2020-Q4,0,0,0
@@ -14527,8 +12711,6 @@ Evgeniy Zheltonozhskiy,2018-Q4,0,0,0
 Evgeniy Zheltonozhskiy,2018-Q3,0,0,0
 Evgeniy Zheltonozhskiy,2018-Q2,1,0,0
 Evgeniy Zheltonozhskiy,2018-Q1,0,0,0
-gurushantj,2021-Q4,0,0,0
-gurushantj,2021-Q3,0,0,0
 gurushantj,2021-Q2,0,0,0
 gurushantj,2021-Q1,0,0,0
 gurushantj,2020-Q4,0,0,0
@@ -14543,8 +12725,6 @@ gurushantj,2018-Q4,0,0,0
 gurushantj,2018-Q3,0,0,0
 gurushantj,2018-Q2,0,0,0
 gurushantj,2018-Q1,0,0,0
-Peng Meng,2021-Q4,0,0,0
-Peng Meng,2021-Q3,0,0,0
 Peng Meng,2021-Q2,0,0,0
 Peng Meng,2021-Q1,0,0,0
 Peng Meng,2020-Q4,0,0,0
@@ -14559,8 +12739,6 @@ Peng Meng,2018-Q4,0,0,0
 Peng Meng,2018-Q3,0,0,0
 Peng Meng,2018-Q2,0,0,0
 Peng Meng,2018-Q1,0,0,0
-xutianming,2021-Q4,0,0,0
-xutianming,2021-Q3,0,0,0
 xutianming,2021-Q2,0,0,0
 xutianming,2021-Q1,0,0,0
 xutianming,2020-Q4,0,0,0
@@ -14575,8 +12753,6 @@ xutianming,2018-Q4,0,0,0
 xutianming,2018-Q3,0,0,0
 xutianming,2018-Q2,0,0,0
 xutianming,2018-Q1,0,0,0
-Angus-Luo,2021-Q4,0,0,0
-Angus-Luo,2021-Q3,0,0,0
 Angus-Luo,2021-Q2,0,0,0
 Angus-Luo,2021-Q1,0,0,0
 Angus-Luo,2020-Q4,0,0,0
@@ -14591,8 +12767,6 @@ Angus-Luo,2018-Q4,0,0,0
 Angus-Luo,2018-Q3,0,0,0
 Angus-Luo,2018-Q2,0,0,0
 Angus-Luo,2018-Q1,0,0,0
-flyingcat,2021-Q4,0,0,0
-flyingcat,2021-Q3,0,0,0
 flyingcat,2021-Q2,0,0,0
 flyingcat,2021-Q1,0,0,0
 flyingcat,2020-Q4,0,0,0
@@ -14607,8 +12781,6 @@ flyingcat,2018-Q4,0,0,0
 flyingcat,2018-Q3,0,0,0
 flyingcat,2018-Q2,0,0,0
 flyingcat,2018-Q1,0,0,0
-JLZ,2021-Q4,0,0,0
-JLZ,2021-Q3,0,0,0
 JLZ,2021-Q2,0,0,0
 JLZ,2021-Q1,0,0,0
 JLZ,2020-Q4,0,0,0
@@ -14623,8 +12795,6 @@ JLZ,2018-Q4,0,0,0
 JLZ,2018-Q3,0,0,0
 JLZ,2018-Q2,0,0,0
 JLZ,2018-Q1,0,0,0
-tomas,2021-Q4,0,0,0
-tomas,2021-Q3,0,0,0
 tomas,2021-Q2,0,0,0
 tomas,2021-Q1,0,0,0
 tomas,2020-Q4,0,0,0
@@ -14639,8 +12809,6 @@ tomas,2018-Q4,0,0,0
 tomas,2018-Q3,0,0,0
 tomas,2018-Q2,0,0,0
 tomas,2018-Q1,0,0,0
-Niranjan Yadla,2021-Q4,0,0,0
-Niranjan Yadla,2021-Q3,0,0,0
 Niranjan Yadla,2021-Q2,0,0,0
 Niranjan Yadla,2021-Q1,0,0,0
 Niranjan Yadla,2020-Q4,0,0,0
@@ -14655,8 +12823,6 @@ Niranjan Yadla,2018-Q4,0,0,0
 Niranjan Yadla,2018-Q3,0,0,0
 Niranjan Yadla,2018-Q2,0,0,0
 Niranjan Yadla,2018-Q1,0,0,0
-Tony Tonev,2021-Q4,0,0,0
-Tony Tonev,2021-Q3,0,0,0
 Tony Tonev,2021-Q2,0,0,0
 Tony Tonev,2021-Q1,0,0,0
 Tony Tonev,2020-Q4,0,0,0
@@ -14671,8 +12837,6 @@ Tony Tonev,2018-Q4,0,0,0
 Tony Tonev,2018-Q3,0,0,0
 Tony Tonev,2018-Q2,0,0,0
 Tony Tonev,2018-Q1,0,0,0
-Itamar Turner-Trauring,2021-Q4,0,0,0
-Itamar Turner-Trauring,2021-Q3,0,0,0
 Itamar Turner-Trauring,2021-Q2,0,0,0
 Itamar Turner-Trauring,2021-Q1,0,0,0
 Itamar Turner-Trauring,2020-Q4,0,0,0
@@ -14687,8 +12851,6 @@ Itamar Turner-Trauring,2018-Q4,0,0,0
 Itamar Turner-Trauring,2018-Q3,0,0,0
 Itamar Turner-Trauring,2018-Q2,0,0,0
 Itamar Turner-Trauring,2018-Q1,0,0,0
-Marcel Koester,2021-Q4,0,0,0
-Marcel Koester,2021-Q3,0,0,0
 Marcel Koester,2021-Q2,0,0,0
 Marcel Koester,2021-Q1,0,0,0
 Marcel Koester,2020-Q4,0,0,0
@@ -14703,8 +12865,6 @@ Marcel Koester,2018-Q4,0,0,0
 Marcel Koester,2018-Q3,0,0,0
 Marcel Koester,2018-Q2,0,0,0
 Marcel Koester,2018-Q1,0,0,0
-Manish,2021-Q4,0,0,0
-Manish,2021-Q3,0,0,0
 Manish,2021-Q2,0,0,0
 Manish,2021-Q1,0,0,0
 Manish,2020-Q4,0,0,0
@@ -14719,8 +12879,6 @@ Manish,2018-Q4,0,0,0
 Manish,2018-Q3,0,0,0
 Manish,2018-Q2,0,0,0
 Manish,2018-Q1,0,0,0
-ganler,2021-Q4,0,0,0
-ganler,2021-Q3,0,0,0
 ganler,2021-Q2,0,0,0
 ganler,2021-Q1,0,0,0
 ganler,2020-Q4,0,0,0
@@ -14735,8 +12893,6 @@ ganler,2018-Q4,0,0,0
 ganler,2018-Q3,0,0,0
 ganler,2018-Q2,0,0,0
 ganler,2018-Q1,0,0,0
-Owen Lyke,2021-Q4,0,0,0
-Owen Lyke,2021-Q3,0,0,0
 Owen Lyke,2021-Q2,0,0,0
 Owen Lyke,2021-Q1,0,0,0
 Owen Lyke,2020-Q4,0,0,0
@@ -14751,8 +12907,6 @@ Owen Lyke,2018-Q4,0,0,0
 Owen Lyke,2018-Q3,0,0,0
 Owen Lyke,2018-Q2,0,0,0
 Owen Lyke,2018-Q1,0,0,0
-oclyke,2021-Q4,0,0,0
-oclyke,2021-Q3,0,0,0
 oclyke,2021-Q2,0,0,0
 oclyke,2021-Q1,0,0,0
 oclyke,2020-Q4,0,0,0
@@ -14767,8 +12921,6 @@ oclyke,2018-Q4,0,0,0
 oclyke,2018-Q3,0,0,0
 oclyke,2018-Q2,0,0,0
 oclyke,2018-Q1,0,0,0
-Rohan Reddy,2021-Q4,0,0,0
-Rohan Reddy,2021-Q3,0,0,0
 Rohan Reddy,2021-Q2,0,0,0
 Rohan Reddy,2021-Q1,0,0,0
 Rohan Reddy,2020-Q4,0,0,0
@@ -14783,8 +12935,6 @@ Rohan Reddy,2018-Q4,0,0,0
 Rohan Reddy,2018-Q3,0,0,0
 Rohan Reddy,2018-Q2,0,0,0
 Rohan Reddy,2018-Q1,0,0,0
-vcarpani,2021-Q4,0,0,0
-vcarpani,2021-Q3,0,0,0
 vcarpani,2021-Q2,0,0,0
 vcarpani,2021-Q1,0,0,0
 vcarpani,2020-Q4,0,0,0
@@ -14799,8 +12949,6 @@ vcarpani,2018-Q4,0,0,0
 vcarpani,2018-Q3,0,0,0
 vcarpani,2018-Q2,0,0,0
 vcarpani,2018-Q1,0,0,0
-Kam D Kasravi,2021-Q4,0,0,0
-Kam D Kasravi,2021-Q3,0,0,0
 Kam D Kasravi,2021-Q2,0,0,0
 Kam D Kasravi,2021-Q1,0,0,0
 Kam D Kasravi,2020-Q4,0,0,0
@@ -14815,8 +12963,6 @@ Kam D Kasravi,2018-Q4,0,0,0
 Kam D Kasravi,2018-Q3,0,0,0
 Kam D Kasravi,2018-Q2,0,0,0
 Kam D Kasravi,2018-Q1,0,0,0
-Byambaa,2021-Q4,0,0,0
-Byambaa,2021-Q3,0,0,0
 Byambaa,2021-Q2,0,0,0
 Byambaa,2021-Q1,0,0,0
 Byambaa,2020-Q4,0,0,0
@@ -14831,8 +12977,6 @@ Byambaa,2018-Q4,0,0,0
 Byambaa,2018-Q3,0,0,0
 Byambaa,2018-Q2,0,0,0
 Byambaa,2018-Q1,0,0,0
-Jenni Kilduff,2021-Q4,0,0,0
-Jenni Kilduff,2021-Q3,0,0,0
 Jenni Kilduff,2021-Q2,0,0,0
 Jenni Kilduff,2021-Q1,0,0,0
 Jenni Kilduff,2020-Q4,0,0,0
@@ -14847,8 +12991,6 @@ Jenni Kilduff,2018-Q4,0,0,0
 Jenni Kilduff,2018-Q3,0,0,0
 Jenni Kilduff,2018-Q2,0,0,0
 Jenni Kilduff,2018-Q1,0,0,0
-James Bradbury,2021-Q4,0,0,0
-James Bradbury,2021-Q3,0,0,0
 James Bradbury,2021-Q2,0,0,0
 James Bradbury,2021-Q1,0,0,0
 James Bradbury,2020-Q4,0,0,0
@@ -14863,8 +13005,6 @@ James Bradbury,2018-Q4,0,0,0
 James Bradbury,2018-Q3,0,0,0
 James Bradbury,2018-Q2,0,0,0
 James Bradbury,2018-Q1,0,0,0
-blueyi,2021-Q4,0,0,0
-blueyi,2021-Q3,0,0,0
 blueyi,2021-Q2,0,0,0
 blueyi,2021-Q1,0,0,0
 blueyi,2020-Q4,0,0,0
@@ -14879,8 +13019,6 @@ blueyi,2018-Q4,0,0,0
 blueyi,2018-Q3,0,0,0
 blueyi,2018-Q2,0,0,0
 blueyi,2018-Q1,0,0,0
-Vijay Tadikamalla,2021-Q4,0,0,0
-Vijay Tadikamalla,2021-Q3,0,0,0
 Vijay Tadikamalla,2021-Q2,0,0,0
 Vijay Tadikamalla,2021-Q1,0,0,0
 Vijay Tadikamalla,2020-Q4,0,0,0
@@ -14895,8 +13033,6 @@ Vijay Tadikamalla,2018-Q4,0,0,0
 Vijay Tadikamalla,2018-Q3,0,0,0
 Vijay Tadikamalla,2018-Q2,0,0,0
 Vijay Tadikamalla,2018-Q1,0,0,0
-Artem Mavrin,2021-Q4,0,0,0
-Artem Mavrin,2021-Q3,0,0,0
 Artem Mavrin,2021-Q2,0,0,0
 Artem Mavrin,2021-Q1,0,0,0
 Artem Mavrin,2020-Q4,0,0,0
@@ -14911,8 +13047,6 @@ Artem Mavrin,2018-Q4,0,0,0
 Artem Mavrin,2018-Q3,0,0,0
 Artem Mavrin,2018-Q2,0,0,0
 Artem Mavrin,2018-Q1,0,0,0
-zhaozheng09,2021-Q4,0,0,0
-zhaozheng09,2021-Q3,0,0,0
 zhaozheng09,2021-Q2,0,0,0
 zhaozheng09,2021-Q1,0,0,0
 zhaozheng09,2020-Q4,0,0,0
@@ -14927,8 +13061,6 @@ zhaozheng09,2018-Q4,0,0,0
 zhaozheng09,2018-Q3,0,0,0
 zhaozheng09,2018-Q2,0,0,0
 zhaozheng09,2018-Q1,0,0,0
-Téo Bouvard,2021-Q4,0,0,0
-Téo Bouvard,2021-Q3,0,0,0
 Téo Bouvard,2021-Q2,0,0,0
 Téo Bouvard,2021-Q1,0,0,0
 Téo Bouvard,2020-Q4,0,0,0
@@ -14943,8 +13075,6 @@ Téo Bouvard,2018-Q4,0,0,0
 Téo Bouvard,2018-Q3,0,0,0
 Téo Bouvard,2018-Q2,0,0,0
 Téo Bouvard,2018-Q1,0,0,0
-Paul Andrey,2021-Q4,0,0,0
-Paul Andrey,2021-Q3,0,0,0
 Paul Andrey,2021-Q2,0,0,0
 Paul Andrey,2021-Q1,0,0,0
 Paul Andrey,2020-Q4,0,0,0
@@ -14959,8 +13089,6 @@ Paul Andrey,2018-Q4,0,0,0
 Paul Andrey,2018-Q3,0,0,0
 Paul Andrey,2018-Q2,0,0,0
 Paul Andrey,2018-Q1,0,0,0
-Sven-Hendrik Haase,2021-Q4,0,0,0
-Sven-Hendrik Haase,2021-Q3,0,0,0
 Sven-Hendrik Haase,2021-Q2,0,0,0
 Sven-Hendrik Haase,2021-Q1,0,0,0
 Sven-Hendrik Haase,2020-Q4,0,0,0
@@ -14975,8 +13103,6 @@ Sven-Hendrik Haase,2018-Q4,0,0,0
 Sven-Hendrik Haase,2018-Q3,0,0,0
 Sven-Hendrik Haase,2018-Q2,0,0,0
 Sven-Hendrik Haase,2018-Q1,0,0,0
-Michael Reneer,2021-Q4,0,0,0
-Michael Reneer,2021-Q3,0,0,0
 Michael Reneer,2021-Q2,0,0,0
 Michael Reneer,2021-Q1,0,0,0
 Michael Reneer,2020-Q4,0,0,0
@@ -14991,8 +13117,6 @@ Michael Reneer,2018-Q4,1,0,0
 Michael Reneer,2018-Q3,0,0,0
 Michael Reneer,2018-Q2,0,0,0
 Michael Reneer,2018-Q1,0,0,0
-Anush Elangovan,2021-Q4,0,0,0
-Anush Elangovan,2021-Q3,0,0,0
 Anush Elangovan,2021-Q2,0,0,0
 Anush Elangovan,2021-Q1,0,0,0
 Anush Elangovan,2020-Q4,0,0,0
@@ -15007,8 +13131,6 @@ Anush Elangovan,2018-Q4,0,0,0
 Anush Elangovan,2018-Q3,0,0,0
 Anush Elangovan,2018-Q2,0,0,0
 Anush Elangovan,2018-Q1,0,0,0
-khaled besrour,2021-Q4,0,0,0
-khaled besrour,2021-Q3,0,0,0
 khaled besrour,2021-Q2,0,0,0
 khaled besrour,2021-Q1,0,0,0
 khaled besrour,2020-Q4,0,0,0
@@ -15023,8 +13145,6 @@ khaled besrour,2018-Q4,0,0,0
 khaled besrour,2018-Q3,0,0,0
 khaled besrour,2018-Q2,0,0,0
 khaled besrour,2018-Q1,0,0,0
-Igor Ganichev,2021-Q4,0,0,0
-Igor Ganichev,2021-Q3,0,0,0
 Igor Ganichev,2021-Q2,0,0,0
 Igor Ganichev,2021-Q1,0,0,0
 Igor Ganichev,2020-Q4,0,0,0
@@ -15039,8 +13159,6 @@ Igor Ganichev,2018-Q4,76,2844,881
 Igor Ganichev,2018-Q3,53,953,228
 Igor Ganichev,2018-Q2,84,2948,616
 Igor Ganichev,2018-Q1,32,1550,208
-Jonas Skog,2021-Q4,0,0,0
-Jonas Skog,2021-Q3,0,0,0
 Jonas Skog,2021-Q2,0,0,0
 Jonas Skog,2021-Q1,0,0,0
 Jonas Skog,2020-Q4,0,0,0
@@ -15055,8 +13173,6 @@ Jonas Skog,2018-Q4,0,0,0
 Jonas Skog,2018-Q3,0,0,0
 Jonas Skog,2018-Q2,0,0,0
 Jonas Skog,2018-Q1,0,0,0
-sunchenggen,2021-Q4,0,0,0
-sunchenggen,2021-Q3,0,0,0
 sunchenggen,2021-Q2,0,0,0
 sunchenggen,2021-Q1,0,0,0
 sunchenggen,2020-Q4,0,0,0
@@ -15071,8 +13187,6 @@ sunchenggen,2018-Q4,0,0,0
 sunchenggen,2018-Q3,0,0,0
 sunchenggen,2018-Q2,0,0,0
 sunchenggen,2018-Q1,0,0,0
-Tomohiro Ubukata,2021-Q4,0,0,0
-Tomohiro Ubukata,2021-Q3,0,0,0
 Tomohiro Ubukata,2021-Q2,0,0,0
 Tomohiro Ubukata,2021-Q1,0,0,0
 Tomohiro Ubukata,2020-Q4,0,0,0
@@ -15087,8 +13201,6 @@ Tomohiro Ubukata,2018-Q4,0,0,0
 Tomohiro Ubukata,2018-Q3,0,0,0
 Tomohiro Ubukata,2018-Q2,0,0,0
 Tomohiro Ubukata,2018-Q1,0,0,0
-Ir1d,2021-Q4,0,0,0
-Ir1d,2021-Q3,0,0,0
 Ir1d,2021-Q2,0,0,0
 Ir1d,2021-Q1,0,0,0
 Ir1d,2020-Q4,0,0,0
@@ -15103,8 +13215,6 @@ Ir1d,2018-Q4,0,0,0
 Ir1d,2018-Q3,0,0,0
 Ir1d,2018-Q2,0,0,0
 Ir1d,2018-Q1,0,0,0
-Kathy Ruan,2021-Q4,0,0,0
-Kathy Ruan,2021-Q3,0,0,0
 Kathy Ruan,2021-Q2,0,0,0
 Kathy Ruan,2021-Q1,0,0,0
 Kathy Ruan,2020-Q4,0,0,0
@@ -15119,8 +13229,6 @@ Kathy Ruan,2018-Q4,0,0,0
 Kathy Ruan,2018-Q3,0,0,0
 Kathy Ruan,2018-Q2,0,0,0
 Kathy Ruan,2018-Q1,0,0,0
-“jaketae”,2021-Q4,0,0,0
-“jaketae”,2021-Q3,0,0,0
 “jaketae”,2021-Q2,0,0,0
 “jaketae”,2021-Q1,0,0,0
 “jaketae”,2020-Q4,0,0,0
@@ -15135,8 +13243,6 @@ Kathy Ruan,2018-Q1,0,0,0
 “jaketae”,2018-Q3,0,0,0
 “jaketae”,2018-Q2,0,0,0
 “jaketae”,2018-Q1,0,0,0
-Siyavash Najafzade,2021-Q4,0,0,0
-Siyavash Najafzade,2021-Q3,0,0,0
 Siyavash Najafzade,2021-Q2,0,0,0
 Siyavash Najafzade,2021-Q1,0,0,0
 Siyavash Najafzade,2020-Q4,0,0,0
@@ -15151,8 +13257,6 @@ Siyavash Najafzade,2018-Q4,0,0,0
 Siyavash Najafzade,2018-Q3,0,0,0
 Siyavash Najafzade,2018-Q2,0,0,0
 Siyavash Najafzade,2018-Q1,0,0,0
-张志豪,2021-Q4,0,0,0
-张志豪,2021-Q3,0,0,0
 张志豪,2021-Q2,0,0,0
 张志豪,2021-Q1,0,0,0
 张志豪,2020-Q4,0,0,0
@@ -15167,8 +13271,6 @@ Siyavash Najafzade,2018-Q1,0,0,0
 张志豪,2018-Q3,0,0,0
 张志豪,2018-Q2,0,0,0
 张志豪,2018-Q1,0,0,0
-Fabio Di Domenico,2021-Q4,0,0,0
-Fabio Di Domenico,2021-Q3,0,0,0
 Fabio Di Domenico,2021-Q2,0,0,0
 Fabio Di Domenico,2021-Q1,0,0,0
 Fabio Di Domenico,2020-Q4,0,0,0
@@ -15183,8 +13285,6 @@ Fabio Di Domenico,2018-Q4,0,0,0
 Fabio Di Domenico,2018-Q3,0,0,0
 Fabio Di Domenico,2018-Q2,0,0,0
 Fabio Di Domenico,2018-Q1,0,0,0
-angusluo,2021-Q4,0,0,0
-angusluo,2021-Q3,0,0,0
 angusluo,2021-Q2,0,0,0
 angusluo,2021-Q1,0,0,0
 angusluo,2020-Q4,0,0,0
@@ -15199,8 +13299,6 @@ angusluo,2018-Q4,0,0,0
 angusluo,2018-Q3,0,0,0
 angusluo,2018-Q2,0,0,0
 angusluo,2018-Q1,0,0,0
-Oleg Rybakov,2021-Q4,0,0,0
-Oleg Rybakov,2021-Q3,0,0,0
 Oleg Rybakov,2021-Q2,0,0,0
 Oleg Rybakov,2021-Q1,0,0,0
 Oleg Rybakov,2020-Q4,0,0,0
@@ -15215,8 +13313,6 @@ Oleg Rybakov,2018-Q4,0,0,0
 Oleg Rybakov,2018-Q3,0,0,0
 Oleg Rybakov,2018-Q2,0,0,0
 Oleg Rybakov,2018-Q1,0,0,0
-Nick Morgan,2021-Q4,0,0,0
-Nick Morgan,2021-Q3,0,0,0
 Nick Morgan,2021-Q2,0,0,0
 Nick Morgan,2021-Q1,0,0,0
 Nick Morgan,2020-Q4,0,0,0
@@ -15231,8 +13327,6 @@ Nick Morgan,2018-Q4,0,0,0
 Nick Morgan,2018-Q3,0,0,0
 Nick Morgan,2018-Q2,0,0,0
 Nick Morgan,2018-Q1,0,0,0
-Guy David,2021-Q4,0,0,0
-Guy David,2021-Q3,0,0,0
 Guy David,2021-Q2,0,0,0
 Guy David,2021-Q1,0,0,0
 Guy David,2020-Q4,0,0,0
@@ -15247,8 +13341,6 @@ Guy David,2018-Q4,0,0,0
 Guy David,2018-Q3,0,0,0
 Guy David,2018-Q2,0,0,0
 Guy David,2018-Q1,0,0,0
-Georgios Pinitas,2021-Q4,0,0,0
-Georgios Pinitas,2021-Q3,0,0,0
 Georgios Pinitas,2021-Q2,0,0,0
 Georgios Pinitas,2021-Q1,0,0,0
 Georgios Pinitas,2020-Q4,0,0,0
@@ -15263,8 +13355,6 @@ Georgios Pinitas,2018-Q4,0,0,0
 Georgios Pinitas,2018-Q3,0,0,0
 Georgios Pinitas,2018-Q2,0,0,0
 Georgios Pinitas,2018-Q1,0,0,0
-Vojtech Bardiovsky,2021-Q4,0,0,0
-Vojtech Bardiovsky,2021-Q3,0,0,0
 Vojtech Bardiovsky,2021-Q2,0,0,0
 Vojtech Bardiovsky,2021-Q1,0,0,0
 Vojtech Bardiovsky,2020-Q4,0,0,0
@@ -15279,8 +13369,6 @@ Vojtech Bardiovsky,2018-Q4,0,0,0
 Vojtech Bardiovsky,2018-Q3,0,0,0
 Vojtech Bardiovsky,2018-Q2,0,0,0
 Vojtech Bardiovsky,2018-Q1,0,0,0
-Rajan Singh,2021-Q4,0,0,0
-Rajan Singh,2021-Q3,0,0,0
 Rajan Singh,2021-Q2,0,0,0
 Rajan Singh,2021-Q1,0,0,0
 Rajan Singh,2020-Q4,0,0,0
@@ -15295,8 +13383,6 @@ Rajan Singh,2018-Q4,0,0,0
 Rajan Singh,2018-Q3,0,0,0
 Rajan Singh,2018-Q2,0,0,0
 Rajan Singh,2018-Q1,0,0,0
-Raziel Alvarez,2021-Q4,0,0,0
-Raziel Alvarez,2021-Q3,0,0,0
 Raziel Alvarez,2021-Q2,0,0,0
 Raziel Alvarez,2021-Q1,0,0,0
 Raziel Alvarez,2020-Q4,0,0,0
@@ -15311,8 +13397,6 @@ Raziel Alvarez,2018-Q4,0,0,0
 Raziel Alvarez,2018-Q3,0,0,0
 Raziel Alvarez,2018-Q2,0,0,0
 Raziel Alvarez,2018-Q1,0,0,0
-Martin Jul,2021-Q4,0,0,0
-Martin Jul,2021-Q3,0,0,0
 Martin Jul,2021-Q2,0,0,0
 Martin Jul,2021-Q1,0,0,0
 Martin Jul,2020-Q4,0,0,0
@@ -15327,8 +13411,6 @@ Martin Jul,2018-Q4,0,0,0
 Martin Jul,2018-Q3,0,0,0
 Martin Jul,2018-Q2,0,0,0
 Martin Jul,2018-Q1,0,0,0
-vijayphoenix,2021-Q4,0,0,0
-vijayphoenix,2021-Q3,0,0,0
 vijayphoenix,2021-Q2,0,0,0
 vijayphoenix,2021-Q1,0,0,0
 vijayphoenix,2020-Q4,0,0,0
@@ -15343,8 +13425,6 @@ vijayphoenix,2018-Q4,0,0,0
 vijayphoenix,2018-Q3,0,0,0
 vijayphoenix,2018-Q2,0,0,0
 vijayphoenix,2018-Q1,0,0,0
-Mokke Meguru,2021-Q4,0,0,0
-Mokke Meguru,2021-Q3,0,0,0
 Mokke Meguru,2021-Q2,0,0,0
 Mokke Meguru,2021-Q1,0,0,0
 Mokke Meguru,2020-Q4,0,0,0
@@ -15359,8 +13439,6 @@ Mokke Meguru,2018-Q4,0,0,0
 Mokke Meguru,2018-Q3,0,0,0
 Mokke Meguru,2018-Q2,0,0,0
 Mokke Meguru,2018-Q1,0,0,0
-Michael Käufl,2021-Q4,0,0,0
-Michael Käufl,2021-Q3,0,0,0
 Michael Käufl,2021-Q2,0,0,0
 Michael Käufl,2021-Q1,0,0,0
 Michael Käufl,2020-Q4,0,0,0
@@ -15375,8 +13453,6 @@ Michael Käufl,2018-Q4,0,0,0
 Michael Käufl,2018-Q3,0,0,0
 Michael Käufl,2018-Q2,0,0,0
 Michael Käufl,2018-Q1,0,0,0
-Ruan Kunliang,2021-Q4,0,0,0
-Ruan Kunliang,2021-Q3,0,0,0
 Ruan Kunliang,2021-Q2,0,0,0
 Ruan Kunliang,2021-Q1,0,0,0
 Ruan Kunliang,2020-Q4,0,0,0
@@ -15391,8 +13467,6 @@ Ruan Kunliang,2018-Q4,0,0,0
 Ruan Kunliang,2018-Q3,0,0,0
 Ruan Kunliang,2018-Q2,0,0,0
 Ruan Kunliang,2018-Q1,0,0,0
-Harald Husum,2021-Q4,0,0,0
-Harald Husum,2021-Q3,0,0,0
 Harald Husum,2021-Q2,0,0,0
 Harald Husum,2021-Q1,0,0,0
 Harald Husum,2020-Q4,0,0,0
@@ -15407,8 +13481,6 @@ Harald Husum,2018-Q4,0,0,0
 Harald Husum,2018-Q3,0,0,0
 Harald Husum,2018-Q2,1,10,7
 Harald Husum,2018-Q1,1,20,6
-Dayeong Lee,2021-Q4,0,0,0
-Dayeong Lee,2021-Q3,0,0,0
 Dayeong Lee,2021-Q2,0,0,0
 Dayeong Lee,2021-Q1,0,0,0
 Dayeong Lee,2020-Q4,0,0,0
@@ -15423,8 +13495,6 @@ Dayeong Lee,2018-Q4,0,0,0
 Dayeong Lee,2018-Q3,0,0,0
 Dayeong Lee,2018-Q2,0,0,0
 Dayeong Lee,2018-Q1,0,0,0
-tigertang,2021-Q4,0,0,0
-tigertang,2021-Q3,0,0,0
 tigertang,2021-Q2,0,0,0
 tigertang,2021-Q1,0,0,0
 tigertang,2020-Q4,0,0,0
@@ -15439,8 +13509,6 @@ tigertang,2018-Q4,0,0,0
 tigertang,2018-Q3,0,0,0
 tigertang,2018-Q2,0,0,0
 tigertang,2018-Q1,0,0,0
-ayushmankumar7,2021-Q4,0,0,0
-ayushmankumar7,2021-Q3,0,0,0
 ayushmankumar7,2021-Q2,0,0,0
 ayushmankumar7,2021-Q1,0,0,0
 ayushmankumar7,2020-Q4,0,0,0
@@ -15455,8 +13523,6 @@ ayushmankumar7,2018-Q4,0,0,0
 ayushmankumar7,2018-Q3,0,0,0
 ayushmankumar7,2018-Q2,0,0,0
 ayushmankumar7,2018-Q1,0,0,0
-jayanth,2021-Q4,0,0,0
-jayanth,2021-Q3,0,0,0
 jayanth,2021-Q2,0,0,0
 jayanth,2021-Q1,0,0,0
 jayanth,2020-Q4,0,0,0
@@ -15471,8 +13537,6 @@ jayanth,2018-Q4,0,0,0
 jayanth,2018-Q3,0,0,0
 jayanth,2018-Q2,0,0,0
 jayanth,2018-Q1,0,0,0
-Giuseppe Rossini,2021-Q4,0,0,0
-Giuseppe Rossini,2021-Q3,0,0,0
 Giuseppe Rossini,2021-Q2,0,0,0
 Giuseppe Rossini,2021-Q1,0,0,0
 Giuseppe Rossini,2020-Q4,0,0,0
@@ -15487,8 +13551,6 @@ Giuseppe Rossini,2018-Q4,0,0,0
 Giuseppe Rossini,2018-Q3,0,0,0
 Giuseppe Rossini,2018-Q2,0,0,0
 Giuseppe Rossini,2018-Q1,0,0,0
-Haoyu Wu,2021-Q4,0,0,0
-Haoyu Wu,2021-Q3,0,0,0
 Haoyu Wu,2021-Q2,0,0,0
 Haoyu Wu,2021-Q1,0,0,0
 Haoyu Wu,2020-Q4,0,0,0
@@ -15503,8 +13565,6 @@ Haoyu Wu,2018-Q4,0,0,0
 Haoyu Wu,2018-Q3,0,0,0
 Haoyu Wu,2018-Q2,0,0,0
 Haoyu Wu,2018-Q1,0,0,0
-sunway513,2021-Q4,0,0,0
-sunway513,2021-Q3,0,0,0
 sunway513,2021-Q2,0,0,0
 sunway513,2021-Q1,0,0,0
 sunway513,2020-Q4,0,0,0
@@ -15519,8 +13579,6 @@ sunway513,2018-Q4,0,0,0
 sunway513,2018-Q3,0,0,0
 sunway513,2018-Q2,0,0,0
 sunway513,2018-Q1,0,0,0
-Alex Hoffman,2021-Q4,0,0,0
-Alex Hoffman,2021-Q3,0,0,0
 Alex Hoffman,2021-Q2,0,0,0
 Alex Hoffman,2021-Q1,0,0,0
 Alex Hoffman,2020-Q4,0,0,0
@@ -15535,8 +13593,6 @@ Alex Hoffman,2018-Q4,0,0,0
 Alex Hoffman,2018-Q3,0,0,0
 Alex Hoffman,2018-Q2,0,0,0
 Alex Hoffman,2018-Q1,0,0,0
-Yanping Huang,2021-Q4,0,0,0
-Yanping Huang,2021-Q3,0,0,0
 Yanping Huang,2021-Q2,0,0,0
 Yanping Huang,2021-Q1,0,0,0
 Yanping Huang,2020-Q4,0,0,0
@@ -15551,8 +13607,6 @@ Yanping Huang,2018-Q4,0,0,0
 Yanping Huang,2018-Q3,0,0,0
 Yanping Huang,2018-Q2,1,2,3
 Yanping Huang,2018-Q1,0,0,0
-OverLordGoldDragon,2021-Q4,0,0,0
-OverLordGoldDragon,2021-Q3,0,0,0
 OverLordGoldDragon,2021-Q2,0,0,0
 OverLordGoldDragon,2021-Q1,0,0,0
 OverLordGoldDragon,2020-Q4,0,0,0
@@ -15567,8 +13621,6 @@ OverLordGoldDragon,2018-Q4,0,0,0
 OverLordGoldDragon,2018-Q3,0,0,0
 OverLordGoldDragon,2018-Q2,0,0,0
 OverLordGoldDragon,2018-Q1,0,0,0
-lyonguyen8697,2021-Q4,0,0,0
-lyonguyen8697,2021-Q3,0,0,0
 lyonguyen8697,2021-Q2,0,0,0
 lyonguyen8697,2021-Q1,0,0,0
 lyonguyen8697,2020-Q4,0,0,0
@@ -15583,8 +13635,6 @@ lyonguyen8697,2018-Q4,0,0,0
 lyonguyen8697,2018-Q3,0,0,0
 lyonguyen8697,2018-Q2,0,0,0
 lyonguyen8697,2018-Q1,0,0,0
-Clayne Robison,2021-Q4,0,0,0
-Clayne Robison,2021-Q3,0,0,0
 Clayne Robison,2021-Q2,0,0,0
 Clayne Robison,2021-Q1,0,0,0
 Clayne Robison,2020-Q4,0,0,0
@@ -15599,8 +13649,6 @@ Clayne Robison,2018-Q4,15,194,77
 Clayne Robison,2018-Q3,21,394,105
 Clayne Robison,2018-Q2,15,488,136
 Clayne Robison,2018-Q1,4,25,18
-jojimonv,2021-Q4,0,0,0
-jojimonv,2021-Q3,0,0,0
 jojimonv,2021-Q2,0,0,0
 jojimonv,2021-Q1,0,0,0
 jojimonv,2020-Q4,0,0,0
@@ -15615,8 +13663,6 @@ jojimonv,2018-Q4,0,0,0
 jojimonv,2018-Q3,0,0,0
 jojimonv,2018-Q2,0,0,0
 jojimonv,2018-Q1,0,0,0
-aaronhma,2021-Q4,0,0,0
-aaronhma,2021-Q3,0,0,0
 aaronhma,2021-Q2,0,0,0
 aaronhma,2021-Q1,0,0,0
 aaronhma,2020-Q4,0,0,0
@@ -15631,8 +13677,6 @@ aaronhma,2018-Q4,0,0,0
 aaronhma,2018-Q3,0,0,0
 aaronhma,2018-Q2,0,0,0
 aaronhma,2018-Q1,0,0,0
-jojivk-intel-nervana,2021-Q4,0,0,0
-jojivk-intel-nervana,2021-Q3,0,0,0
 jojivk-intel-nervana,2021-Q2,0,0,0
 jojivk-intel-nervana,2021-Q1,0,0,0
 jojivk-intel-nervana,2020-Q4,0,0,0
@@ -15647,8 +13691,6 @@ jojivk-intel-nervana,2018-Q4,0,0,0
 jojivk-intel-nervana,2018-Q3,0,0,0
 jojivk-intel-nervana,2018-Q2,0,0,0
 jojivk-intel-nervana,2018-Q1,0,0,0
-jmsmdy,2021-Q4,0,0,0
-jmsmdy,2021-Q3,0,0,0
 jmsmdy,2021-Q2,0,0,0
 jmsmdy,2021-Q1,0,0,0
 jmsmdy,2020-Q4,0,0,0
@@ -15663,8 +13705,6 @@ jmsmdy,2018-Q4,0,0,0
 jmsmdy,2018-Q3,0,0,0
 jmsmdy,2018-Q2,0,0,0
 jmsmdy,2018-Q1,0,0,0
-Brian Atkinson,2021-Q4,0,0,0
-Brian Atkinson,2021-Q3,0,0,0
 Brian Atkinson,2021-Q2,0,0,0
 Brian Atkinson,2021-Q1,0,0,0
 Brian Atkinson,2020-Q4,0,0,0
@@ -15679,8 +13719,6 @@ Brian Atkinson,2018-Q4,0,0,0
 Brian Atkinson,2018-Q3,0,0,0
 Brian Atkinson,2018-Q2,0,0,0
 Brian Atkinson,2018-Q1,0,0,0
-Jinzhe Zeng,2021-Q4,0,0,0
-Jinzhe Zeng,2021-Q3,0,0,0
 Jinzhe Zeng,2021-Q2,0,0,0
 Jinzhe Zeng,2021-Q1,0,0,0
 Jinzhe Zeng,2020-Q4,0,0,0
@@ -15695,8 +13733,6 @@ Jinzhe Zeng,2018-Q4,0,0,0
 Jinzhe Zeng,2018-Q3,0,0,0
 Jinzhe Zeng,2018-Q2,0,0,0
 Jinzhe Zeng,2018-Q1,0,0,0
-Alan Yee,2021-Q4,0,0,0
-Alan Yee,2021-Q3,0,0,0
 Alan Yee,2021-Q2,0,0,0
 Alan Yee,2021-Q1,0,0,0
 Alan Yee,2020-Q4,0,0,0
@@ -15711,8 +13747,6 @@ Alan Yee,2018-Q4,0,0,0
 Alan Yee,2018-Q3,0,0,0
 Alan Yee,2018-Q2,1,21,16
 Alan Yee,2018-Q1,1,0,0
-madisetti,2021-Q4,0,0,0
-madisetti,2021-Q3,0,0,0
 madisetti,2021-Q2,0,0,0
 madisetti,2021-Q1,0,0,0
 madisetti,2020-Q4,0,0,0
@@ -15727,8 +13761,6 @@ madisetti,2018-Q4,0,0,0
 madisetti,2018-Q3,0,0,0
 madisetti,2018-Q2,0,0,0
 madisetti,2018-Q1,0,0,0
-Zongwei Zhou,2021-Q4,0,0,0
-Zongwei Zhou,2021-Q3,0,0,0
 Zongwei Zhou,2021-Q2,0,0,0
 Zongwei Zhou,2021-Q1,0,0,0
 Zongwei Zhou,2020-Q4,0,0,0
@@ -15743,8 +13775,6 @@ Zongwei Zhou,2018-Q4,0,0,0
 Zongwei Zhou,2018-Q3,0,0,0
 Zongwei Zhou,2018-Q2,0,0,0
 Zongwei Zhou,2018-Q1,0,0,0
-JaehunRyu,2021-Q4,0,0,0
-JaehunRyu,2021-Q3,0,0,0
 JaehunRyu,2021-Q2,0,0,0
 JaehunRyu,2021-Q1,0,0,0
 JaehunRyu,2020-Q4,0,0,0
@@ -15759,8 +13789,6 @@ JaehunRyu,2018-Q4,0,0,0
 JaehunRyu,2018-Q3,0,0,0
 JaehunRyu,2018-Q2,0,0,0
 JaehunRyu,2018-Q1,0,0,0
-dothinking,2021-Q4,0,0,0
-dothinking,2021-Q3,0,0,0
 dothinking,2021-Q2,0,0,0
 dothinking,2021-Q1,0,0,0
 dothinking,2020-Q4,0,0,0
@@ -15775,8 +13803,6 @@ dothinking,2018-Q4,0,0,0
 dothinking,2018-Q3,0,0,0
 dothinking,2018-Q2,0,0,0
 dothinking,2018-Q1,0,0,0
-MoussaMM,2021-Q4,0,0,0
-MoussaMM,2021-Q3,0,0,0
 MoussaMM,2021-Q2,0,0,0
 MoussaMM,2021-Q1,0,0,0
 MoussaMM,2020-Q4,0,0,0
@@ -15791,8 +13817,6 @@ MoussaMM,2018-Q4,0,0,0
 MoussaMM,2018-Q3,0,0,0
 MoussaMM,2018-Q2,0,0,0
 MoussaMM,2018-Q1,0,0,0
-pingsutw,2021-Q4,0,0,0
-pingsutw,2021-Q3,0,0,0
 pingsutw,2021-Q2,0,0,0
 pingsutw,2021-Q1,0,0,0
 pingsutw,2020-Q4,0,0,0
@@ -15807,8 +13831,6 @@ pingsutw,2018-Q4,0,0,0
 pingsutw,2018-Q3,0,0,0
 pingsutw,2018-Q2,0,0,0
 pingsutw,2018-Q1,0,0,0
-Kwabena W. Agyeman,2021-Q4,0,0,0
-Kwabena W. Agyeman,2021-Q3,0,0,0
 Kwabena W. Agyeman,2021-Q2,0,0,0
 Kwabena W. Agyeman,2021-Q1,0,0,0
 Kwabena W. Agyeman,2020-Q4,0,0,0
@@ -15823,8 +13845,6 @@ Kwabena W. Agyeman,2018-Q4,0,0,0
 Kwabena W. Agyeman,2018-Q3,0,0,0
 Kwabena W. Agyeman,2018-Q2,0,0,0
 Kwabena W. Agyeman,2018-Q1,0,0,0
-nikochiko,2021-Q4,0,0,0
-nikochiko,2021-Q3,0,0,0
 nikochiko,2021-Q2,0,0,0
 nikochiko,2021-Q1,0,0,0
 nikochiko,2020-Q4,0,0,0
@@ -15839,8 +13859,6 @@ nikochiko,2018-Q4,0,0,0
 nikochiko,2018-Q3,0,0,0
 nikochiko,2018-Q2,0,0,0
 nikochiko,2018-Q1,0,0,0
-Benjamin Gaillard,2021-Q4,0,0,0
-Benjamin Gaillard,2021-Q3,0,0,0
 Benjamin Gaillard,2021-Q2,0,0,0
 Benjamin Gaillard,2021-Q1,0,0,0
 Benjamin Gaillard,2020-Q4,0,0,0
@@ -15855,8 +13873,6 @@ Benjamin Gaillard,2018-Q4,0,0,0
 Benjamin Gaillard,2018-Q3,0,0,0
 Benjamin Gaillard,2018-Q2,0,0,0
 Benjamin Gaillard,2018-Q1,0,0,0
-kurileo,2021-Q4,0,0,0
-kurileo,2021-Q3,0,0,0
 kurileo,2021-Q2,0,0,0
 kurileo,2021-Q1,0,0,0
 kurileo,2020-Q4,0,0,0
@@ -15871,8 +13887,6 @@ kurileo,2018-Q4,0,0,0
 kurileo,2018-Q3,0,0,0
 kurileo,2018-Q2,0,0,0
 kurileo,2018-Q1,0,0,0
-Pallavi G,2021-Q4,0,0,0
-Pallavi G,2021-Q3,0,0,0
 Pallavi G,2021-Q2,0,0,0
 Pallavi G,2021-Q1,0,0,0
 Pallavi G,2020-Q4,0,0,0
@@ -15887,8 +13901,6 @@ Pallavi G,2018-Q4,0,0,0
 Pallavi G,2018-Q3,0,0,0
 Pallavi G,2018-Q2,0,0,0
 Pallavi G,2018-Q1,0,0,0
-Youlong Cheng,2021-Q4,0,0,0
-Youlong Cheng,2021-Q3,0,0,0
 Youlong Cheng,2021-Q2,0,0,0
 Youlong Cheng,2021-Q1,0,0,0
 Youlong Cheng,2020-Q4,0,0,0
@@ -15903,8 +13915,6 @@ Youlong Cheng,2018-Q4,4,51,11
 Youlong Cheng,2018-Q3,47,1176,229
 Youlong Cheng,2018-Q2,15,796,33
 Youlong Cheng,2018-Q1,0,0,0
-Tom Forbes,2021-Q4,0,0,0
-Tom Forbes,2021-Q3,0,0,0
 Tom Forbes,2021-Q2,0,0,0
 Tom Forbes,2021-Q1,0,0,0
 Tom Forbes,2020-Q4,0,0,0
@@ -15919,8 +13929,6 @@ Tom Forbes,2018-Q4,0,0,0
 Tom Forbes,2018-Q3,0,0,0
 Tom Forbes,2018-Q2,0,0,0
 Tom Forbes,2018-Q1,0,0,0
-Officium,2021-Q4,0,0,0
-Officium,2021-Q3,0,0,0
 Officium,2021-Q2,0,0,0
 Officium,2021-Q1,0,0,0
 Officium,2020-Q4,0,0,0
@@ -15935,8 +13943,6 @@ Officium,2018-Q4,0,0,0
 Officium,2018-Q3,0,0,0
 Officium,2018-Q2,0,0,0
 Officium,2018-Q1,0,0,0
-Vincent Abriou,2021-Q4,0,0,0
-Vincent Abriou,2021-Q3,0,0,0
 Vincent Abriou,2021-Q2,0,0,0
 Vincent Abriou,2021-Q1,0,0,0
 Vincent Abriou,2020-Q4,0,0,0
@@ -15951,8 +13957,6 @@ Vincent Abriou,2018-Q4,0,0,0
 Vincent Abriou,2018-Q3,0,0,0
 Vincent Abriou,2018-Q2,0,0,0
 Vincent Abriou,2018-Q1,0,0,0
-William D. Irons,2021-Q4,0,0,0
-William D. Irons,2021-Q3,0,0,0
 William D. Irons,2021-Q2,0,0,0
 William D. Irons,2021-Q1,0,0,0
 William D. Irons,2020-Q4,0,0,0
@@ -15967,8 +13971,6 @@ William D. Irons,2018-Q4,3,11,6
 William D. Irons,2018-Q3,39,405,221
 William D. Irons,2018-Q2,17,195,16
 William D. Irons,2018-Q1,0,0,0
-Aditya Patwardhan,2021-Q4,0,0,0
-Aditya Patwardhan,2021-Q3,0,0,0
 Aditya Patwardhan,2021-Q2,0,0,0
 Aditya Patwardhan,2021-Q1,0,0,0
 Aditya Patwardhan,2020-Q4,0,0,0
@@ -15983,8 +13985,6 @@ Aditya Patwardhan,2018-Q4,0,0,0
 Aditya Patwardhan,2018-Q3,0,0,0
 Aditya Patwardhan,2018-Q2,0,0,0
 Aditya Patwardhan,2018-Q1,0,0,0
-Frédéric Rechtenstein,2021-Q4,0,0,0
-Frédéric Rechtenstein,2021-Q3,0,0,0
 Frédéric Rechtenstein,2021-Q2,0,0,0
 Frédéric Rechtenstein,2021-Q1,0,0,0
 Frédéric Rechtenstein,2020-Q4,0,0,0
@@ -15999,8 +13999,6 @@ Frédéric Rechtenstein,2018-Q4,0,0,0
 Frédéric Rechtenstein,2018-Q3,0,0,0
 Frédéric Rechtenstein,2018-Q2,0,0,0
 Frédéric Rechtenstein,2018-Q1,0,0,0
-TengLu,2021-Q4,0,0,0
-TengLu,2021-Q3,0,0,0
 TengLu,2021-Q2,0,0,0
 TengLu,2021-Q1,0,0,0
 TengLu,2020-Q4,0,0,0
@@ -16015,8 +14013,6 @@ TengLu,2018-Q4,0,0,0
 TengLu,2018-Q3,0,0,0
 TengLu,2018-Q2,0,0,0
 TengLu,2018-Q1,0,0,0
-FAIJUL,2021-Q4,0,0,0
-FAIJUL,2021-Q3,0,0,0
 FAIJUL,2021-Q2,0,0,0
 FAIJUL,2021-Q1,0,0,0
 FAIJUL,2020-Q4,0,0,0
@@ -16031,8 +14027,6 @@ FAIJUL,2018-Q4,0,0,0
 FAIJUL,2018-Q3,0,0,0
 FAIJUL,2018-Q2,0,0,0
 FAIJUL,2018-Q1,0,0,0
-Judd,2021-Q4,0,0,0
-Judd,2021-Q3,0,0,0
 Judd,2021-Q2,0,0,0
 Judd,2021-Q1,0,0,0
 Judd,2020-Q4,0,0,0
@@ -16047,8 +14041,6 @@ Judd,2018-Q4,0,0,0
 Judd,2018-Q3,0,0,0
 Judd,2018-Q2,0,0,0
 Judd,2018-Q1,0,0,0
-Timon Van Overveldt,2021-Q4,0,0,0
-Timon Van Overveldt,2021-Q3,0,0,0
 Timon Van Overveldt,2021-Q2,0,0,0
 Timon Van Overveldt,2021-Q1,0,0,0
 Timon Van Overveldt,2020-Q4,0,0,0
@@ -16063,8 +14055,6 @@ Timon Van Overveldt,2018-Q4,0,0,0
 Timon Van Overveldt,2018-Q3,2,23,0
 Timon Van Overveldt,2018-Q2,1,2,0
 Timon Van Overveldt,2018-Q1,0,0,0
-vladbataev,2021-Q4,0,0,0
-vladbataev,2021-Q3,0,0,0
 vladbataev,2021-Q2,0,0,0
 vladbataev,2021-Q1,0,0,0
 vladbataev,2020-Q4,0,0,0
@@ -16079,8 +14069,6 @@ vladbataev,2018-Q4,0,0,0
 vladbataev,2018-Q3,0,0,0
 vladbataev,2018-Q2,0,0,0
 vladbataev,2018-Q1,0,0,0
-Mitchell Vitez,2021-Q4,0,0,0
-Mitchell Vitez,2021-Q3,0,0,0
 Mitchell Vitez,2021-Q2,0,0,0
 Mitchell Vitez,2021-Q1,0,0,0
 Mitchell Vitez,2020-Q4,0,0,0
@@ -16095,8 +14083,6 @@ Mitchell Vitez,2018-Q4,0,0,0
 Mitchell Vitez,2018-Q3,0,0,0
 Mitchell Vitez,2018-Q2,0,0,0
 Mitchell Vitez,2018-Q1,0,0,0
-Puneeth K,2021-Q4,0,0,0
-Puneeth K,2021-Q3,0,0,0
 Puneeth K,2021-Q2,0,0,0
 Puneeth K,2021-Q1,0,0,0
 Puneeth K,2020-Q4,0,0,0
@@ -16111,8 +14097,6 @@ Puneeth K,2018-Q4,0,0,0
 Puneeth K,2018-Q3,0,0,0
 Puneeth K,2018-Q2,0,0,0
 Puneeth K,2018-Q1,0,0,0
-David Rees,2021-Q4,0,0,0
-David Rees,2021-Q3,0,0,0
 David Rees,2021-Q2,0,0,0
 David Rees,2021-Q1,0,0,0
 David Rees,2020-Q4,0,0,0
@@ -16127,8 +14111,6 @@ David Rees,2018-Q4,1,0,0
 David Rees,2018-Q3,0,0,0
 David Rees,2018-Q2,0,0,0
 David Rees,2018-Q1,0,0,0
-ga,2021-Q4,0,0,0
-ga,2021-Q3,0,0,0
 ga,2021-Q2,0,0,0
 ga,2021-Q1,0,0,0
 ga,2020-Q4,0,0,0
@@ -16143,8 +14125,6 @@ ga,2018-Q4,0,0,0
 ga,2018-Q3,0,0,0
 ga,2018-Q2,0,0,0
 ga,2018-Q1,0,0,0
-Tom Carchrae,2021-Q4,0,0,0
-Tom Carchrae,2021-Q3,0,0,0
 Tom Carchrae,2021-Q2,0,0,0
 Tom Carchrae,2021-Q1,0,0,0
 Tom Carchrae,2020-Q4,0,0,0
@@ -16159,8 +14139,6 @@ Tom Carchrae,2018-Q4,0,0,0
 Tom Carchrae,2018-Q3,0,0,0
 Tom Carchrae,2018-Q2,0,0,0
 Tom Carchrae,2018-Q1,0,0,0
-372046933,2021-Q4,0,0,0
-372046933,2021-Q3,0,0,0
 372046933,2021-Q2,0,0,0
 372046933,2021-Q1,0,0,0
 372046933,2020-Q4,0,0,0
@@ -16175,8 +14153,6 @@ Tom Carchrae,2018-Q1,0,0,0
 372046933,2018-Q3,0,0,0
 372046933,2018-Q2,0,0,0
 372046933,2018-Q1,0,0,0
-MichaelKonobeev,2021-Q4,0,0,0
-MichaelKonobeev,2021-Q3,0,0,0
 MichaelKonobeev,2021-Q2,0,0,0
 MichaelKonobeev,2021-Q1,0,0,0
 MichaelKonobeev,2020-Q4,0,0,0
@@ -16191,8 +14167,6 @@ MichaelKonobeev,2018-Q4,0,0,0
 MichaelKonobeev,2018-Q3,0,0,0
 MichaelKonobeev,2018-Q2,0,0,0
 MichaelKonobeev,2018-Q1,0,0,0
-PhilipMay,2021-Q4,0,0,0
-PhilipMay,2021-Q3,0,0,0
 PhilipMay,2021-Q2,0,0,0
 PhilipMay,2021-Q1,0,0,0
 PhilipMay,2020-Q4,0,0,0
@@ -16207,8 +14181,6 @@ PhilipMay,2018-Q4,0,0,0
 PhilipMay,2018-Q3,0,0,0
 PhilipMay,2018-Q2,0,0,0
 PhilipMay,2018-Q1,0,0,0
-exfalso,2021-Q4,0,0,0
-exfalso,2021-Q3,0,0,0
 exfalso,2021-Q2,0,0,0
 exfalso,2021-Q1,0,0,0
 exfalso,2020-Q4,0,0,0
@@ -16223,8 +14195,6 @@ exfalso,2018-Q4,0,0,0
 exfalso,2018-Q3,0,0,0
 exfalso,2018-Q2,0,0,0
 exfalso,2018-Q1,0,0,0
-Fei Hu,2021-Q4,0,0,0
-Fei Hu,2021-Q3,0,0,0
 Fei Hu,2021-Q2,0,0,0
 Fei Hu,2021-Q1,0,0,0
 Fei Hu,2020-Q4,0,0,0
@@ -16239,8 +14209,6 @@ Fei Hu,2018-Q4,70,585,347
 Fei Hu,2018-Q3,70,1201,520
 Fei Hu,2018-Q2,0,0,0
 Fei Hu,2018-Q1,0,0,0
-punndcoder28,2021-Q4,0,0,0
-punndcoder28,2021-Q3,0,0,0
 punndcoder28,2021-Q2,0,0,0
 punndcoder28,2021-Q1,0,0,0
 punndcoder28,2020-Q4,0,0,0
@@ -16255,8 +14223,6 @@ punndcoder28,2018-Q4,0,0,0
 punndcoder28,2018-Q3,0,0,0
 punndcoder28,2018-Q2,0,0,0
 punndcoder28,2018-Q1,0,0,0
-Taylor Robie,2021-Q4,0,0,0
-Taylor Robie,2021-Q3,0,0,0
 Taylor Robie,2021-Q2,0,0,0
 Taylor Robie,2021-Q1,0,0,0
 Taylor Robie,2020-Q4,0,0,0
@@ -16271,8 +14237,6 @@ Taylor Robie,2018-Q4,14,65,21
 Taylor Robie,2018-Q3,0,0,0
 Taylor Robie,2018-Q2,1,0,0
 Taylor Robie,2018-Q1,0,0,0
-Jeff Daily,2021-Q4,0,0,0
-Jeff Daily,2021-Q3,0,0,0
 Jeff Daily,2021-Q2,0,0,0
 Jeff Daily,2021-Q1,0,0,0
 Jeff Daily,2020-Q4,0,0,0
@@ -16287,8 +14251,6 @@ Jeff Daily,2018-Q4,0,0,0
 Jeff Daily,2018-Q3,0,0,0
 Jeff Daily,2018-Q2,0,0,0
 Jeff Daily,2018-Q1,0,0,0
-Meng Zhang,2021-Q4,0,0,0
-Meng Zhang,2021-Q3,0,0,0
 Meng Zhang,2021-Q2,0,0,0
 Meng Zhang,2021-Q1,0,0,0
 Meng Zhang,2020-Q4,0,0,0
@@ -16303,8 +14265,6 @@ Meng Zhang,2018-Q4,0,0,0
 Meng Zhang,2018-Q3,0,0,0
 Meng Zhang,2018-Q2,0,0,0
 Meng Zhang,2018-Q1,0,0,0
-Elton Yang,2021-Q4,0,0,0
-Elton Yang,2021-Q3,0,0,0
 Elton Yang,2021-Q2,0,0,0
 Elton Yang,2021-Q1,0,0,0
 Elton Yang,2020-Q4,0,0,0
@@ -16319,8 +14279,6 @@ Elton Yang,2018-Q4,0,0,0
 Elton Yang,2018-Q3,0,0,0
 Elton Yang,2018-Q2,0,0,0
 Elton Yang,2018-Q1,0,0,0
-srinivasan.narayanamoorthy,2021-Q4,0,0,0
-srinivasan.narayanamoorthy,2021-Q3,0,0,0
 srinivasan.narayanamoorthy,2021-Q2,0,0,0
 srinivasan.narayanamoorthy,2021-Q1,0,0,0
 srinivasan.narayanamoorthy,2020-Q4,0,0,0
@@ -16335,8 +14293,6 @@ srinivasan.narayanamoorthy,2018-Q4,0,0,0
 srinivasan.narayanamoorthy,2018-Q3,0,0,0
 srinivasan.narayanamoorthy,2018-Q2,0,0,0
 srinivasan.narayanamoorthy,2018-Q1,0,0,0
-Kevin Hanselman,2021-Q4,0,0,0
-Kevin Hanselman,2021-Q3,0,0,0
 Kevin Hanselman,2021-Q2,0,0,0
 Kevin Hanselman,2021-Q1,0,0,0
 Kevin Hanselman,2020-Q4,0,0,0
@@ -16351,8 +14307,6 @@ Kevin Hanselman,2018-Q4,0,0,0
 Kevin Hanselman,2018-Q3,0,0,0
 Kevin Hanselman,2018-Q2,0,0,0
 Kevin Hanselman,2018-Q1,0,0,0
-Stephan Uphoff,2021-Q4,0,0,0
-Stephan Uphoff,2021-Q3,0,0,0
 Stephan Uphoff,2021-Q2,0,0,0
 Stephan Uphoff,2021-Q1,0,0,0
 Stephan Uphoff,2020-Q4,0,0,0
@@ -16367,8 +14321,6 @@ Stephan Uphoff,2018-Q4,0,0,0
 Stephan Uphoff,2018-Q3,0,0,0
 Stephan Uphoff,2018-Q2,0,0,0
 Stephan Uphoff,2018-Q1,0,0,0
-Anthony Barbier,2021-Q4,0,0,0
-Anthony Barbier,2021-Q3,0,0,0
 Anthony Barbier,2021-Q2,0,0,0
 Anthony Barbier,2021-Q1,0,0,0
 Anthony Barbier,2020-Q4,0,0,0
@@ -16383,8 +14335,6 @@ Anthony Barbier,2018-Q4,0,0,0
 Anthony Barbier,2018-Q3,0,0,0
 Anthony Barbier,2018-Q2,0,0,0
 Anthony Barbier,2018-Q1,0,0,0
-Rasul Karimov,2021-Q4,0,0,0
-Rasul Karimov,2021-Q3,0,0,0
 Rasul Karimov,2021-Q2,0,0,0
 Rasul Karimov,2021-Q1,0,0,0
 Rasul Karimov,2020-Q4,0,0,0
@@ -16399,8 +14349,6 @@ Rasul Karimov,2018-Q4,0,0,0
 Rasul Karimov,2018-Q3,0,0,0
 Rasul Karimov,2018-Q2,0,0,0
 Rasul Karimov,2018-Q1,0,0,0
-Scott Todd,2021-Q4,0,0,0
-Scott Todd,2021-Q3,0,0,0
 Scott Todd,2021-Q2,0,0,0
 Scott Todd,2021-Q1,0,0,0
 Scott Todd,2020-Q4,0,0,0
@@ -16415,8 +14363,6 @@ Scott Todd,2018-Q4,0,0,0
 Scott Todd,2018-Q3,0,0,0
 Scott Todd,2018-Q2,0,0,0
 Scott Todd,2018-Q1,0,0,0
-Prashant Dandriyal,2021-Q4,0,0,0
-Prashant Dandriyal,2021-Q3,0,0,0
 Prashant Dandriyal,2021-Q2,0,0,0
 Prashant Dandriyal,2021-Q1,0,0,0
 Prashant Dandriyal,2020-Q4,0,0,0
@@ -16431,8 +14377,6 @@ Prashant Dandriyal,2018-Q4,0,0,0
 Prashant Dandriyal,2018-Q3,0,0,0
 Prashant Dandriyal,2018-Q2,0,0,0
 Prashant Dandriyal,2018-Q1,0,0,0
-comet,2021-Q4,0,0,0
-comet,2021-Q3,0,0,0
 comet,2021-Q2,0,0,0
 comet,2021-Q1,0,0,0
 comet,2020-Q4,0,0,0
@@ -16447,8 +14391,6 @@ comet,2018-Q4,0,0,0
 comet,2018-Q3,0,0,0
 comet,2018-Q2,0,0,0
 comet,2018-Q1,0,0,0
-Pooya Davoodi,2021-Q4,0,0,0
-Pooya Davoodi,2021-Q3,0,0,0
 Pooya Davoodi,2021-Q2,0,0,0
 Pooya Davoodi,2021-Q1,0,0,0
 Pooya Davoodi,2020-Q4,0,0,0
@@ -16463,8 +14405,6 @@ Pooya Davoodi,2018-Q4,45,221,165
 Pooya Davoodi,2018-Q3,0,0,0
 Pooya Davoodi,2018-Q2,0,0,0
 Pooya Davoodi,2018-Q1,0,0,0
-Maher Jendoubi,2021-Q4,0,0,0
-Maher Jendoubi,2021-Q3,0,0,0
 Maher Jendoubi,2021-Q2,0,0,0
 Maher Jendoubi,2021-Q1,0,0,0
 Maher Jendoubi,2020-Q4,0,0,0
@@ -16479,8 +14419,6 @@ Maher Jendoubi,2018-Q4,0,0,0
 Maher Jendoubi,2018-Q3,0,0,0
 Maher Jendoubi,2018-Q2,0,0,0
 Maher Jendoubi,2018-Q1,0,0,0
-Stanley Bileschi,2021-Q4,0,0,0
-Stanley Bileschi,2021-Q3,0,0,0
 Stanley Bileschi,2021-Q2,0,0,0
 Stanley Bileschi,2021-Q1,0,0,0
 Stanley Bileschi,2020-Q4,0,0,0
@@ -16495,8 +14433,6 @@ Stanley Bileschi,2018-Q4,0,0,0
 Stanley Bileschi,2018-Q3,2,11,0
 Stanley Bileschi,2018-Q2,2,18,8
 Stanley Bileschi,2018-Q1,0,0,0
-Erik Zettel,2021-Q4,0,0,0
-Erik Zettel,2021-Q3,0,0,0
 Erik Zettel,2021-Q2,0,0,0
 Erik Zettel,2021-Q1,0,0,0
 Erik Zettel,2020-Q4,0,0,0
@@ -16511,8 +14447,6 @@ Erik Zettel,2018-Q4,0,0,0
 Erik Zettel,2018-Q3,0,0,0
 Erik Zettel,2018-Q2,0,0,0
 Erik Zettel,2018-Q1,0,0,0
-Abin Shahab,2021-Q4,0,0,0
-Abin Shahab,2021-Q3,0,0,0
 Abin Shahab,2021-Q2,0,0,0
 Abin Shahab,2021-Q1,0,0,0
 Abin Shahab,2020-Q4,0,0,0
@@ -16527,8 +14461,6 @@ Abin Shahab,2018-Q4,0,0,0
 Abin Shahab,2018-Q3,0,0,0
 Abin Shahab,2018-Q2,0,0,0
 Abin Shahab,2018-Q1,0,0,0
-Michael Liao,2021-Q4,0,0,0
-Michael Liao,2021-Q3,0,0,0
 Michael Liao,2021-Q2,0,0,0
 Michael Liao,2021-Q1,0,0,0
 Michael Liao,2020-Q4,0,0,0
@@ -16543,8 +14475,6 @@ Michael Liao,2018-Q4,0,0,0
 Michael Liao,2018-Q3,0,0,0
 Michael Liao,2018-Q2,0,0,0
 Michael Liao,2018-Q1,0,0,0
-Owen L - SFE,2021-Q4,0,0,0
-Owen L - SFE,2021-Q3,0,0,0
 Owen L - SFE,2021-Q2,0,0,0
 Owen L - SFE,2021-Q1,0,0,0
 Owen L - SFE,2020-Q4,0,0,0
@@ -16559,8 +14489,6 @@ Owen L - SFE,2018-Q4,0,0,0
 Owen L - SFE,2018-Q3,0,0,0
 Owen L - SFE,2018-Q2,0,0,0
 Owen L - SFE,2018-Q1,0,0,0
-Ahti Kitsik,2021-Q4,0,0,0
-Ahti Kitsik,2021-Q3,0,0,0
 Ahti Kitsik,2021-Q2,0,0,0
 Ahti Kitsik,2021-Q1,0,0,0
 Ahti Kitsik,2020-Q4,0,0,0
@@ -16575,8 +14503,6 @@ Ahti Kitsik,2018-Q4,0,0,0
 Ahti Kitsik,2018-Q3,0,0,0
 Ahti Kitsik,2018-Q2,0,0,0
 Ahti Kitsik,2018-Q1,0,0,0
-Zhou Peng,2021-Q4,0,0,0
-Zhou Peng,2021-Q3,0,0,0
 Zhou Peng,2021-Q2,0,0,0
 Zhou Peng,2021-Q1,0,0,0
 Zhou Peng,2020-Q4,0,0,0
@@ -16591,8 +14517,6 @@ Zhou Peng,2018-Q4,0,0,0
 Zhou Peng,2018-Q3,0,0,0
 Zhou Peng,2018-Q2,0,0,0
 Zhou Peng,2018-Q1,0,0,0
-IrinaM21,2021-Q4,0,0,0
-IrinaM21,2021-Q3,0,0,0
 IrinaM21,2021-Q2,0,0,0
 IrinaM21,2021-Q1,0,0,0
 IrinaM21,2020-Q4,0,0,0
@@ -16607,8 +14531,6 @@ IrinaM21,2018-Q4,0,0,0
 IrinaM21,2018-Q3,0,0,0
 IrinaM21,2018-Q2,0,0,0
 IrinaM21,2018-Q1,0,0,0
-Joseph-Rance,2021-Q4,0,0,0
-Joseph-Rance,2021-Q3,0,0,0
 Joseph-Rance,2021-Q2,0,0,0
 Joseph-Rance,2021-Q1,0,0,0
 Joseph-Rance,2020-Q4,0,0,0
@@ -16623,8 +14545,6 @@ Joseph-Rance,2018-Q4,0,0,0
 Joseph-Rance,2018-Q3,0,0,0
 Joseph-Rance,2018-Q2,0,0,0
 Joseph-Rance,2018-Q1,0,0,0
-Rick Wierenga,2021-Q4,0,0,0
-Rick Wierenga,2021-Q3,0,0,0
 Rick Wierenga,2021-Q2,0,0,0
 Rick Wierenga,2021-Q1,0,0,0
 Rick Wierenga,2020-Q4,0,0,0
@@ -16639,8 +14559,6 @@ Rick Wierenga,2018-Q4,0,0,0
 Rick Wierenga,2018-Q3,0,0,0
 Rick Wierenga,2018-Q2,0,0,0
 Rick Wierenga,2018-Q1,0,0,0
-Victor Peng,2021-Q4,0,0,0
-Victor Peng,2021-Q3,0,0,0
 Victor Peng,2021-Q2,0,0,0
 Victor Peng,2021-Q1,0,0,0
 Victor Peng,2020-Q4,0,0,0
@@ -16655,8 +14573,6 @@ Victor Peng,2018-Q4,0,0,0
 Victor Peng,2018-Q3,0,0,0
 Victor Peng,2018-Q2,0,0,0
 Victor Peng,2018-Q1,0,0,0
-Shyam Sundar Dhanabalan,2021-Q4,0,0,0
-Shyam Sundar Dhanabalan,2021-Q3,0,0,0
 Shyam Sundar Dhanabalan,2021-Q2,0,0,0
 Shyam Sundar Dhanabalan,2021-Q1,0,0,0
 Shyam Sundar Dhanabalan,2020-Q4,0,0,0
@@ -16671,8 +14587,6 @@ Shyam Sundar Dhanabalan,2018-Q4,0,0,0
 Shyam Sundar Dhanabalan,2018-Q3,0,0,0
 Shyam Sundar Dhanabalan,2018-Q2,0,0,0
 Shyam Sundar Dhanabalan,2018-Q1,0,0,0
-Tong Shen,2021-Q4,0,0,0
-Tong Shen,2021-Q3,0,0,0
 Tong Shen,2021-Q2,0,0,0
 Tong Shen,2021-Q1,0,0,0
 Tong Shen,2020-Q4,0,0,0
@@ -16687,8 +14601,6 @@ Tong Shen,2018-Q4,108,6415,2065
 Tong Shen,2018-Q3,102,1609,821
 Tong Shen,2018-Q2,0,0,0
 Tong Shen,2018-Q1,0,0,0
-Saleem Abdulrasool,2021-Q4,0,0,0
-Saleem Abdulrasool,2021-Q3,0,0,0
 Saleem Abdulrasool,2021-Q2,0,0,0
 Saleem Abdulrasool,2021-Q1,0,0,0
 Saleem Abdulrasool,2020-Q4,0,0,0
@@ -16703,8 +14615,6 @@ Saleem Abdulrasool,2018-Q4,0,0,0
 Saleem Abdulrasool,2018-Q3,0,0,0
 Saleem Abdulrasool,2018-Q2,0,0,0
 Saleem Abdulrasool,2018-Q1,0,0,0
-archis,2021-Q4,0,0,0
-archis,2021-Q3,0,0,0
 archis,2021-Q2,0,0,0
 archis,2021-Q1,0,0,0
 archis,2020-Q4,0,0,0
@@ -16719,8 +14629,6 @@ archis,2018-Q4,0,0,0
 archis,2018-Q3,0,0,0
 archis,2018-Q2,0,0,0
 archis,2018-Q1,0,0,0
-Sasan Jafarnejad,2021-Q4,0,0,0
-Sasan Jafarnejad,2021-Q3,0,0,0
 Sasan Jafarnejad,2021-Q2,0,0,0
 Sasan Jafarnejad,2021-Q1,0,0,0
 Sasan Jafarnejad,2020-Q4,0,0,0
@@ -16735,8 +14643,6 @@ Sasan Jafarnejad,2018-Q4,0,0,0
 Sasan Jafarnejad,2018-Q3,0,0,0
 Sasan Jafarnejad,2018-Q2,0,0,0
 Sasan Jafarnejad,2018-Q1,0,0,0
-Christian Goll,2021-Q4,0,0,0
-Christian Goll,2021-Q3,0,0,0
 Christian Goll,2021-Q2,0,0,0
 Christian Goll,2021-Q1,0,0,0
 Christian Goll,2020-Q4,0,0,0
@@ -16751,8 +14657,6 @@ Christian Goll,2018-Q4,1,16,5
 Christian Goll,2018-Q3,0,0,0
 Christian Goll,2018-Q2,0,0,0
 Christian Goll,2018-Q1,0,0,0
-Qwerty71,2021-Q4,0,0,0
-Qwerty71,2021-Q3,0,0,0
 Qwerty71,2021-Q2,0,0,0
 Qwerty71,2021-Q1,0,0,0
 Qwerty71,2020-Q4,0,0,0
@@ -16767,8 +14671,6 @@ Qwerty71,2018-Q4,0,0,0
 Qwerty71,2018-Q3,0,0,0
 Qwerty71,2018-Q2,0,0,0
 Qwerty71,2018-Q1,0,0,0
-Hugo,2021-Q4,0,0,0
-Hugo,2021-Q3,0,0,0
 Hugo,2021-Q2,0,0,0
 Hugo,2021-Q1,0,0,0
 Hugo,2020-Q4,0,0,0
@@ -16783,8 +14685,6 @@ Hugo,2018-Q4,0,0,0
 Hugo,2018-Q3,0,0,0
 Hugo,2018-Q2,0,0,0
 Hugo,2018-Q1,0,0,0
-elzino,2021-Q4,0,0,0
-elzino,2021-Q3,0,0,0
 elzino,2021-Q2,0,0,0
 elzino,2021-Q1,0,0,0
 elzino,2020-Q4,0,0,0
@@ -16799,8 +14699,6 @@ elzino,2018-Q4,0,0,0
 elzino,2018-Q3,0,0,0
 elzino,2018-Q2,0,0,0
 elzino,2018-Q1,0,0,0
-Craig Citro,2021-Q4,0,0,0
-Craig Citro,2021-Q3,0,0,0
 Craig Citro,2021-Q2,0,0,0
 Craig Citro,2021-Q1,0,0,0
 Craig Citro,2020-Q4,0,0,0
@@ -16815,8 +14713,6 @@ Craig Citro,2018-Q4,0,0,0
 Craig Citro,2018-Q3,1,4,0
 Craig Citro,2018-Q2,1,5,0
 Craig Citro,2018-Q1,0,0,0
-Mrinal Jain,2021-Q4,0,0,0
-Mrinal Jain,2021-Q3,0,0,0
 Mrinal Jain,2021-Q2,0,0,0
 Mrinal Jain,2021-Q1,0,0,0
 Mrinal Jain,2020-Q4,0,0,0
@@ -16831,8 +14727,6 @@ Mrinal Jain,2018-Q4,0,0,0
 Mrinal Jain,2018-Q3,0,0,0
 Mrinal Jain,2018-Q2,0,0,0
 Mrinal Jain,2018-Q1,0,0,0
-ytyt-yt,2021-Q4,0,0,0
-ytyt-yt,2021-Q3,0,0,0
 ytyt-yt,2021-Q2,0,0,0
 ytyt-yt,2021-Q1,0,0,0
 ytyt-yt,2020-Q4,0,0,0
@@ -16847,8 +14741,6 @@ ytyt-yt,2018-Q4,0,0,0
 ytyt-yt,2018-Q3,0,0,0
 ytyt-yt,2018-Q2,0,0,0
 ytyt-yt,2018-Q1,0,0,0
-Yanan Cao,2021-Q4,0,0,0
-Yanan Cao,2021-Q3,0,0,0
 Yanan Cao,2021-Q2,0,0,0
 Yanan Cao,2021-Q1,0,0,0
 Yanan Cao,2020-Q4,0,0,0
@@ -16863,8 +14755,6 @@ Yanan Cao,2018-Q4,51,1516,696
 Yanan Cao,2018-Q3,40,1294,1029
 Yanan Cao,2018-Q2,2,11,2
 Yanan Cao,2018-Q1,0,0,0
-Nicholas Gao,2021-Q4,0,0,0
-Nicholas Gao,2021-Q3,0,0,0
 Nicholas Gao,2021-Q2,0,0,0
 Nicholas Gao,2021-Q1,0,0,0
 Nicholas Gao,2020-Q4,0,0,0
@@ -16879,8 +14769,6 @@ Nicholas Gao,2018-Q4,0,0,0
 Nicholas Gao,2018-Q3,0,0,0
 Nicholas Gao,2018-Q2,0,0,0
 Nicholas Gao,2018-Q1,0,0,0
-Kaustubh Maske Patil,2021-Q4,0,0,0
-Kaustubh Maske Patil,2021-Q3,0,0,0
 Kaustubh Maske Patil,2021-Q2,0,0,0
 Kaustubh Maske Patil,2021-Q1,0,0,0
 Kaustubh Maske Patil,2020-Q4,0,0,0
@@ -16895,8 +14783,6 @@ Kaustubh Maske Patil,2018-Q4,0,0,0
 Kaustubh Maske Patil,2018-Q3,0,0,0
 Kaustubh Maske Patil,2018-Q2,0,0,0
 Kaustubh Maske Patil,2018-Q1,0,0,0
-William-Yin123,2021-Q4,0,0,0
-William-Yin123,2021-Q3,0,0,0
 William-Yin123,2021-Q2,0,0,0
 William-Yin123,2021-Q1,0,0,0
 William-Yin123,2020-Q4,0,0,0
@@ -16911,8 +14797,6 @@ William-Yin123,2018-Q4,0,0,0
 William-Yin123,2018-Q3,0,0,0
 William-Yin123,2018-Q2,0,0,0
 William-Yin123,2018-Q1,0,0,0
-Dheeraj R Reddy,2021-Q4,0,0,0
-Dheeraj R Reddy,2021-Q3,0,0,0
 Dheeraj R Reddy,2021-Q2,0,0,0
 Dheeraj R Reddy,2021-Q1,0,0,0
 Dheeraj R Reddy,2020-Q4,0,0,0
@@ -16927,8 +14811,6 @@ Dheeraj R Reddy,2018-Q4,0,0,0
 Dheeraj R Reddy,2018-Q3,0,0,0
 Dheeraj R Reddy,2018-Q2,0,0,0
 Dheeraj R Reddy,2018-Q1,0,0,0
-boron,2021-Q4,0,0,0
-boron,2021-Q3,0,0,0
 boron,2021-Q2,0,0,0
 boron,2021-Q1,0,0,0
 boron,2020-Q4,0,0,0
@@ -16943,8 +14825,6 @@ boron,2018-Q4,0,0,0
 boron,2018-Q3,0,0,0
 boron,2018-Q2,0,0,0
 boron,2018-Q1,0,0,0
-George Sterpu,2021-Q4,0,0,0
-George Sterpu,2021-Q3,0,0,0
 George Sterpu,2021-Q2,0,0,0
 George Sterpu,2021-Q1,0,0,0
 George Sterpu,2020-Q4,0,0,0
@@ -16959,8 +14839,6 @@ George Sterpu,2018-Q4,1,0,0
 George Sterpu,2018-Q3,0,0,0
 George Sterpu,2018-Q2,0,0,0
 George Sterpu,2018-Q1,1,2,2
-Andrei Kulik,2021-Q4,0,0,0
-Andrei Kulik,2021-Q3,0,0,0
 Andrei Kulik,2021-Q2,0,0,0
 Andrei Kulik,2021-Q1,0,0,0
 Andrei Kulik,2020-Q4,0,0,0
@@ -16975,8 +14853,6 @@ Andrei Kulik,2018-Q4,0,0,0
 Andrei Kulik,2018-Q3,0,0,0
 Andrei Kulik,2018-Q2,0,0,0
 Andrei Kulik,2018-Q1,0,0,0
-Eyvind Niklasson,2021-Q4,0,0,0
-Eyvind Niklasson,2021-Q3,0,0,0
 Eyvind Niklasson,2021-Q2,0,0,0
 Eyvind Niklasson,2021-Q1,0,0,0
 Eyvind Niklasson,2020-Q4,0,0,0
@@ -16991,8 +14867,6 @@ Eyvind Niklasson,2018-Q4,0,0,0
 Eyvind Niklasson,2018-Q3,0,0,0
 Eyvind Niklasson,2018-Q2,0,0,0
 Eyvind Niklasson,2018-Q1,0,0,0
-Richard Xiao,2021-Q4,0,0,0
-Richard Xiao,2021-Q3,0,0,0
 Richard Xiao,2021-Q2,0,0,0
 Richard Xiao,2021-Q1,0,0,0
 Richard Xiao,2020-Q4,0,0,0
@@ -17007,8 +14881,6 @@ Richard Xiao,2018-Q4,0,0,0
 Richard Xiao,2018-Q3,0,0,0
 Richard Xiao,2018-Q2,0,0,0
 Richard Xiao,2018-Q1,0,0,0
-Lamar,2021-Q4,0,0,0
-Lamar,2021-Q3,0,0,0
 Lamar,2021-Q2,0,0,0
 Lamar,2021-Q1,0,0,0
 Lamar,2020-Q4,0,0,0
@@ -17023,8 +14895,6 @@ Lamar,2018-Q4,0,0,0
 Lamar,2018-Q3,0,0,0
 Lamar,2018-Q2,0,0,0
 Lamar,2018-Q1,0,0,0
-Tetragramm,2021-Q4,0,0,0
-Tetragramm,2021-Q3,0,0,0
 Tetragramm,2021-Q2,0,0,0
 Tetragramm,2021-Q1,0,0,0
 Tetragramm,2020-Q4,0,0,0
@@ -17039,8 +14909,6 @@ Tetragramm,2018-Q4,0,0,0
 Tetragramm,2018-Q3,0,0,0
 Tetragramm,2018-Q2,0,0,0
 Tetragramm,2018-Q1,0,0,0
-sharkdtu,2021-Q4,0,0,0
-sharkdtu,2021-Q3,0,0,0
 sharkdtu,2021-Q2,0,0,0
 sharkdtu,2021-Q1,0,0,0
 sharkdtu,2020-Q4,0,0,0
@@ -17055,8 +14923,6 @@ sharkdtu,2018-Q4,0,0,0
 sharkdtu,2018-Q3,0,0,0
 sharkdtu,2018-Q2,0,0,0
 sharkdtu,2018-Q1,0,0,0
-Sami,2021-Q4,0,0,0
-Sami,2021-Q3,0,0,0
 Sami,2021-Q2,0,0,0
 Sami,2021-Q1,0,0,0
 Sami,2020-Q4,0,0,0
@@ -17071,8 +14937,6 @@ Sami,2018-Q4,0,0,0
 Sami,2018-Q3,0,0,0
 Sami,2018-Q2,0,0,0
 Sami,2018-Q1,0,0,0
-Paul Baranay,2021-Q4,0,0,0
-Paul Baranay,2021-Q3,0,0,0
 Paul Baranay,2021-Q2,0,0,0
 Paul Baranay,2021-Q1,0,0,0
 Paul Baranay,2020-Q4,0,0,0
@@ -17087,8 +14951,6 @@ Paul Baranay,2018-Q4,0,0,0
 Paul Baranay,2018-Q3,0,0,0
 Paul Baranay,2018-Q2,0,0,0
 Paul Baranay,2018-Q1,0,0,0
-autoih,2021-Q4,0,0,0
-autoih,2021-Q3,0,0,0
 autoih,2021-Q2,0,0,0
 autoih,2021-Q1,0,0,0
 autoih,2020-Q4,0,0,0
@@ -17103,8 +14965,6 @@ autoih,2018-Q4,0,0,0
 autoih,2018-Q3,0,0,0
 autoih,2018-Q2,0,0,0
 autoih,2018-Q1,0,0,0
-BashirSbaiti,2021-Q4,0,0,0
-BashirSbaiti,2021-Q3,0,0,0
 BashirSbaiti,2021-Q2,0,0,0
 BashirSbaiti,2021-Q1,0,0,0
 BashirSbaiti,2020-Q4,0,0,0
@@ -17119,8 +14979,6 @@ BashirSbaiti,2018-Q4,0,0,0
 BashirSbaiti,2018-Q3,0,0,0
 BashirSbaiti,2018-Q2,0,0,0
 BashirSbaiti,2018-Q1,0,0,0
-Adam Wood,2021-Q4,0,0,0
-Adam Wood,2021-Q3,0,0,0
 Adam Wood,2021-Q2,0,0,0
 Adam Wood,2021-Q1,0,0,0
 Adam Wood,2020-Q4,0,0,0
@@ -17135,8 +14993,6 @@ Adam Wood,2018-Q4,0,0,0
 Adam Wood,2018-Q3,0,0,0
 Adam Wood,2018-Q2,0,0,0
 Adam Wood,2018-Q1,0,0,0
-Mbah-Javis,2021-Q4,0,0,0
-Mbah-Javis,2021-Q3,0,0,0
 Mbah-Javis,2021-Q2,0,0,0
 Mbah-Javis,2021-Q1,0,0,0
 Mbah-Javis,2020-Q4,0,0,0
@@ -17151,8 +15007,6 @@ Mbah-Javis,2018-Q4,0,0,0
 Mbah-Javis,2018-Q3,0,0,0
 Mbah-Javis,2018-Q2,0,0,0
 Mbah-Javis,2018-Q1,0,0,0
-Yuki Ueda,2021-Q4,0,0,0
-Yuki Ueda,2021-Q3,0,0,0
 Yuki Ueda,2021-Q2,0,0,0
 Yuki Ueda,2021-Q1,0,0,0
 Yuki Ueda,2020-Q4,0,0,0
@@ -17167,8 +15021,6 @@ Yuki Ueda,2018-Q4,0,0,0
 Yuki Ueda,2018-Q3,0,0,0
 Yuki Ueda,2018-Q2,0,0,0
 Yuki Ueda,2018-Q1,0,0,0
-Shreyash Patodia,2021-Q4,0,0,0
-Shreyash Patodia,2021-Q3,0,0,0
 Shreyash Patodia,2021-Q2,0,0,0
 Shreyash Patodia,2021-Q1,0,0,0
 Shreyash Patodia,2020-Q4,0,0,0
@@ -17183,8 +15035,6 @@ Shreyash Patodia,2018-Q4,0,0,0
 Shreyash Patodia,2018-Q3,0,0,0
 Shreyash Patodia,2018-Q2,0,0,0
 Shreyash Patodia,2018-Q1,0,0,0
-Khor Chean Wei,2021-Q4,0,0,0
-Khor Chean Wei,2021-Q3,0,0,0
 Khor Chean Wei,2021-Q2,0,0,0
 Khor Chean Wei,2021-Q1,0,0,0
 Khor Chean Wei,2020-Q4,0,0,0
@@ -17199,8 +15049,6 @@ Khor Chean Wei,2018-Q4,0,0,0
 Khor Chean Wei,2018-Q3,0,0,0
 Khor Chean Wei,2018-Q2,0,0,0
 Khor Chean Wei,2018-Q1,0,0,0
-Ethan Saadia,2021-Q4,0,0,0
-Ethan Saadia,2021-Q3,0,0,0
 Ethan Saadia,2021-Q2,0,0,0
 Ethan Saadia,2021-Q1,0,0,0
 Ethan Saadia,2020-Q4,0,0,0
@@ -17215,8 +15063,6 @@ Ethan Saadia,2018-Q4,0,0,0
 Ethan Saadia,2018-Q3,0,0,0
 Ethan Saadia,2018-Q2,0,0,0
 Ethan Saadia,2018-Q1,0,0,0
-Hristo Vrigazov,2021-Q4,0,0,0
-Hristo Vrigazov,2021-Q3,0,0,0
 Hristo Vrigazov,2021-Q2,0,0,0
 Hristo Vrigazov,2021-Q1,0,0,0
 Hristo Vrigazov,2020-Q4,0,0,0
@@ -17231,8 +15077,6 @@ Hristo Vrigazov,2018-Q4,0,0,0
 Hristo Vrigazov,2018-Q3,0,0,0
 Hristo Vrigazov,2018-Q2,0,0,0
 Hristo Vrigazov,2018-Q1,0,0,0
-msteknoadam,2021-Q4,0,0,0
-msteknoadam,2021-Q3,0,0,0
 msteknoadam,2021-Q2,0,0,0
 msteknoadam,2021-Q1,0,0,0
 msteknoadam,2020-Q4,0,0,0
@@ -17247,8 +15091,6 @@ msteknoadam,2018-Q4,0,0,0
 msteknoadam,2018-Q3,0,0,0
 msteknoadam,2018-Q2,0,0,0
 msteknoadam,2018-Q1,0,0,0
-pshiko,2021-Q4,0,0,0
-pshiko,2021-Q3,0,0,0
 pshiko,2021-Q2,0,0,0
 pshiko,2021-Q1,0,0,0
 pshiko,2020-Q4,0,0,0
@@ -17263,8 +15105,6 @@ pshiko,2018-Q4,0,0,0
 pshiko,2018-Q3,0,0,0
 pshiko,2018-Q2,0,0,0
 pshiko,2018-Q1,0,0,0
-zhuwenxi,2021-Q4,0,0,0
-zhuwenxi,2021-Q3,0,0,0
 zhuwenxi,2021-Q2,0,0,0
 zhuwenxi,2021-Q1,0,0,0
 zhuwenxi,2020-Q4,0,0,0
@@ -17279,8 +15119,6 @@ zhuwenxi,2018-Q4,0,0,0
 zhuwenxi,2018-Q3,0,0,0
 zhuwenxi,2018-Q2,0,0,0
 zhuwenxi,2018-Q1,0,0,0
-arpan-dhatt,2021-Q4,0,0,0
-arpan-dhatt,2021-Q3,0,0,0
 arpan-dhatt,2021-Q2,0,0,0
 arpan-dhatt,2021-Q1,0,0,0
 arpan-dhatt,2020-Q4,0,0,0
@@ -17295,8 +15133,6 @@ arpan-dhatt,2018-Q4,0,0,0
 arpan-dhatt,2018-Q3,0,0,0
 arpan-dhatt,2018-Q2,0,0,0
 arpan-dhatt,2018-Q1,0,0,0
-HotPotatoC,2021-Q4,0,0,0
-HotPotatoC,2021-Q3,0,0,0
 HotPotatoC,2021-Q2,0,0,0
 HotPotatoC,2021-Q1,0,0,0
 HotPotatoC,2020-Q4,0,0,0
@@ -17311,8 +15147,6 @@ HotPotatoC,2018-Q4,0,0,0
 HotPotatoC,2018-Q3,0,0,0
 HotPotatoC,2018-Q2,0,0,0
 HotPotatoC,2018-Q1,0,0,0
-leike666666,2021-Q4,0,0,0
-leike666666,2021-Q3,0,0,0
 leike666666,2021-Q2,0,0,0
 leike666666,2021-Q1,0,0,0
 leike666666,2020-Q4,0,0,0
@@ -17327,8 +15161,6 @@ leike666666,2018-Q4,0,0,0
 leike666666,2018-Q3,0,0,0
 leike666666,2018-Q2,0,0,0
 leike666666,2018-Q1,0,0,0
-RichardXiao13,2021-Q4,0,0,0
-RichardXiao13,2021-Q3,0,0,0
 RichardXiao13,2021-Q2,0,0,0
 RichardXiao13,2021-Q1,0,0,0
 RichardXiao13,2020-Q4,0,0,0
@@ -17343,8 +15175,6 @@ RichardXiao13,2018-Q4,0,0,0
 RichardXiao13,2018-Q3,0,0,0
 RichardXiao13,2018-Q2,0,0,0
 RichardXiao13,2018-Q1,0,0,0
-Arvind Sundararajan,2021-Q4,0,0,0
-Arvind Sundararajan,2021-Q3,0,0,0
 Arvind Sundararajan,2021-Q2,0,0,0
 Arvind Sundararajan,2021-Q1,0,0,0
 Arvind Sundararajan,2020-Q4,0,0,0
@@ -17359,8 +15189,6 @@ Arvind Sundararajan,2018-Q4,0,0,0
 Arvind Sundararajan,2018-Q3,0,0,0
 Arvind Sundararajan,2018-Q2,0,0,0
 Arvind Sundararajan,2018-Q1,0,0,0
-Manuel Freiberger,2021-Q4,0,0,0
-Manuel Freiberger,2021-Q3,0,0,0
 Manuel Freiberger,2021-Q2,0,0,0
 Manuel Freiberger,2021-Q1,0,0,0
 Manuel Freiberger,2020-Q4,0,0,0
@@ -17375,8 +15203,6 @@ Manuel Freiberger,2018-Q4,0,0,0
 Manuel Freiberger,2018-Q3,0,0,0
 Manuel Freiberger,2018-Q2,0,0,0
 Manuel Freiberger,2018-Q1,0,0,0
-ruchit2801,2021-Q4,0,0,0
-ruchit2801,2021-Q3,0,0,0
 ruchit2801,2021-Q2,0,0,0
 ruchit2801,2021-Q1,0,0,0
 ruchit2801,2020-Q4,0,0,0
@@ -17391,8 +15217,6 @@ ruchit2801,2018-Q4,0,0,0
 ruchit2801,2018-Q3,0,0,0
 ruchit2801,2018-Q2,0,0,0
 ruchit2801,2018-Q1,0,0,0
-SumanSudhir,2021-Q4,0,0,0
-SumanSudhir,2021-Q3,0,0,0
 SumanSudhir,2021-Q2,0,0,0
 SumanSudhir,2021-Q1,0,0,0
 SumanSudhir,2020-Q4,0,0,0
@@ -17407,8 +15231,6 @@ SumanSudhir,2018-Q4,0,0,0
 SumanSudhir,2018-Q3,0,0,0
 SumanSudhir,2018-Q2,0,0,0
 SumanSudhir,2018-Q1,0,0,0
-Alexandre Abadie,2021-Q4,0,0,0
-Alexandre Abadie,2021-Q3,0,0,0
 Alexandre Abadie,2021-Q2,0,0,0
 Alexandre Abadie,2021-Q1,0,0,0
 Alexandre Abadie,2020-Q4,0,0,0
@@ -17423,8 +15245,6 @@ Alexandre Abadie,2018-Q4,0,0,0
 Alexandre Abadie,2018-Q3,0,0,0
 Alexandre Abadie,2018-Q2,0,0,0
 Alexandre Abadie,2018-Q1,0,0,0
-Frank Laub,2021-Q4,0,0,0
-Frank Laub,2021-Q3,0,0,0
 Frank Laub,2021-Q2,0,0,0
 Frank Laub,2021-Q1,0,0,0
 Frank Laub,2020-Q4,0,0,0
@@ -17439,8 +15259,6 @@ Frank Laub,2018-Q4,0,0,0
 Frank Laub,2018-Q3,0,0,0
 Frank Laub,2018-Q2,0,0,0
 Frank Laub,2018-Q1,0,0,0
-deepakm,2021-Q4,0,0,0
-deepakm,2021-Q3,0,0,0
 deepakm,2021-Q2,0,0,0
 deepakm,2021-Q1,0,0,0
 deepakm,2020-Q4,0,0,0
@@ -17455,8 +15273,6 @@ deepakm,2018-Q4,0,0,0
 deepakm,2018-Q3,0,0,0
 deepakm,2018-Q2,0,0,0
 deepakm,2018-Q1,0,0,0
-Wallyss Lima,2021-Q4,0,0,0
-Wallyss Lima,2021-Q3,0,0,0
 Wallyss Lima,2021-Q2,0,0,0
 Wallyss Lima,2021-Q1,0,0,0
 Wallyss Lima,2020-Q4,0,0,0
@@ -17471,8 +15287,6 @@ Wallyss Lima,2018-Q4,0,0,0
 Wallyss Lima,2018-Q3,0,0,0
 Wallyss Lima,2018-Q2,0,0,0
 Wallyss Lima,2018-Q1,0,0,0
-Noah Trenaman,2021-Q4,0,0,0
-Noah Trenaman,2021-Q3,0,0,0
 Noah Trenaman,2021-Q2,0,0,0
 Noah Trenaman,2021-Q1,0,0,0
 Noah Trenaman,2020-Q4,0,0,0
@@ -17487,8 +15301,6 @@ Noah Trenaman,2018-Q4,0,0,0
 Noah Trenaman,2018-Q3,0,0,0
 Noah Trenaman,2018-Q2,0,0,0
 Noah Trenaman,2018-Q1,0,0,0
-Andr? Susano Pinto,2021-Q4,0,0,0
-Andr? Susano Pinto,2021-Q3,0,0,0
 Andr? Susano Pinto,2021-Q2,0,0,0
 Andr? Susano Pinto,2021-Q1,0,0,0
 Andr? Susano Pinto,2020-Q4,0,0,0
@@ -17503,8 +15315,6 @@ Andr? Susano Pinto,2018-Q4,0,0,0
 Andr? Susano Pinto,2018-Q3,0,0,0
 Andr? Susano Pinto,2018-Q2,0,0,0
 Andr? Susano Pinto,2018-Q1,0,0,0
-Marco Jacopo Ferrarotti,2021-Q4,0,0,0
-Marco Jacopo Ferrarotti,2021-Q3,0,0,0
 Marco Jacopo Ferrarotti,2021-Q2,0,0,0
 Marco Jacopo Ferrarotti,2021-Q1,0,0,0
 Marco Jacopo Ferrarotti,2020-Q4,0,0,0
@@ -17519,8 +15329,6 @@ Marco Jacopo Ferrarotti,2018-Q4,0,0,0
 Marco Jacopo Ferrarotti,2018-Q3,0,0,0
 Marco Jacopo Ferrarotti,2018-Q2,0,0,0
 Marco Jacopo Ferrarotti,2018-Q1,0,0,0
-Anuj Rawat,2021-Q4,0,0,0
-Anuj Rawat,2021-Q3,0,0,0
 Anuj Rawat,2021-Q2,0,0,0
 Anuj Rawat,2021-Q1,0,0,0
 Anuj Rawat,2020-Q4,0,0,0
@@ -17535,8 +15343,6 @@ Anuj Rawat,2018-Q4,0,0,0
 Anuj Rawat,2018-Q3,0,0,0
 Anuj Rawat,2018-Q2,0,0,0
 Anuj Rawat,2018-Q1,0,0,0
-Huanming Fang,2021-Q4,0,0,0
-Huanming Fang,2021-Q3,0,0,0
 Huanming Fang,2021-Q2,0,0,0
 Huanming Fang,2021-Q1,0,0,0
 Huanming Fang,2020-Q4,0,0,0
@@ -17551,8 +15357,6 @@ Huanming Fang,2018-Q4,0,0,0
 Huanming Fang,2018-Q3,0,0,0
 Huanming Fang,2018-Q2,0,0,0
 Huanming Fang,2018-Q1,0,0,0
-Jean-Denis Lesage,2021-Q4,0,0,0
-Jean-Denis Lesage,2021-Q3,0,0,0
 Jean-Denis Lesage,2021-Q2,0,0,0
 Jean-Denis Lesage,2021-Q1,0,0,0
 Jean-Denis Lesage,2020-Q4,0,0,0
@@ -17567,8 +15371,6 @@ Jean-Denis Lesage,2018-Q4,0,0,0
 Jean-Denis Lesage,2018-Q3,0,0,0
 Jean-Denis Lesage,2018-Q2,0,0,0
 Jean-Denis Lesage,2018-Q1,0,0,0
-Hans Gaiser,2021-Q4,0,0,0
-Hans Gaiser,2021-Q3,0,0,0
 Hans Gaiser,2021-Q2,0,0,0
 Hans Gaiser,2021-Q1,0,0,0
 Hans Gaiser,2020-Q4,0,0,0
@@ -17583,8 +15385,6 @@ Hans Gaiser,2018-Q4,0,0,0
 Hans Gaiser,2018-Q3,0,0,0
 Hans Gaiser,2018-Q2,0,0,0
 Hans Gaiser,2018-Q1,0,0,0
-Benjamin Barenblat,2021-Q4,0,0,0
-Benjamin Barenblat,2021-Q3,0,0,0
 Benjamin Barenblat,2021-Q2,0,0,0
 Benjamin Barenblat,2021-Q1,0,0,0
 Benjamin Barenblat,2020-Q4,0,0,0
@@ -17599,8 +15399,6 @@ Benjamin Barenblat,2018-Q4,2,4,2
 Benjamin Barenblat,2018-Q3,0,0,0
 Benjamin Barenblat,2018-Q2,0,0,0
 Benjamin Barenblat,2018-Q1,0,0,0
-William Zhang,2021-Q4,0,0,0
-William Zhang,2021-Q3,0,0,0
 William Zhang,2021-Q2,0,0,0
 William Zhang,2021-Q1,0,0,0
 William Zhang,2020-Q4,0,0,0
@@ -17615,8 +15413,6 @@ William Zhang,2018-Q4,0,0,0
 William Zhang,2018-Q3,0,0,0
 William Zhang,2018-Q2,0,0,0
 William Zhang,2018-Q1,0,0,0
-Jin Mingjian,2021-Q4,0,0,0
-Jin Mingjian,2021-Q3,0,0,0
 Jin Mingjian,2021-Q2,0,0,0
 Jin Mingjian,2021-Q1,0,0,0
 Jin Mingjian,2020-Q4,0,0,0
@@ -17631,8 +15427,6 @@ Jin Mingjian,2018-Q4,0,0,0
 Jin Mingjian,2018-Q3,0,0,0
 Jin Mingjian,2018-Q2,0,0,0
 Jin Mingjian,2018-Q1,0,0,0
-Taehun Kim,2021-Q4,0,0,0
-Taehun Kim,2021-Q3,0,0,0
 Taehun Kim,2021-Q2,0,0,0
 Taehun Kim,2021-Q1,0,0,0
 Taehun Kim,2020-Q4,0,0,0
@@ -17647,8 +15441,6 @@ Taehun Kim,2018-Q4,0,0,0
 Taehun Kim,2018-Q3,0,0,0
 Taehun Kim,2018-Q2,0,0,0
 Taehun Kim,2018-Q1,0,0,0
-Jose Ignacio Gomez,2021-Q4,0,0,0
-Jose Ignacio Gomez,2021-Q3,0,0,0
 Jose Ignacio Gomez,2021-Q2,0,0,0
 Jose Ignacio Gomez,2021-Q1,0,0,0
 Jose Ignacio Gomez,2020-Q4,0,0,0
@@ -17663,8 +15455,6 @@ Jose Ignacio Gomez,2018-Q4,0,0,0
 Jose Ignacio Gomez,2018-Q3,0,0,0
 Jose Ignacio Gomez,2018-Q2,0,0,0
 Jose Ignacio Gomez,2018-Q1,0,0,0
-Fangjun Kuang,2021-Q4,0,0,0
-Fangjun Kuang,2021-Q3,0,0,0
 Fangjun Kuang,2021-Q2,0,0,0
 Fangjun Kuang,2021-Q1,0,0,0
 Fangjun Kuang,2020-Q4,0,0,0
@@ -17679,8 +15469,6 @@ Fangjun Kuang,2018-Q4,0,0,0
 Fangjun Kuang,2018-Q3,0,0,0
 Fangjun Kuang,2018-Q2,0,0,0
 Fangjun Kuang,2018-Q1,0,0,0
-Drake Gens,2021-Q4,0,0,0
-Drake Gens,2021-Q3,0,0,0
 Drake Gens,2021-Q2,0,0,0
 Drake Gens,2021-Q1,0,0,0
 Drake Gens,2020-Q4,0,0,0
@@ -17695,8 +15483,6 @@ Drake Gens,2018-Q4,0,0,0
 Drake Gens,2018-Q3,0,0,0
 Drake Gens,2018-Q2,0,0,0
 Drake Gens,2018-Q1,0,0,0
-minoring,2021-Q4,0,0,0
-minoring,2021-Q3,0,0,0
 minoring,2021-Q2,0,0,0
 minoring,2021-Q1,0,0,0
 minoring,2020-Q4,0,0,0
@@ -17711,8 +15497,6 @@ minoring,2018-Q4,0,0,0
 minoring,2018-Q3,0,0,0
 minoring,2018-Q2,0,0,0
 minoring,2018-Q1,0,0,0
-Yaxun (Sam) Liu,2021-Q4,0,0,0
-Yaxun (Sam) Liu,2021-Q3,0,0,0
 Yaxun (Sam) Liu,2021-Q2,0,0,0
 Yaxun (Sam) Liu,2021-Q1,0,0,0
 Yaxun (Sam) Liu,2020-Q4,0,0,0
@@ -17727,8 +15511,6 @@ Yaxun (Sam) Liu,2018-Q4,0,0,0
 Yaxun (Sam) Liu,2018-Q3,0,0,0
 Yaxun (Sam) Liu,2018-Q2,0,0,0
 Yaxun (Sam) Liu,2018-Q1,0,0,0
-Alkis Evlogimenos,2021-Q4,0,0,0
-Alkis Evlogimenos,2021-Q3,0,0,0
 Alkis Evlogimenos,2021-Q2,0,0,0
 Alkis Evlogimenos,2021-Q1,0,0,0
 Alkis Evlogimenos,2020-Q4,0,0,0
@@ -17743,8 +15525,6 @@ Alkis Evlogimenos,2018-Q4,0,0,0
 Alkis Evlogimenos,2018-Q3,0,0,0
 Alkis Evlogimenos,2018-Q2,0,0,0
 Alkis Evlogimenos,2018-Q1,0,0,0
-thierry,2021-Q4,0,0,0
-thierry,2021-Q3,0,0,0
 thierry,2021-Q2,0,0,0
 thierry,2021-Q1,0,0,0
 thierry,2020-Q4,0,0,0
@@ -17759,8 +15539,6 @@ thierry,2018-Q4,0,0,0
 thierry,2018-Q3,0,0,0
 thierry,2018-Q2,0,0,0
 thierry,2018-Q1,0,0,0
-Thierry Herrmann,2021-Q4,0,0,0
-Thierry Herrmann,2021-Q3,0,0,0
 Thierry Herrmann,2021-Q2,0,0,0
 Thierry Herrmann,2021-Q1,0,0,0
 Thierry Herrmann,2020-Q4,0,0,0
@@ -17775,8 +15553,6 @@ Thierry Herrmann,2018-Q4,0,0,0
 Thierry Herrmann,2018-Q3,0,0,0
 Thierry Herrmann,2018-Q2,0,0,0
 Thierry Herrmann,2018-Q1,0,0,0
-Vishal Bhola,2021-Q4,0,0,0
-Vishal Bhola,2021-Q3,0,0,0
 Vishal Bhola,2021-Q2,0,0,0
 Vishal Bhola,2021-Q1,0,0,0
 Vishal Bhola,2020-Q4,0,0,0
@@ -17791,8 +15567,6 @@ Vishal Bhola,2018-Q4,0,0,0
 Vishal Bhola,2018-Q3,0,0,0
 Vishal Bhola,2018-Q2,0,0,0
 Vishal Bhola,2018-Q1,0,0,0
-Wen-Heng (Jack) Chung,2021-Q4,0,0,0
-Wen-Heng (Jack) Chung,2021-Q3,0,0,0
 Wen-Heng (Jack) Chung,2021-Q2,0,0,0
 Wen-Heng (Jack) Chung,2021-Q1,0,0,0
 Wen-Heng (Jack) Chung,2020-Q4,0,0,0
@@ -17807,8 +15581,6 @@ Wen-Heng (Jack) Chung,2018-Q4,28,888,242
 Wen-Heng (Jack) Chung,2018-Q3,55,563,446
 Wen-Heng (Jack) Chung,2018-Q2,33,1611,23
 Wen-Heng (Jack) Chung,2018-Q1,0,0,0
-Denis Khalikov,2021-Q4,0,0,0
-Denis Khalikov,2021-Q3,0,0,0
 Denis Khalikov,2021-Q2,0,0,0
 Denis Khalikov,2021-Q1,0,0,0
 Denis Khalikov,2020-Q4,0,0,0
@@ -17823,8 +15595,6 @@ Denis Khalikov,2018-Q4,0,0,0
 Denis Khalikov,2018-Q3,0,0,0
 Denis Khalikov,2018-Q2,0,0,0
 Denis Khalikov,2018-Q1,0,0,0
-Hugo Sjöberg,2021-Q4,0,0,0
-Hugo Sjöberg,2021-Q3,0,0,0
 Hugo Sjöberg,2021-Q2,0,0,0
 Hugo Sjöberg,2021-Q1,0,0,0
 Hugo Sjöberg,2020-Q4,0,0,0
@@ -17839,8 +15609,6 @@ Hugo Sjöberg,2018-Q4,0,0,0
 Hugo Sjöberg,2018-Q3,0,0,0
 Hugo Sjöberg,2018-Q2,0,0,0
 Hugo Sjöberg,2018-Q1,0,0,0
-www,2021-Q4,0,0,0
-www,2021-Q3,0,0,0
 www,2021-Q2,0,0,0
 www,2021-Q1,0,0,0
 www,2020-Q4,0,0,0
@@ -17855,8 +15623,6 @@ www,2018-Q4,0,0,0
 www,2018-Q3,0,0,0
 www,2018-Q2,0,0,0
 www,2018-Q1,0,0,0
-Ewout ter Hoeven,2021-Q4,0,0,0
-Ewout ter Hoeven,2021-Q3,0,0,0
 Ewout ter Hoeven,2021-Q2,0,0,0
 Ewout ter Hoeven,2021-Q1,0,0,0
 Ewout ter Hoeven,2020-Q4,0,0,0
@@ -17871,8 +15637,6 @@ Ewout ter Hoeven,2018-Q4,0,0,0
 Ewout ter Hoeven,2018-Q3,0,0,0
 Ewout ter Hoeven,2018-Q2,0,0,0
 Ewout ter Hoeven,2018-Q1,0,0,0
-Daniel Falbel,2021-Q4,0,0,0
-Daniel Falbel,2021-Q3,0,0,0
 Daniel Falbel,2021-Q2,0,0,0
 Daniel Falbel,2021-Q1,0,0,0
 Daniel Falbel,2020-Q4,0,0,0
@@ -17887,8 +15651,6 @@ Daniel Falbel,2018-Q4,0,0,0
 Daniel Falbel,2018-Q3,0,0,0
 Daniel Falbel,2018-Q2,0,0,0
 Daniel Falbel,2018-Q1,0,0,0
-LIUJIAN435,2021-Q4,0,0,0
-LIUJIAN435,2021-Q3,0,0,0
 LIUJIAN435,2021-Q2,0,0,0
 LIUJIAN435,2021-Q1,0,0,0
 LIUJIAN435,2020-Q4,0,0,0
@@ -17903,8 +15665,6 @@ LIUJIAN435,2018-Q4,0,0,0
 LIUJIAN435,2018-Q3,0,0,0
 LIUJIAN435,2018-Q2,0,0,0
 LIUJIAN435,2018-Q1,0,0,0
-Kimberly,2021-Q4,0,0,0
-Kimberly,2021-Q3,0,0,0
 Kimberly,2021-Q2,0,0,0
 Kimberly,2021-Q1,0,0,0
 Kimberly,2020-Q4,0,0,0
@@ -17919,8 +15679,6 @@ Kimberly,2018-Q4,0,0,0
 Kimberly,2018-Q3,0,0,0
 Kimberly,2018-Q2,0,0,0
 Kimberly,2018-Q1,0,0,0
-nmostafa,2021-Q4,0,0,0
-nmostafa,2021-Q3,0,0,0
 nmostafa,2021-Q2,0,0,0
 nmostafa,2021-Q1,0,0,0
 nmostafa,2020-Q4,0,0,0
@@ -17935,8 +15693,6 @@ nmostafa,2018-Q4,0,0,0
 nmostafa,2018-Q3,0,0,0
 nmostafa,2018-Q2,0,0,0
 nmostafa,2018-Q1,0,0,0
-Anthony Liu,2021-Q4,0,0,0
-Anthony Liu,2021-Q3,0,0,0
 Anthony Liu,2021-Q2,0,0,0
 Anthony Liu,2021-Q1,0,0,0
 Anthony Liu,2020-Q4,0,0,0
@@ -17951,8 +15707,6 @@ Anthony Liu,2018-Q4,0,0,0
 Anthony Liu,2018-Q3,0,0,0
 Anthony Liu,2018-Q2,0,0,0
 Anthony Liu,2018-Q1,0,0,0
-Shane Smiskol,2021-Q4,0,0,0
-Shane Smiskol,2021-Q3,0,0,0
 Shane Smiskol,2021-Q2,0,0,0
 Shane Smiskol,2021-Q1,0,0,0
 Shane Smiskol,2020-Q4,0,0,0
@@ -17967,8 +15721,6 @@ Shane Smiskol,2018-Q4,0,0,0
 Shane Smiskol,2018-Q3,0,0,0
 Shane Smiskol,2018-Q2,0,0,0
 Shane Smiskol,2018-Q1,0,0,0
-Alexandre E. Eichenberger,2021-Q4,0,0,0
-Alexandre E. Eichenberger,2021-Q3,0,0,0
 Alexandre E. Eichenberger,2021-Q2,0,0,0
 Alexandre E. Eichenberger,2021-Q1,0,0,0
 Alexandre E. Eichenberger,2020-Q4,0,0,0
@@ -17983,8 +15735,6 @@ Alexandre E. Eichenberger,2018-Q4,0,0,0
 Alexandre E. Eichenberger,2018-Q3,0,0,0
 Alexandre E. Eichenberger,2018-Q2,0,0,0
 Alexandre E. Eichenberger,2018-Q1,0,0,0
-David Chen,2021-Q4,0,0,0
-David Chen,2021-Q3,0,0,0
 David Chen,2021-Q2,0,0,0
 David Chen,2021-Q1,0,0,0
 David Chen,2020-Q4,0,0,0
@@ -17999,8 +15749,6 @@ David Chen,2018-Q4,0,0,0
 David Chen,2018-Q3,0,0,0
 David Chen,2018-Q2,0,0,0
 David Chen,2018-Q1,0,0,0
-David Soergel,2021-Q4,0,0,0
-David Soergel,2021-Q3,0,0,0
 David Soergel,2021-Q2,0,0,0
 David Soergel,2021-Q1,0,0,0
 David Soergel,2020-Q4,0,0,0
@@ -18015,8 +15763,6 @@ David Soergel,2018-Q4,0,0,0
 David Soergel,2018-Q3,0,0,0
 David Soergel,2018-Q2,0,0,0
 David Soergel,2018-Q1,2,67,16
-Robert Crowe,2021-Q4,0,0,0
-Robert Crowe,2021-Q3,0,0,0
 Robert Crowe,2021-Q2,0,0,0
 Robert Crowe,2021-Q1,0,0,0
 Robert Crowe,2020-Q4,0,0,0
@@ -18031,8 +15777,6 @@ Robert Crowe,2018-Q4,0,0,0
 Robert Crowe,2018-Q3,0,0,0
 Robert Crowe,2018-Q2,0,0,0
 Robert Crowe,2018-Q1,0,0,0
-Markus Franke,2021-Q4,0,0,0
-Markus Franke,2021-Q3,0,0,0
 Markus Franke,2021-Q2,0,0,0
 Markus Franke,2021-Q1,0,0,0
 Markus Franke,2020-Q4,0,0,0
@@ -18047,8 +15791,6 @@ Markus Franke,2018-Q4,0,0,0
 Markus Franke,2018-Q3,0,0,0
 Markus Franke,2018-Q2,0,0,0
 Markus Franke,2018-Q1,0,0,0
-Niels Ole Salscheider,2021-Q4,0,0,0
-Niels Ole Salscheider,2021-Q3,0,0,0
 Niels Ole Salscheider,2021-Q2,0,0,0
 Niels Ole Salscheider,2021-Q1,0,0,0
 Niels Ole Salscheider,2020-Q4,0,0,0
@@ -18063,8 +15805,6 @@ Niels Ole Salscheider,2018-Q4,3,190,0
 Niels Ole Salscheider,2018-Q3,0,0,0
 Niels Ole Salscheider,2018-Q2,0,0,0
 Niels Ole Salscheider,2018-Q1,0,0,0
-rpalakkal,2021-Q4,0,0,0
-rpalakkal,2021-Q3,0,0,0
 rpalakkal,2021-Q2,0,0,0
 rpalakkal,2021-Q1,0,0,0
 rpalakkal,2020-Q4,0,0,0
@@ -18079,8 +15819,6 @@ rpalakkal,2018-Q4,0,0,0
 rpalakkal,2018-Q3,0,0,0
 rpalakkal,2018-Q2,0,0,0
 rpalakkal,2018-Q1,0,0,0
-Diederik van Liere,2021-Q4,0,0,0
-Diederik van Liere,2021-Q3,0,0,0
 Diederik van Liere,2021-Q2,0,0,0
 Diederik van Liere,2021-Q1,0,0,0
 Diederik van Liere,2020-Q4,0,0,0
@@ -18095,8 +15833,6 @@ Diederik van Liere,2018-Q4,0,0,0
 Diederik van Liere,2018-Q3,0,0,0
 Diederik van Liere,2018-Q2,0,0,0
 Diederik van Liere,2018-Q1,0,0,0
-Christian Sachs,2021-Q4,0,0,0
-Christian Sachs,2021-Q3,0,0,0
 Christian Sachs,2021-Q2,0,0,0
 Christian Sachs,2021-Q1,0,0,0
 Christian Sachs,2020-Q4,0,0,0
@@ -18111,8 +15847,6 @@ Christian Sachs,2018-Q4,0,0,0
 Christian Sachs,2018-Q3,0,0,0
 Christian Sachs,2018-Q2,0,0,0
 Christian Sachs,2018-Q1,0,0,0
-Diego Caballero,2021-Q4,0,0,0
-Diego Caballero,2021-Q3,0,0,0
 Diego Caballero,2021-Q2,0,0,0
 Diego Caballero,2021-Q1,0,0,0
 Diego Caballero,2020-Q4,0,0,0
@@ -18127,8 +15861,6 @@ Diego Caballero,2018-Q4,0,0,0
 Diego Caballero,2018-Q3,0,0,0
 Diego Caballero,2018-Q2,0,0,0
 Diego Caballero,2018-Q1,0,0,0
-brett koonce,2021-Q4,0,0,0
-brett koonce,2021-Q3,0,0,0
 brett koonce,2021-Q2,0,0,0
 brett koonce,2021-Q1,0,0,0
 brett koonce,2020-Q4,0,0,0
@@ -18143,8 +15875,6 @@ brett koonce,2018-Q4,0,0,0
 brett koonce,2018-Q3,0,0,0
 brett koonce,2018-Q2,29,45,45
 brett koonce,2018-Q1,93,162,162
-JKIsaacLee,2021-Q4,0,0,0
-JKIsaacLee,2021-Q3,0,0,0
 JKIsaacLee,2021-Q2,0,0,0
 JKIsaacLee,2021-Q1,0,0,0
 JKIsaacLee,2020-Q4,0,0,0
@@ -18159,8 +15889,6 @@ JKIsaacLee,2018-Q4,0,0,0
 JKIsaacLee,2018-Q3,0,0,0
 JKIsaacLee,2018-Q2,0,0,0
 JKIsaacLee,2018-Q1,0,0,0
-Johan Euphrosine,2021-Q4,0,0,0
-Johan Euphrosine,2021-Q3,0,0,0
 Johan Euphrosine,2021-Q2,0,0,0
 Johan Euphrosine,2021-Q1,0,0,0
 Johan Euphrosine,2020-Q4,0,0,0
@@ -18175,8 +15903,6 @@ Johan Euphrosine,2018-Q4,0,0,0
 Johan Euphrosine,2018-Q3,0,0,0
 Johan Euphrosine,2018-Q2,0,0,0
 Johan Euphrosine,2018-Q1,0,0,0
-hsahovic,2021-Q4,0,0,0
-hsahovic,2021-Q3,0,0,0
 hsahovic,2021-Q2,0,0,0
 hsahovic,2021-Q1,0,0,0
 hsahovic,2020-Q4,0,0,0
@@ -18191,8 +15917,6 @@ hsahovic,2018-Q4,0,0,0
 hsahovic,2018-Q3,0,0,0
 hsahovic,2018-Q2,0,0,0
 hsahovic,2018-Q1,0,0,0
-Michal Tarnowski,2021-Q4,0,0,0
-Michal Tarnowski,2021-Q3,0,0,0
 Michal Tarnowski,2021-Q2,0,0,0
 Michal Tarnowski,2021-Q1,0,0,0
 Michal Tarnowski,2020-Q4,0,0,0
@@ -18207,8 +15931,6 @@ Michal Tarnowski,2018-Q4,0,0,0
 Michal Tarnowski,2018-Q3,0,0,0
 Michal Tarnowski,2018-Q2,0,0,0
 Michal Tarnowski,2018-Q1,0,0,0
-David Truby,2021-Q4,0,0,0
-David Truby,2021-Q3,0,0,0
 David Truby,2021-Q2,0,0,0
 David Truby,2021-Q1,0,0,0
 David Truby,2020-Q4,0,0,0
@@ -18223,8 +15945,6 @@ David Truby,2018-Q4,0,0,0
 David Truby,2018-Q3,0,0,0
 David Truby,2018-Q2,0,0,0
 David Truby,2018-Q1,0,0,0
-Amit Kumar Jaiswal,2021-Q4,0,0,0
-Amit Kumar Jaiswal,2021-Q3,0,0,0
 Amit Kumar Jaiswal,2021-Q2,0,0,0
 Amit Kumar Jaiswal,2021-Q1,0,0,0
 Amit Kumar Jaiswal,2020-Q4,0,0,0
@@ -18239,8 +15959,6 @@ Amit Kumar Jaiswal,2018-Q4,0,0,0
 Amit Kumar Jaiswal,2018-Q3,0,0,0
 Amit Kumar Jaiswal,2018-Q2,0,0,0
 Amit Kumar Jaiswal,2018-Q1,0,0,0
-Andrew Anderson,2021-Q4,0,0,0
-Andrew Anderson,2021-Q3,0,0,0
 Andrew Anderson,2021-Q2,0,0,0
 Andrew Anderson,2021-Q1,0,0,0
 Andrew Anderson,2020-Q4,0,0,0
@@ -18255,8 +15973,6 @@ Andrew Anderson,2018-Q4,0,0,0
 Andrew Anderson,2018-Q3,0,0,0
 Andrew Anderson,2018-Q2,0,0,0
 Andrew Anderson,2018-Q1,0,0,0
-Dan Zheng,2021-Q4,0,0,0
-Dan Zheng,2021-Q3,0,0,0
 Dan Zheng,2021-Q2,0,0,0
 Dan Zheng,2021-Q1,0,0,0
 Dan Zheng,2020-Q4,0,0,0
@@ -18271,8 +15987,6 @@ Dan Zheng,2018-Q4,0,0,0
 Dan Zheng,2018-Q3,0,0,0
 Dan Zheng,2018-Q2,0,0,0
 Dan Zheng,2018-Q1,0,0,0
-Jacob Burnim,2021-Q4,0,0,0
-Jacob Burnim,2021-Q3,0,0,0
 Jacob Burnim,2021-Q2,0,0,0
 Jacob Burnim,2021-Q1,0,0,0
 Jacob Burnim,2020-Q4,0,0,0
@@ -18287,8 +16001,6 @@ Jacob Burnim,2018-Q4,0,0,0
 Jacob Burnim,2018-Q3,0,0,0
 Jacob Burnim,2018-Q2,0,0,0
 Jacob Burnim,2018-Q1,0,0,0
-Jean-Michel Gorius,2021-Q4,0,0,0
-Jean-Michel Gorius,2021-Q3,0,0,0
 Jean-Michel Gorius,2021-Q2,0,0,0
 Jean-Michel Gorius,2021-Q1,0,0,0
 Jean-Michel Gorius,2020-Q4,0,0,0
@@ -18303,8 +16015,6 @@ Jean-Michel Gorius,2018-Q4,0,0,0
 Jean-Michel Gorius,2018-Q3,0,0,0
 Jean-Michel Gorius,2018-Q2,0,0,0
 Jean-Michel Gorius,2018-Q1,0,0,0
-zhangshijin,2021-Q4,0,0,0
-zhangshijin,2021-Q3,0,0,0
 zhangshijin,2021-Q2,0,0,0
 zhangshijin,2021-Q1,0,0,0
 zhangshijin,2020-Q4,0,0,0
@@ -18319,8 +16029,6 @@ zhangshijin,2018-Q4,0,0,0
 zhangshijin,2018-Q3,0,0,0
 zhangshijin,2018-Q2,0,0,0
 zhangshijin,2018-Q1,0,0,0
-nuka137,2021-Q4,0,0,0
-nuka137,2021-Q3,0,0,0
 nuka137,2021-Q2,0,0,0
 nuka137,2021-Q1,0,0,0
 nuka137,2020-Q4,0,0,0
@@ -18335,8 +16043,6 @@ nuka137,2018-Q4,0,0,0
 nuka137,2018-Q3,0,0,0
 nuka137,2018-Q2,0,0,0
 nuka137,2018-Q1,0,0,0
-Eric Schweitz,2021-Q4,0,0,0
-Eric Schweitz,2021-Q3,0,0,0
 Eric Schweitz,2021-Q2,0,0,0
 Eric Schweitz,2021-Q1,0,0,0
 Eric Schweitz,2020-Q4,0,0,0
@@ -18351,8 +16057,6 @@ Eric Schweitz,2018-Q4,0,0,0
 Eric Schweitz,2018-Q3,0,0,0
 Eric Schweitz,2018-Q2,0,0,0
 Eric Schweitz,2018-Q1,0,0,0
-Bharat Raghunathan,2021-Q4,0,0,0
-Bharat Raghunathan,2021-Q3,0,0,0
 Bharat Raghunathan,2021-Q2,0,0,0
 Bharat Raghunathan,2021-Q1,0,0,0
 Bharat Raghunathan,2020-Q4,0,0,0
@@ -18367,8 +16071,6 @@ Bharat Raghunathan,2018-Q4,0,0,0
 Bharat Raghunathan,2018-Q3,0,0,0
 Bharat Raghunathan,2018-Q2,0,0,0
 Bharat Raghunathan,2018-Q1,0,0,0
-Stefano Mazzocchi,2021-Q4,0,0,0
-Stefano Mazzocchi,2021-Q3,0,0,0
 Stefano Mazzocchi,2021-Q2,0,0,0
 Stefano Mazzocchi,2021-Q1,0,0,0
 Stefano Mazzocchi,2020-Q4,0,0,0
@@ -18383,8 +16085,6 @@ Stefano Mazzocchi,2018-Q4,0,0,0
 Stefano Mazzocchi,2018-Q3,0,0,0
 Stefano Mazzocchi,2018-Q2,0,0,0
 Stefano Mazzocchi,2018-Q1,0,0,0
-Srishti,2021-Q4,0,0,0
-Srishti,2021-Q3,0,0,0
 Srishti,2021-Q2,0,0,0
 Srishti,2021-Q1,0,0,0
 Srishti,2020-Q4,0,0,0
@@ -18399,8 +16099,6 @@ Srishti,2018-Q4,0,0,0
 Srishti,2018-Q3,0,0,0
 Srishti,2018-Q2,0,0,0
 Srishti,2018-Q1,0,0,0
-Namrata Bhave,2021-Q4,0,0,0
-Namrata Bhave,2021-Q3,0,0,0
 Namrata Bhave,2021-Q2,0,0,0
 Namrata Bhave,2021-Q1,0,0,0
 Namrata Bhave,2020-Q4,0,0,0
@@ -18415,8 +16113,6 @@ Namrata Bhave,2018-Q4,0,0,0
 Namrata Bhave,2018-Q3,0,0,0
 Namrata Bhave,2018-Q2,0,0,0
 Namrata Bhave,2018-Q1,0,0,0
-Tian Jin,2021-Q4,0,0,0
-Tian Jin,2021-Q3,0,0,0
 Tian Jin,2021-Q2,0,0,0
 Tian Jin,2021-Q1,0,0,0
 Tian Jin,2020-Q4,0,0,0
@@ -18431,8 +16127,6 @@ Tian Jin,2018-Q4,0,0,0
 Tian Jin,2018-Q3,0,0,0
 Tian Jin,2018-Q2,0,0,0
 Tian Jin,2018-Q1,0,0,0
-Srishti Yadav,2021-Q4,0,0,0
-Srishti Yadav,2021-Q3,0,0,0
 Srishti Yadav,2021-Q2,0,0,0
 Srishti Yadav,2021-Q1,0,0,0
 Srishti Yadav,2020-Q4,0,0,0
@@ -18447,8 +16141,6 @@ Srishti Yadav,2018-Q4,0,0,0
 Srishti Yadav,2018-Q3,0,0,0
 Srishti Yadav,2018-Q2,0,0,0
 Srishti Yadav,2018-Q1,0,0,0
-Hans Pabst,2021-Q4,0,0,0
-Hans Pabst,2021-Q3,0,0,0
 Hans Pabst,2021-Q2,0,0,0
 Hans Pabst,2021-Q1,0,0,0
 Hans Pabst,2020-Q4,0,0,0
@@ -18463,8 +16155,6 @@ Hans Pabst,2018-Q4,0,0,0
 Hans Pabst,2018-Q3,0,0,0
 Hans Pabst,2018-Q2,0,0,0
 Hans Pabst,2018-Q1,0,0,0
-Peng Wu,2021-Q4,0,0,0
-Peng Wu,2021-Q3,0,0,0
 Peng Wu,2021-Q2,0,0,0
 Peng Wu,2021-Q1,0,0,0
 Peng Wu,2020-Q4,0,0,0
@@ -18479,8 +16169,6 @@ Peng Wu,2018-Q4,0,0,0
 Peng Wu,2018-Q3,0,0,0
 Peng Wu,2018-Q2,0,0,0
 Peng Wu,2018-Q1,0,0,0
-namrata-ibm,2021-Q4,0,0,0
-namrata-ibm,2021-Q3,0,0,0
 namrata-ibm,2021-Q2,0,0,0
 namrata-ibm,2021-Q1,0,0,0
 namrata-ibm,2020-Q4,0,0,0
@@ -18495,8 +16183,6 @@ namrata-ibm,2018-Q4,0,0,0
 namrata-ibm,2018-Q3,0,0,0
 namrata-ibm,2018-Q2,0,0,0
 namrata-ibm,2018-Q1,3,44,4
-MLIR Team,2021-Q4,0,0,0
-MLIR Team,2021-Q3,0,0,0
 MLIR Team,2021-Q2,0,0,0
 MLIR Team,2021-Q1,0,0,0
 MLIR Team,2020-Q4,0,0,0
@@ -18511,8 +16197,6 @@ MLIR Team,2018-Q4,89,5791,1244
 MLIR Team,2018-Q3,67,2015,529
 MLIR Team,2018-Q2,15,413,24
 MLIR Team,2018-Q1,0,0,0
-Andy Davis,2021-Q4,0,0,0
-Andy Davis,2021-Q3,0,0,0
 Andy Davis,2021-Q2,0,0,0
 Andy Davis,2021-Q1,0,0,0
 Andy Davis,2020-Q4,0,0,0
@@ -18527,8 +16211,6 @@ Andy Davis,2018-Q4,0,0,0
 Andy Davis,2018-Q3,0,0,0
 Andy Davis,2018-Q2,0,0,0
 Andy Davis,2018-Q1,0,0,0
-PragmaTwice,2021-Q4,0,0,0
-PragmaTwice,2021-Q3,0,0,0
 PragmaTwice,2021-Q2,0,0,0
 PragmaTwice,2021-Q1,0,0,0
 PragmaTwice,2020-Q4,0,0,0
@@ -18543,8 +16225,6 @@ PragmaTwice,2018-Q4,0,0,0
 PragmaTwice,2018-Q3,0,0,0
 PragmaTwice,2018-Q2,0,0,0
 PragmaTwice,2018-Q1,0,0,0
-Sergio Guadarrama,2021-Q4,0,0,0
-Sergio Guadarrama,2021-Q3,0,0,0
 Sergio Guadarrama,2021-Q2,0,0,0
 Sergio Guadarrama,2021-Q1,0,0,0
 Sergio Guadarrama,2020-Q4,0,0,0
@@ -18559,8 +16239,6 @@ Sergio Guadarrama,2018-Q4,3,37,18
 Sergio Guadarrama,2018-Q3,3,32,16
 Sergio Guadarrama,2018-Q2,3,10,3
 Sergio Guadarrama,2018-Q1,8,496,93
-Lee Netherton,2021-Q4,0,0,0
-Lee Netherton,2021-Q3,0,0,0
 Lee Netherton,2021-Q2,0,0,0
 Lee Netherton,2021-Q1,0,0,0
 Lee Netherton,2020-Q4,0,0,0
@@ -18575,8 +16253,6 @@ Lee Netherton,2018-Q4,0,0,0
 Lee Netherton,2018-Q3,0,0,0
 Lee Netherton,2018-Q2,0,0,0
 Lee Netherton,2018-Q1,0,0,0
-darsh8200,2021-Q4,0,0,0
-darsh8200,2021-Q3,0,0,0
 darsh8200,2021-Q2,0,0,0
 darsh8200,2021-Q1,0,0,0
 darsh8200,2020-Q4,0,0,0
@@ -18591,8 +16267,6 @@ darsh8200,2018-Q4,0,0,0
 darsh8200,2018-Q3,0,0,0
 darsh8200,2018-Q2,0,0,0
 darsh8200,2018-Q1,0,0,0
-Devansh Singh,2021-Q4,0,0,0
-Devansh Singh,2021-Q3,0,0,0
 Devansh Singh,2021-Q2,0,0,0
 Devansh Singh,2021-Q1,0,0,0
 Devansh Singh,2020-Q4,0,0,0
@@ -18607,8 +16281,6 @@ Devansh Singh,2018-Q4,0,0,0
 Devansh Singh,2018-Q3,0,0,0
 Devansh Singh,2018-Q2,0,0,0
 Devansh Singh,2018-Q1,0,0,0
-Douman,2021-Q4,0,0,0
-Douman,2021-Q3,0,0,0
 Douman,2021-Q2,0,0,0
 Douman,2021-Q1,0,0,0
 Douman,2020-Q4,0,0,0
@@ -18623,8 +16295,6 @@ Douman,2018-Q4,0,0,0
 Douman,2018-Q3,0,0,0
 Douman,2018-Q2,0,0,0
 Douman,2018-Q1,0,0,0
-Sarvesh Dubey,2021-Q4,0,0,0
-Sarvesh Dubey,2021-Q3,0,0,0
 Sarvesh Dubey,2021-Q2,0,0,0
 Sarvesh Dubey,2021-Q1,0,0,0
 Sarvesh Dubey,2020-Q4,0,0,0
@@ -18639,8 +16309,6 @@ Sarvesh Dubey,2018-Q4,0,0,0
 Sarvesh Dubey,2018-Q3,0,0,0
 Sarvesh Dubey,2018-Q2,0,0,0
 Sarvesh Dubey,2018-Q1,0,0,0
-steph-en-m,2021-Q4,0,0,0
-steph-en-m,2021-Q3,0,0,0
 steph-en-m,2021-Q2,0,0,0
 steph-en-m,2021-Q1,0,0,0
 steph-en-m,2020-Q4,0,0,0
@@ -18655,8 +16323,6 @@ steph-en-m,2018-Q4,0,0,0
 steph-en-m,2018-Q3,0,0,0
 steph-en-m,2018-Q2,0,0,0
 steph-en-m,2018-Q1,0,0,0
-Ending2015a,2021-Q4,0,0,0
-Ending2015a,2021-Q3,0,0,0
 Ending2015a,2021-Q2,0,0,0
 Ending2015a,2021-Q1,0,0,0
 Ending2015a,2020-Q4,0,0,0
@@ -18671,8 +16337,6 @@ Ending2015a,2018-Q4,0,0,0
 Ending2015a,2018-Q3,0,0,0
 Ending2015a,2018-Q2,0,0,0
 Ending2015a,2018-Q1,0,0,0
-Keunwoo Choi,2021-Q4,0,0,0
-Keunwoo Choi,2021-Q3,0,0,0
 Keunwoo Choi,2021-Q2,0,0,0
 Keunwoo Choi,2021-Q1,0,0,0
 Keunwoo Choi,2020-Q4,0,0,0
@@ -18687,8 +16351,6 @@ Keunwoo Choi,2018-Q4,0,0,0
 Keunwoo Choi,2018-Q3,0,0,0
 Keunwoo Choi,2018-Q2,0,0,0
 Keunwoo Choi,2018-Q1,0,0,0
-Somyajit Chakraborty Sam,2021-Q4,0,0,0
-Somyajit Chakraborty Sam,2021-Q3,0,0,0
 Somyajit Chakraborty Sam,2021-Q2,0,0,0
 Somyajit Chakraborty Sam,2021-Q1,0,0,0
 Somyajit Chakraborty Sam,2020-Q4,0,0,0
@@ -18703,8 +16365,6 @@ Somyajit Chakraborty Sam,2018-Q4,0,0,0
 Somyajit Chakraborty Sam,2018-Q3,0,0,0
 Somyajit Chakraborty Sam,2018-Q2,0,0,0
 Somyajit Chakraborty Sam,2018-Q1,0,0,0
-mattn,2021-Q4,0,0,0
-mattn,2021-Q3,0,0,0
 mattn,2021-Q2,0,0,0
 mattn,2021-Q1,0,0,0
 mattn,2020-Q4,0,0,0
@@ -18719,8 +16379,6 @@ mattn,2018-Q4,0,0,0
 mattn,2018-Q3,0,0,0
 mattn,2018-Q2,0,0,0
 mattn,2018-Q1,0,0,0
-scentini,2021-Q4,0,0,0
-scentini,2021-Q3,0,0,0
 scentini,2021-Q2,0,0,0
 scentini,2021-Q1,0,0,0
 scentini,2020-Q4,0,0,0
@@ -18735,8 +16393,6 @@ scentini,2018-Q4,0,0,0
 scentini,2018-Q3,0,0,0
 scentini,2018-Q2,0,0,0
 scentini,2018-Q1,0,0,0
-wenshuai-xiaomi,2021-Q4,0,0,0
-wenshuai-xiaomi,2021-Q3,0,0,0
 wenshuai-xiaomi,2021-Q2,0,0,0
 wenshuai-xiaomi,2021-Q1,0,0,0
 wenshuai-xiaomi,2020-Q4,0,0,0
@@ -18751,8 +16407,6 @@ wenshuai-xiaomi,2018-Q4,0,0,0
 wenshuai-xiaomi,2018-Q3,0,0,0
 wenshuai-xiaomi,2018-Q2,0,0,0
 wenshuai-xiaomi,2018-Q1,0,0,0
-R Gomathi,2021-Q4,0,0,0
-R Gomathi,2021-Q3,0,0,0
 R Gomathi,2021-Q2,0,0,0
 R Gomathi,2021-Q1,0,0,0
 R Gomathi,2020-Q4,0,0,0
@@ -18767,8 +16421,6 @@ R Gomathi,2018-Q4,0,0,0
 R Gomathi,2018-Q3,0,0,0
 R Gomathi,2018-Q2,0,0,0
 R Gomathi,2018-Q1,0,0,0
-wenshuai,2021-Q4,0,0,0
-wenshuai,2021-Q3,0,0,0
 wenshuai,2021-Q2,0,0,0
 wenshuai,2021-Q1,0,0,0
 wenshuai,2020-Q4,0,0,0
@@ -18783,8 +16435,6 @@ wenshuai,2018-Q4,0,0,0
 wenshuai,2018-Q3,0,0,0
 wenshuai,2018-Q2,0,0,0
 wenshuai,2018-Q1,0,0,0
-Roberto Rosmaninho,2021-Q4,0,0,0
-Roberto Rosmaninho,2021-Q3,0,0,0
 Roberto Rosmaninho,2021-Q2,0,0,0
 Roberto Rosmaninho,2021-Q1,0,0,0
 Roberto Rosmaninho,2020-Q4,0,0,0
@@ -18799,8 +16449,6 @@ Roberto Rosmaninho,2018-Q4,0,0,0
 Roberto Rosmaninho,2018-Q3,0,0,0
 Roberto Rosmaninho,2018-Q2,0,0,0
 Roberto Rosmaninho,2018-Q1,0,0,0
-James Molloy,2021-Q4,0,0,0
-James Molloy,2021-Q3,0,0,0
 James Molloy,2021-Q2,0,0,0
 James Molloy,2021-Q1,0,0,0
 James Molloy,2020-Q4,0,0,0
@@ -18815,8 +16463,6 @@ James Molloy,2018-Q4,0,0,0
 James Molloy,2018-Q3,52,1068,426
 James Molloy,2018-Q2,0,0,0
 James Molloy,2018-Q1,0,0,0
-djshen,2021-Q4,0,0,0
-djshen,2021-Q3,0,0,0
 djshen,2021-Q2,0,0,0
 djshen,2021-Q1,0,0,0
 djshen,2020-Q4,0,0,0
@@ -18831,8 +16477,6 @@ djshen,2018-Q4,0,0,0
 djshen,2018-Q3,0,0,0
 djshen,2018-Q2,0,0,0
 djshen,2018-Q1,0,0,0
-angeliand,2021-Q4,0,0,0
-angeliand,2021-Q3,0,0,0
 angeliand,2021-Q2,0,0,0
 angeliand,2021-Q1,0,0,0
 angeliand,2020-Q4,0,0,0
@@ -18847,8 +16491,6 @@ angeliand,2018-Q4,0,0,0
 angeliand,2018-Q3,0,0,0
 angeliand,2018-Q2,0,0,0
 angeliand,2018-Q1,0,0,0
-Yusup,2021-Q4,0,0,0
-Yusup,2021-Q3,0,0,0
 Yusup,2021-Q2,0,0,0
 Yusup,2021-Q1,0,0,0
 Yusup,2020-Q4,0,0,0
@@ -18863,8 +16505,6 @@ Yusup,2018-Q4,0,0,0
 Yusup,2018-Q3,0,0,0
 Yusup,2018-Q2,0,0,0
 Yusup,2018-Q1,0,0,0
-Jared Nielsen,2021-Q4,0,0,0
-Jared Nielsen,2021-Q3,0,0,0
 Jared Nielsen,2021-Q2,0,0,0
 Jared Nielsen,2021-Q1,0,0,0
 Jared Nielsen,2020-Q4,0,0,0
@@ -18879,8 +16519,6 @@ Jared Nielsen,2018-Q4,0,0,0
 Jared Nielsen,2018-Q3,0,0,0
 Jared Nielsen,2018-Q2,0,0,0
 Jared Nielsen,2018-Q1,0,0,0
-Abdülhamit Yilmaz,2021-Q4,0,0,0
-Abdülhamit Yilmaz,2021-Q3,0,0,0
 Abdülhamit Yilmaz,2021-Q2,0,0,0
 Abdülhamit Yilmaz,2021-Q1,0,0,0
 Abdülhamit Yilmaz,2020-Q4,0,0,0
@@ -18895,8 +16533,6 @@ Abdülhamit Yilmaz,2018-Q4,0,0,0
 Abdülhamit Yilmaz,2018-Q3,0,0,0
 Abdülhamit Yilmaz,2018-Q2,0,0,0
 Abdülhamit Yilmaz,2018-Q1,0,0,0
-caster,2021-Q4,0,0,0
-caster,2021-Q3,0,0,0
 caster,2021-Q2,0,0,0
 caster,2021-Q1,0,0,0
 caster,2020-Q4,0,0,0
@@ -18911,8 +16547,6 @@ caster,2018-Q4,0,0,0
 caster,2018-Q3,0,0,0
 caster,2018-Q2,0,0,0
 caster,2018-Q1,0,0,0
-Oleksii Volkovskyi,2021-Q4,0,0,0
-Oleksii Volkovskyi,2021-Q3,0,0,0
 Oleksii Volkovskyi,2021-Q2,0,0,0
 Oleksii Volkovskyi,2021-Q1,0,0,0
 Oleksii Volkovskyi,2020-Q4,0,0,0
@@ -18927,8 +16561,6 @@ Oleksii Volkovskyi,2018-Q4,0,0,0
 Oleksii Volkovskyi,2018-Q3,0,0,0
 Oleksii Volkovskyi,2018-Q2,0,0,0
 Oleksii Volkovskyi,2018-Q1,0,0,0
-Paige Bailey,2021-Q4,0,0,0
-Paige Bailey,2021-Q3,0,0,0
 Paige Bailey,2021-Q2,0,0,0
 Paige Bailey,2021-Q1,0,0,0
 Paige Bailey,2020-Q4,0,0,0
@@ -18943,8 +16575,6 @@ Paige Bailey,2018-Q4,0,0,0
 Paige Bailey,2018-Q3,0,0,0
 Paige Bailey,2018-Q2,0,0,0
 Paige Bailey,2018-Q1,0,0,0
-Jongwon Lee,2021-Q4,0,0,0
-Jongwon Lee,2021-Q3,0,0,0
 Jongwon Lee,2021-Q2,0,0,0
 Jongwon Lee,2021-Q1,0,0,0
 Jongwon Lee,2020-Q4,0,0,0
@@ -18959,8 +16589,6 @@ Jongwon Lee,2018-Q4,0,0,0
 Jongwon Lee,2018-Q3,0,0,0
 Jongwon Lee,2018-Q2,0,0,0
 Jongwon Lee,2018-Q1,0,0,0
-william,2021-Q4,0,0,0
-william,2021-Q3,0,0,0
 william,2021-Q2,0,0,0
 william,2021-Q1,0,0,0
 william,2020-Q4,0,0,0
@@ -18975,8 +16603,6 @@ william,2018-Q4,0,0,0
 william,2018-Q3,0,0,0
 william,2018-Q2,0,0,0
 william,2018-Q1,0,0,0
-Olivier Moindrot,2021-Q4,0,0,0
-Olivier Moindrot,2021-Q3,0,0,0
 Olivier Moindrot,2021-Q2,0,0,0
 Olivier Moindrot,2021-Q1,0,0,0
 Olivier Moindrot,2020-Q4,0,0,0
@@ -18991,8 +16617,6 @@ Olivier Moindrot,2018-Q4,0,0,0
 Olivier Moindrot,2018-Q3,0,0,0
 Olivier Moindrot,2018-Q2,0,0,0
 Olivier Moindrot,2018-Q1,0,0,0
-Trevor Hickey,2021-Q4,0,0,0
-Trevor Hickey,2021-Q3,0,0,0
 Trevor Hickey,2021-Q2,0,0,0
 Trevor Hickey,2021-Q1,0,0,0
 Trevor Hickey,2020-Q4,0,0,0
@@ -19007,8 +16631,6 @@ Trevor Hickey,2018-Q4,0,0,0
 Trevor Hickey,2018-Q3,0,0,0
 Trevor Hickey,2018-Q2,0,0,0
 Trevor Hickey,2018-Q1,0,0,0
-anujajakhade,2021-Q4,0,0,0
-anujajakhade,2021-Q3,0,0,0
 anujajakhade,2021-Q2,0,0,0
 anujajakhade,2021-Q1,0,0,0
 anujajakhade,2020-Q4,0,0,0
@@ -19023,8 +16645,6 @@ anujajakhade,2018-Q4,0,0,0
 anujajakhade,2018-Q3,0,0,0
 anujajakhade,2018-Q2,0,0,0
 anujajakhade,2018-Q1,0,0,0
-James Ring,2021-Q4,0,0,0
-James Ring,2021-Q3,0,0,0
 James Ring,2021-Q2,0,0,0
 James Ring,2021-Q1,0,0,0
 James Ring,2020-Q4,0,0,0
@@ -19039,8 +16659,6 @@ James Ring,2018-Q4,50,995,55
 James Ring,2018-Q3,0,0,0
 James Ring,2018-Q2,0,0,0
 James Ring,2018-Q1,0,0,0
-Keiji ARIYAMA,2021-Q4,0,0,0
-Keiji ARIYAMA,2021-Q3,0,0,0
 Keiji ARIYAMA,2021-Q2,0,0,0
 Keiji ARIYAMA,2021-Q1,0,0,0
 Keiji ARIYAMA,2020-Q4,0,0,0
@@ -19055,8 +16673,6 @@ Keiji ARIYAMA,2018-Q4,0,0,0
 Keiji ARIYAMA,2018-Q3,0,0,0
 Keiji ARIYAMA,2018-Q2,0,0,0
 Keiji ARIYAMA,2018-Q1,0,0,0
-Stephen Mugisha,2021-Q4,0,0,0
-Stephen Mugisha,2021-Q3,0,0,0
 Stephen Mugisha,2021-Q2,0,0,0
 Stephen Mugisha,2021-Q1,0,0,0
 Stephen Mugisha,2020-Q4,0,0,0
@@ -19071,8 +16687,6 @@ Stephen Mugisha,2018-Q4,0,0,0
 Stephen Mugisha,2018-Q3,0,0,0
 Stephen Mugisha,2018-Q2,0,0,0
 Stephen Mugisha,2018-Q1,0,0,0
-giuros01,2021-Q4,0,0,0
-giuros01,2021-Q3,0,0,0
 giuros01,2021-Q2,0,0,0
 giuros01,2021-Q1,0,0,0
 giuros01,2020-Q4,0,0,0
@@ -19087,8 +16701,6 @@ giuros01,2018-Q4,0,0,0
 giuros01,2018-Q3,0,0,0
 giuros01,2018-Q2,0,0,0
 giuros01,2018-Q1,0,0,0
-Jeff Poznanovic,2021-Q4,0,0,0
-Jeff Poznanovic,2021-Q3,0,0,0
 Jeff Poznanovic,2021-Q2,0,0,0
 Jeff Poznanovic,2021-Q1,0,0,0
 Jeff Poznanovic,2020-Q4,0,0,0
@@ -19103,8 +16715,6 @@ Jeff Poznanovic,2018-Q4,0,0,0
 Jeff Poznanovic,2018-Q3,0,0,0
 Jeff Poznanovic,2018-Q2,0,0,0
 Jeff Poznanovic,2018-Q1,0,0,0
-kamalkraj,2021-Q4,0,0,0
-kamalkraj,2021-Q3,0,0,0
 kamalkraj,2021-Q2,0,0,0
 kamalkraj,2021-Q1,0,0,0
 kamalkraj,2020-Q4,0,0,0
@@ -19119,8 +16729,6 @@ kamalkraj,2018-Q4,0,0,0
 kamalkraj,2018-Q3,0,0,0
 kamalkraj,2018-Q2,0,0,0
 kamalkraj,2018-Q1,0,0,0
-Zhenyu Guo,2021-Q4,0,0,0
-Zhenyu Guo,2021-Q3,0,0,0
 Zhenyu Guo,2021-Q2,0,0,0
 Zhenyu Guo,2021-Q1,0,0,0
 Zhenyu Guo,2020-Q4,0,0,0
@@ -19135,8 +16743,6 @@ Zhenyu Guo,2018-Q4,0,0,0
 Zhenyu Guo,2018-Q3,0,0,0
 Zhenyu Guo,2018-Q2,0,0,0
 Zhenyu Guo,2018-Q1,0,0,0
-Irina Bejan,2021-Q4,0,0,0
-Irina Bejan,2021-Q3,0,0,0
 Irina Bejan,2021-Q2,0,0,0
 Irina Bejan,2021-Q1,0,0,0
 Irina Bejan,2020-Q4,0,0,0
@@ -19151,8 +16757,6 @@ Irina Bejan,2018-Q4,0,0,0
 Irina Bejan,2018-Q3,0,0,0
 Irina Bejan,2018-Q2,0,0,0
 Irina Bejan,2018-Q1,0,0,0
-reinerp,2021-Q4,0,0,0
-reinerp,2021-Q3,0,0,0
 reinerp,2021-Q2,0,0,0
 reinerp,2021-Q1,0,0,0
 reinerp,2020-Q4,0,0,0
@@ -19167,8 +16771,6 @@ reinerp,2018-Q4,0,0,0
 reinerp,2018-Q3,0,0,0
 reinerp,2018-Q2,0,0,0
 reinerp,2018-Q1,0,0,0
-Anuja Jakhade,2021-Q4,0,0,0
-Anuja Jakhade,2021-Q3,0,0,0
 Anuja Jakhade,2021-Q2,0,0,0
 Anuja Jakhade,2021-Q1,0,0,0
 Anuja Jakhade,2020-Q4,0,0,0
@@ -19183,8 +16785,6 @@ Anuja Jakhade,2018-Q4,0,0,0
 Anuja Jakhade,2018-Q3,0,0,0
 Anuja Jakhade,2018-Q2,0,0,0
 Anuja Jakhade,2018-Q1,0,0,0
-Abhai Kollara,2021-Q4,0,0,0
-Abhai Kollara,2021-Q3,0,0,0
 Abhai Kollara,2021-Q2,0,0,0
 Abhai Kollara,2021-Q1,0,0,0
 Abhai Kollara,2020-Q4,0,0,0
@@ -19199,8 +16799,6 @@ Abhai Kollara,2018-Q4,0,0,0
 Abhai Kollara,2018-Q3,0,0,0
 Abhai Kollara,2018-Q2,0,0,0
 Abhai Kollara,2018-Q1,0,0,0
-Rob Suderman,2021-Q4,0,0,0
-Rob Suderman,2021-Q3,0,0,0
 Rob Suderman,2021-Q2,0,0,0
 Rob Suderman,2021-Q1,0,0,0
 Rob Suderman,2020-Q4,0,0,0
@@ -19215,8 +16813,6 @@ Rob Suderman,2018-Q4,0,0,0
 Rob Suderman,2018-Q3,0,0,0
 Rob Suderman,2018-Q2,0,0,0
 Rob Suderman,2018-Q1,0,0,0
-Alexander Vasilyev,2021-Q4,0,0,0
-Alexander Vasilyev,2021-Q3,0,0,0
 Alexander Vasilyev,2021-Q2,0,0,0
 Alexander Vasilyev,2021-Q1,0,0,0
 Alexander Vasilyev,2020-Q4,0,0,0
@@ -19231,8 +16827,6 @@ Alexander Vasilyev,2018-Q4,0,0,0
 Alexander Vasilyev,2018-Q3,0,0,0
 Alexander Vasilyev,2018-Q2,0,0,0
 Alexander Vasilyev,2018-Q1,0,0,0
-Sana Damani,2021-Q4,0,0,0
-Sana Damani,2021-Q3,0,0,0
 Sana Damani,2021-Q2,0,0,0
 Sana Damani,2021-Q1,0,0,0
 Sana Damani,2020-Q4,0,0,0
@@ -19247,8 +16841,6 @@ Sana Damani,2018-Q4,0,0,0
 Sana Damani,2018-Q3,0,0,0
 Sana Damani,2018-Q2,0,0,0
 Sana Damani,2018-Q1,0,0,0
-Laszlo Csomor,2021-Q4,0,0,0
-Laszlo Csomor,2021-Q3,0,0,0
 Laszlo Csomor,2021-Q2,0,0,0
 Laszlo Csomor,2021-Q1,0,0,0
 Laszlo Csomor,2020-Q4,0,0,0
@@ -19263,8 +16855,6 @@ Laszlo Csomor,2018-Q4,0,0,0
 Laszlo Csomor,2018-Q3,0,0,0
 Laszlo Csomor,2018-Q2,0,0,0
 Laszlo Csomor,2018-Q1,0,0,0
-Shahid,2021-Q4,0,0,0
-Shahid,2021-Q3,0,0,0
 Shahid,2021-Q2,0,0,0
 Shahid,2021-Q1,0,0,0
 Shahid,2020-Q4,0,0,0
@@ -19279,8 +16869,6 @@ Shahid,2018-Q4,0,0,0
 Shahid,2018-Q3,0,0,0
 Shahid,2018-Q2,0,0,0
 Shahid,2018-Q1,0,0,0
-Yannic,2021-Q4,0,0,0
-Yannic,2021-Q3,0,0,0
 Yannic,2021-Q2,0,0,0
 Yannic,2021-Q1,0,0,0
 Yannic,2020-Q4,0,0,0
@@ -19295,8 +16883,6 @@ Yannic,2018-Q4,0,0,0
 Yannic,2018-Q3,0,0,0
 Yannic,2018-Q2,0,0,0
 Yannic,2018-Q1,0,0,0
-Kristian Holsheimer,2021-Q4,0,0,0
-Kristian Holsheimer,2021-Q3,0,0,0
 Kristian Holsheimer,2021-Q2,0,0,0
 Kristian Holsheimer,2021-Q1,0,0,0
 Kristian Holsheimer,2020-Q4,0,0,0
@@ -19311,8 +16897,6 @@ Kristian Holsheimer,2018-Q4,0,0,0
 Kristian Holsheimer,2018-Q3,0,0,0
 Kristian Holsheimer,2018-Q2,0,0,0
 Kristian Holsheimer,2018-Q1,0,0,0
-EFanZh,2021-Q4,0,0,0
-EFanZh,2021-Q3,0,0,0
 EFanZh,2021-Q2,0,0,0
 EFanZh,2021-Q1,0,0,0
 EFanZh,2020-Q4,0,0,0
@@ -19327,8 +16911,6 @@ EFanZh,2018-Q4,0,0,0
 EFanZh,2018-Q3,5,86,11
 EFanZh,2018-Q2,1,0,0
 EFanZh,2018-Q1,0,0,0
-Adria Puigdomenech,2021-Q4,0,0,0
-Adria Puigdomenech,2021-Q3,0,0,0
 Adria Puigdomenech,2021-Q2,0,0,0
 Adria Puigdomenech,2021-Q1,0,0,0
 Adria Puigdomenech,2020-Q4,0,0,0
@@ -19343,8 +16925,6 @@ Adria Puigdomenech,2018-Q4,3,19,9
 Adria Puigdomenech,2018-Q3,15,468,0
 Adria Puigdomenech,2018-Q2,12,258,34
 Adria Puigdomenech,2018-Q1,0,0,0
-Richard Barnes,2021-Q4,0,0,0
-Richard Barnes,2021-Q3,0,0,0
 Richard Barnes,2021-Q2,0,0,0
 Richard Barnes,2021-Q1,0,0,0
 Richard Barnes,2020-Q4,0,0,0
@@ -19359,8 +16939,6 @@ Richard Barnes,2018-Q4,0,0,0
 Richard Barnes,2018-Q3,0,0,0
 Richard Barnes,2018-Q2,0,0,0
 Richard Barnes,2018-Q1,0,0,0
-Lena Martens,2021-Q4,0,0,0
-Lena Martens,2021-Q3,0,0,0
 Lena Martens,2021-Q2,0,0,0
 Lena Martens,2021-Q1,0,0,0
 Lena Martens,2020-Q4,0,0,0
@@ -19375,8 +16953,6 @@ Lena Martens,2018-Q4,0,0,0
 Lena Martens,2018-Q3,0,0,0
 Lena Martens,2018-Q2,0,0,0
 Lena Martens,2018-Q1,0,0,0
-parkers,2021-Q4,0,0,0
-parkers,2021-Q3,0,0,0
 parkers,2021-Q2,0,0,0
 parkers,2021-Q1,0,0,0
 parkers,2020-Q4,0,0,0
@@ -19391,8 +16967,6 @@ parkers,2018-Q4,0,0,0
 parkers,2018-Q3,0,0,0
 parkers,2018-Q2,0,0,0
 parkers,2018-Q1,0,0,0
-Jasper Vicenti,2021-Q4,0,0,0
-Jasper Vicenti,2021-Q3,0,0,0
 Jasper Vicenti,2021-Q2,0,0,0
 Jasper Vicenti,2021-Q1,0,0,0
 Jasper Vicenti,2020-Q4,0,0,0
@@ -19407,8 +16981,6 @@ Jasper Vicenti,2018-Q4,0,0,0
 Jasper Vicenti,2018-Q3,0,0,0
 Jasper Vicenti,2018-Q2,0,0,0
 Jasper Vicenti,2018-Q1,0,0,0
-Prabindh Sundareson,2021-Q4,0,0,0
-Prabindh Sundareson,2021-Q3,0,0,0
 Prabindh Sundareson,2021-Q2,0,0,0
 Prabindh Sundareson,2021-Q1,0,0,0
 Prabindh Sundareson,2020-Q4,0,0,0
@@ -19423,8 +16995,6 @@ Prabindh Sundareson,2018-Q4,0,0,0
 Prabindh Sundareson,2018-Q3,0,0,0
 Prabindh Sundareson,2018-Q2,0,0,0
 Prabindh Sundareson,2018-Q1,0,0,0
-Gomathi Ramamurthy,2021-Q4,0,0,0
-Gomathi Ramamurthy,2021-Q3,0,0,0
 Gomathi Ramamurthy,2021-Q2,0,0,0
 Gomathi Ramamurthy,2021-Q1,0,0,0
 Gomathi Ramamurthy,2020-Q4,0,0,0
@@ -19439,8 +17009,6 @@ Gomathi Ramamurthy,2018-Q4,0,0,0
 Gomathi Ramamurthy,2018-Q3,0,0,0
 Gomathi Ramamurthy,2018-Q2,0,0,0
 Gomathi Ramamurthy,2018-Q1,0,0,0
-shahidhs-ibm,2021-Q4,0,0,0
-shahidhs-ibm,2021-Q3,0,0,0
 shahidhs-ibm,2021-Q2,0,0,0
 shahidhs-ibm,2021-Q1,0,0,0
 shahidhs-ibm,2020-Q4,0,0,0
@@ -19455,8 +17023,6 @@ shahidhs-ibm,2018-Q4,0,0,0
 shahidhs-ibm,2018-Q3,0,0,0
 shahidhs-ibm,2018-Q2,0,0,0
 shahidhs-ibm,2018-Q1,0,0,0
-David Refaeli,2021-Q4,0,0,0
-David Refaeli,2021-Q3,0,0,0
 David Refaeli,2021-Q2,0,0,0
 David Refaeli,2021-Q1,0,0,0
 David Refaeli,2020-Q4,0,0,0
@@ -19471,8 +17037,6 @@ David Refaeli,2018-Q4,0,0,0
 David Refaeli,2018-Q3,0,0,0
 David Refaeli,2018-Q2,0,0,0
 David Refaeli,2018-Q1,0,0,0
-Brett Koonce,2021-Q4,0,0,0
-Brett Koonce,2021-Q3,0,0,0
 Brett Koonce,2021-Q2,0,0,0
 Brett Koonce,2021-Q1,0,0,0
 Brett Koonce,2020-Q4,0,0,0
@@ -19487,8 +17051,6 @@ Brett Koonce,2018-Q4,0,0,0
 Brett Koonce,2018-Q3,6,7,7
 Brett Koonce,2018-Q2,10,30,30
 Brett Koonce,2018-Q1,25,36,36
-Wei Wang,2021-Q4,0,0,0
-Wei Wang,2021-Q3,0,0,0
 Wei Wang,2021-Q2,0,0,0
 Wei Wang,2021-Q1,0,0,0
 Wei Wang,2020-Q4,0,0,0
@@ -19503,8 +17065,6 @@ Wei Wang,2018-Q4,0,0,0
 Wei Wang,2018-Q3,0,0,0
 Wei Wang,2018-Q2,0,0,0
 Wei Wang,2018-Q1,0,0,0
-Dan Smilkov,2021-Q4,0,0,0
-Dan Smilkov,2021-Q3,0,0,0
 Dan Smilkov,2021-Q2,0,0,0
 Dan Smilkov,2021-Q1,0,0,0
 Dan Smilkov,2020-Q4,0,0,0
@@ -19519,8 +17079,6 @@ Dan Smilkov,2018-Q4,0,0,0
 Dan Smilkov,2018-Q3,0,0,0
 Dan Smilkov,2018-Q2,0,0,0
 Dan Smilkov,2018-Q1,0,0,0
-Kevin Wang,2021-Q4,0,0,0
-Kevin Wang,2021-Q3,0,0,0
 Kevin Wang,2021-Q2,0,0,0
 Kevin Wang,2021-Q1,0,0,0
 Kevin Wang,2020-Q4,0,0,0
@@ -19535,8 +17093,6 @@ Kevin Wang,2018-Q4,0,0,0
 Kevin Wang,2018-Q3,0,0,0
 Kevin Wang,2018-Q2,0,0,0
 Kevin Wang,2018-Q1,0,0,0
-Lasse Espeholt,2021-Q4,0,0,0
-Lasse Espeholt,2021-Q3,0,0,0
 Lasse Espeholt,2021-Q2,0,0,0
 Lasse Espeholt,2021-Q1,0,0,0
 Lasse Espeholt,2020-Q4,0,0,0
@@ -19551,8 +17107,6 @@ Lasse Espeholt,2018-Q4,0,0,0
 Lasse Espeholt,2018-Q3,5,53,43
 Lasse Espeholt,2018-Q2,0,0,0
 Lasse Espeholt,2018-Q1,0,0,0
-Simon Plovyt,2021-Q4,0,0,0
-Simon Plovyt,2021-Q3,0,0,0
 Simon Plovyt,2021-Q2,0,0,0
 Simon Plovyt,2021-Q1,0,0,0
 Simon Plovyt,2020-Q4,0,0,0
@@ -19567,8 +17121,6 @@ Simon Plovyt,2018-Q4,0,0,0
 Simon Plovyt,2018-Q3,0,0,0
 Simon Plovyt,2018-Q2,0,0,0
 Simon Plovyt,2018-Q1,0,0,0
-韩董,2021-Q4,0,0,0
-韩董,2021-Q3,0,0,0
 韩董,2021-Q2,0,0,0
 韩董,2021-Q1,0,0,0
 韩董,2020-Q4,0,0,0
@@ -19583,8 +17135,6 @@ Simon Plovyt,2018-Q1,0,0,0
 韩董,2018-Q3,0,0,0
 韩董,2018-Q2,0,0,0
 韩董,2018-Q1,0,0,0
-Kevin Rose,2021-Q4,0,0,0
-Kevin Rose,2021-Q3,0,0,0
 Kevin Rose,2021-Q2,0,0,0
 Kevin Rose,2021-Q1,0,0,0
 Kevin Rose,2020-Q4,0,0,0
@@ -19599,8 +17149,6 @@ Kevin Rose,2018-Q4,0,0,0
 Kevin Rose,2018-Q3,0,0,0
 Kevin Rose,2018-Q2,0,0,0
 Kevin Rose,2018-Q1,0,0,0
-skeydan,2021-Q4,0,0,0
-skeydan,2021-Q3,0,0,0
 skeydan,2021-Q2,0,0,0
 skeydan,2021-Q1,0,0,0
 skeydan,2020-Q4,0,0,0
@@ -19615,8 +17163,6 @@ skeydan,2018-Q4,0,0,0
 skeydan,2018-Q3,0,0,0
 skeydan,2018-Q2,0,0,0
 skeydan,2018-Q1,0,0,0
-handong,2021-Q4,0,0,0
-handong,2021-Q3,0,0,0
 handong,2021-Q2,0,0,0
 handong,2021-Q1,0,0,0
 handong,2020-Q4,0,0,0
@@ -19631,8 +17177,6 @@ handong,2018-Q4,0,0,0
 handong,2018-Q3,0,0,0
 handong,2018-Q2,0,0,0
 handong,2018-Q1,0,0,0
-Juram Park,2021-Q4,0,0,0
-Juram Park,2021-Q3,0,0,0
 Juram Park,2021-Q2,0,0,0
 Juram Park,2021-Q1,0,0,0
 Juram Park,2020-Q4,0,0,0
@@ -19647,8 +17191,6 @@ Juram Park,2018-Q4,0,0,0
 Juram Park,2018-Q3,0,0,0
 Juram Park,2018-Q2,0,0,0
 Juram Park,2018-Q1,0,0,0
-aflc,2021-Q4,0,0,0
-aflc,2021-Q3,0,0,0
 aflc,2021-Q2,0,0,0
 aflc,2021-Q1,0,0,0
 aflc,2020-Q4,0,0,0
@@ -19663,8 +17205,6 @@ aflc,2018-Q4,0,0,0
 aflc,2018-Q3,0,0,0
 aflc,2018-Q2,0,0,0
 aflc,2018-Q1,0,0,0
-G. Ari Aye,2021-Q4,0,0,0
-G. Ari Aye,2021-Q3,0,0,0
 G. Ari Aye,2021-Q2,0,0,0
 G. Ari Aye,2021-Q1,0,0,0
 G. Ari Aye,2020-Q4,0,0,0
@@ -19679,8 +17219,6 @@ G. Ari Aye,2018-Q4,0,0,0
 G. Ari Aye,2018-Q3,0,0,0
 G. Ari Aye,2018-Q2,0,0,0
 G. Ari Aye,2018-Q1,0,0,0
-dengziming,2021-Q4,0,0,0
-dengziming,2021-Q3,0,0,0
 dengziming,2021-Q2,0,0,0
 dengziming,2021-Q1,0,0,0
 dengziming,2020-Q4,0,0,0
@@ -19695,8 +17233,6 @@ dengziming,2018-Q4,0,0,0
 dengziming,2018-Q3,0,0,0
 dengziming,2018-Q2,0,0,0
 dengziming,2018-Q1,0,0,0
-Joshua V. Dillon,2021-Q4,0,0,0
-Joshua V. Dillon,2021-Q3,0,0,0
 Joshua V. Dillon,2021-Q2,0,0,0
 Joshua V. Dillon,2021-Q1,0,0,0
 Joshua V. Dillon,2020-Q4,0,0,0
@@ -19711,8 +17247,6 @@ Joshua V. Dillon,2018-Q4,4,243,7
 Joshua V. Dillon,2018-Q3,0,0,0
 Joshua V. Dillon,2018-Q2,14,540,253
 Joshua V. Dillon,2018-Q1,86,5744,14313
-cathy,2021-Q4,0,0,0
-cathy,2021-Q3,0,0,0
 cathy,2021-Q2,0,0,0
 cathy,2021-Q1,0,0,0
 cathy,2020-Q4,0,0,0
@@ -19727,8 +17261,6 @@ cathy,2018-Q4,0,0,0
 cathy,2018-Q3,0,0,0
 cathy,2018-Q2,0,0,0
 cathy,2018-Q1,0,0,0
-Asmita Poddar,2021-Q4,0,0,0
-Asmita Poddar,2021-Q3,0,0,0
 Asmita Poddar,2021-Q2,0,0,0
 Asmita Poddar,2021-Q1,0,0,0
 Asmita Poddar,2020-Q4,0,0,0
@@ -19743,8 +17275,6 @@ Asmita Poddar,2018-Q4,0,0,0
 Asmita Poddar,2018-Q3,0,0,0
 Asmita Poddar,2018-Q2,0,0,0
 Asmita Poddar,2018-Q1,0,0,0
-wenxizhu,2021-Q4,0,0,0
-wenxizhu,2021-Q3,0,0,0
 wenxizhu,2021-Q2,0,0,0
 wenxizhu,2021-Q1,0,0,0
 wenxizhu,2020-Q4,0,0,0
@@ -19759,8 +17289,6 @@ wenxizhu,2018-Q4,38,1190,476
 wenxizhu,2018-Q3,0,0,0
 wenxizhu,2018-Q2,0,0,0
 wenxizhu,2018-Q1,0,0,0
-Satoshi Tanaka,2021-Q4,0,0,0
-Satoshi Tanaka,2021-Q3,0,0,0
 Satoshi Tanaka,2021-Q2,0,0,0
 Satoshi Tanaka,2021-Q1,0,0,0
 Satoshi Tanaka,2020-Q4,0,0,0
@@ -19775,8 +17303,6 @@ Satoshi Tanaka,2018-Q4,0,0,0
 Satoshi Tanaka,2018-Q3,0,0,0
 Satoshi Tanaka,2018-Q2,0,0,0
 Satoshi Tanaka,2018-Q1,0,0,0
-yuan,2021-Q4,0,0,0
-yuan,2021-Q3,0,0,0
 yuan,2021-Q2,0,0,0
 yuan,2021-Q1,0,0,0
 yuan,2020-Q4,0,0,0
@@ -19791,8 +17317,6 @@ yuan,2018-Q4,0,0,0
 yuan,2018-Q3,0,0,0
 yuan,2018-Q2,0,0,0
 yuan,2018-Q1,0,0,0
-Youwei Song,2021-Q4,0,0,0
-Youwei Song,2021-Q3,0,0,0
 Youwei Song,2021-Q2,0,0,0
 Youwei Song,2021-Q1,0,0,0
 Youwei Song,2020-Q4,0,0,0
@@ -19807,8 +17331,6 @@ Youwei Song,2018-Q4,0,0,0
 Youwei Song,2018-Q3,0,0,0
 Youwei Song,2018-Q2,0,0,0
 Youwei Song,2018-Q1,0,0,0
-Robert Herbig,2021-Q4,0,0,0
-Robert Herbig,2021-Q3,0,0,0
 Robert Herbig,2021-Q2,0,0,0
 Robert Herbig,2021-Q1,0,0,0
 Robert Herbig,2020-Q4,0,0,0
@@ -19823,8 +17345,6 @@ Robert Herbig,2018-Q4,0,0,0
 Robert Herbig,2018-Q3,0,0,0
 Robert Herbig,2018-Q2,0,0,0
 Robert Herbig,2018-Q1,0,0,0
-HarikrishnanBalagopal,2021-Q4,0,0,0
-HarikrishnanBalagopal,2021-Q3,0,0,0
 HarikrishnanBalagopal,2021-Q2,0,0,0
 HarikrishnanBalagopal,2021-Q1,0,0,0
 HarikrishnanBalagopal,2020-Q4,0,0,0
@@ -19839,8 +17359,6 @@ HarikrishnanBalagopal,2018-Q4,0,0,0
 HarikrishnanBalagopal,2018-Q3,0,0,0
 HarikrishnanBalagopal,2018-Q2,0,0,0
 HarikrishnanBalagopal,2018-Q1,0,0,0
-Greg Billock,2021-Q4,0,0,0
-Greg Billock,2021-Q3,0,0,0
 Greg Billock,2021-Q2,0,0,0
 Greg Billock,2021-Q1,0,0,0
 Greg Billock,2020-Q4,0,0,0
@@ -19855,8 +17373,6 @@ Greg Billock,2018-Q4,4,17,24
 Greg Billock,2018-Q3,0,0,0
 Greg Billock,2018-Q2,0,0,0
 Greg Billock,2018-Q1,0,0,0
-Tim Bradley,2021-Q4,0,0,0
-Tim Bradley,2021-Q3,0,0,0
 Tim Bradley,2021-Q2,0,0,0
 Tim Bradley,2021-Q1,0,0,0
 Tim Bradley,2020-Q4,0,0,0
@@ -19871,8 +17387,6 @@ Tim Bradley,2018-Q4,0,0,0
 Tim Bradley,2018-Q3,0,0,0
 Tim Bradley,2018-Q2,0,0,0
 Tim Bradley,2018-Q1,0,0,0
-Romeo Kienzler,2021-Q4,0,0,0
-Romeo Kienzler,2021-Q3,0,0,0
 Romeo Kienzler,2021-Q2,0,0,0
 Romeo Kienzler,2021-Q1,0,0,0
 Romeo Kienzler,2020-Q4,0,0,0
@@ -19887,8 +17401,6 @@ Romeo Kienzler,2018-Q4,0,0,0
 Romeo Kienzler,2018-Q3,0,0,0
 Romeo Kienzler,2018-Q2,0,0,0
 Romeo Kienzler,2018-Q1,0,0,0
-Stefan Dierauf,2021-Q4,0,0,0
-Stefan Dierauf,2021-Q3,0,0,0
 Stefan Dierauf,2021-Q2,0,0,0
 Stefan Dierauf,2021-Q1,0,0,0
 Stefan Dierauf,2020-Q4,0,0,0
@@ -19903,8 +17415,6 @@ Stefan Dierauf,2018-Q4,0,0,0
 Stefan Dierauf,2018-Q3,0,0,0
 Stefan Dierauf,2018-Q2,0,0,0
 Stefan Dierauf,2018-Q1,0,0,0
-DESKTOP-GOCKTI8\monkey_jesus,2021-Q4,0,0,0
-DESKTOP-GOCKTI8\monkey_jesus,2021-Q3,0,0,0
 DESKTOP-GOCKTI8\monkey_jesus,2021-Q2,0,0,0
 DESKTOP-GOCKTI8\monkey_jesus,2021-Q1,0,0,0
 DESKTOP-GOCKTI8\monkey_jesus,2020-Q4,0,0,0
@@ -19919,8 +17429,6 @@ DESKTOP-GOCKTI8\monkey_jesus,2018-Q4,0,0,0
 DESKTOP-GOCKTI8\monkey_jesus,2018-Q3,0,0,0
 DESKTOP-GOCKTI8\monkey_jesus,2018-Q2,0,0,0
 DESKTOP-GOCKTI8\monkey_jesus,2018-Q1,0,0,0
-saishruthi,2021-Q4,0,0,0
-saishruthi,2021-Q3,0,0,0
 saishruthi,2021-Q2,0,0,0
 saishruthi,2021-Q1,0,0,0
 saishruthi,2020-Q4,0,0,0
@@ -19935,8 +17443,6 @@ saishruthi,2018-Q4,0,0,0
 saishruthi,2018-Q3,0,0,0
 saishruthi,2018-Q2,0,0,0
 saishruthi,2018-Q1,0,0,0
-Yongfeng Gu,2021-Q4,0,0,0
-Yongfeng Gu,2021-Q3,0,0,0
 Yongfeng Gu,2021-Q2,0,0,0
 Yongfeng Gu,2021-Q1,0,0,0
 Yongfeng Gu,2020-Q4,0,0,0
@@ -19951,8 +17457,6 @@ Yongfeng Gu,2018-Q4,0,0,0
 Yongfeng Gu,2018-Q3,0,0,0
 Yongfeng Gu,2018-Q2,0,0,0
 Yongfeng Gu,2018-Q1,0,0,0
-Tim Gates,2021-Q4,0,0,0
-Tim Gates,2021-Q3,0,0,0
 Tim Gates,2021-Q2,0,0,0
 Tim Gates,2021-Q1,0,0,0
 Tim Gates,2020-Q4,0,0,0
@@ -19967,8 +17471,6 @@ Tim Gates,2018-Q4,0,0,0
 Tim Gates,2018-Q3,0,0,0
 Tim Gates,2018-Q2,0,0,0
 Tim Gates,2018-Q1,0,0,0
-Divyanshu,2021-Q4,0,0,0
-Divyanshu,2021-Q3,0,0,0
 Divyanshu,2021-Q2,0,0,0
 Divyanshu,2021-Q1,0,0,0
 Divyanshu,2020-Q4,0,0,0
@@ -19983,8 +17485,6 @@ Divyanshu,2018-Q4,0,0,0
 Divyanshu,2018-Q3,0,0,0
 Divyanshu,2018-Q2,0,0,0
 Divyanshu,2018-Q1,0,0,0
-Yuxin Wu,2021-Q4,0,0,0
-Yuxin Wu,2021-Q3,0,0,0
 Yuxin Wu,2021-Q2,0,0,0
 Yuxin Wu,2021-Q1,0,0,0
 Yuxin Wu,2020-Q4,0,0,0
@@ -19999,8 +17499,6 @@ Yuxin Wu,2018-Q4,1,0,0
 Yuxin Wu,2018-Q3,1,12,0
 Yuxin Wu,2018-Q2,12,78,28
 Yuxin Wu,2018-Q1,19,92,117
-Fred Reiss,2021-Q4,0,0,0
-Fred Reiss,2021-Q3,0,0,0
 Fred Reiss,2021-Q2,0,0,0
 Fred Reiss,2021-Q1,0,0,0
 Fred Reiss,2020-Q4,0,0,0
@@ -20015,8 +17513,6 @@ Fred Reiss,2018-Q4,0,0,0
 Fred Reiss,2018-Q3,0,0,0
 Fred Reiss,2018-Q2,0,0,0
 Fred Reiss,2018-Q1,3,142,127
-Nagy Mostafa,2021-Q4,0,0,0
-Nagy Mostafa,2021-Q3,0,0,0
 Nagy Mostafa,2021-Q2,0,0,0
 Nagy Mostafa,2021-Q1,0,0,0
 Nagy Mostafa,2020-Q4,0,0,0
@@ -20031,8 +17527,6 @@ Nagy Mostafa,2018-Q4,0,0,0
 Nagy Mostafa,2018-Q3,0,0,0
 Nagy Mostafa,2018-Q2,0,0,0
 Nagy Mostafa,2018-Q1,0,0,0
-Jessan Hutchison-Quillian,2021-Q4,0,0,0
-Jessan Hutchison-Quillian,2021-Q3,0,0,0
 Jessan Hutchison-Quillian,2021-Q2,0,0,0
 Jessan Hutchison-Quillian,2021-Q1,0,0,0
 Jessan Hutchison-Quillian,2020-Q4,0,0,0
@@ -20047,8 +17541,6 @@ Jessan Hutchison-Quillian,2018-Q4,0,0,0
 Jessan Hutchison-Quillian,2018-Q3,0,0,0
 Jessan Hutchison-Quillian,2018-Q2,0,0,0
 Jessan Hutchison-Quillian,2018-Q1,0,0,0
-refraction-ray,2021-Q4,0,0,0
-refraction-ray,2021-Q3,0,0,0
 refraction-ray,2021-Q2,0,0,0
 refraction-ray,2021-Q1,0,0,0
 refraction-ray,2020-Q4,0,0,0
@@ -20063,8 +17555,6 @@ refraction-ray,2018-Q4,0,0,0
 refraction-ray,2018-Q3,0,0,0
 refraction-ray,2018-Q2,0,0,0
 refraction-ray,2018-Q1,0,0,0
-Luciano Resende,2021-Q4,0,0,0
-Luciano Resende,2021-Q3,0,0,0
 Luciano Resende,2021-Q2,0,0,0
 Luciano Resende,2021-Q1,0,0,0
 Luciano Resende,2020-Q4,0,0,0
@@ -20079,8 +17569,6 @@ Luciano Resende,2018-Q4,0,0,0
 Luciano Resende,2018-Q3,0,0,0
 Luciano Resende,2018-Q2,0,0,0
 Luciano Resende,2018-Q1,0,0,0
-Huang Chen-Yi,2021-Q4,0,0,0
-Huang Chen-Yi,2021-Q3,0,0,0
 Huang Chen-Yi,2021-Q2,0,0,0
 Huang Chen-Yi,2021-Q1,0,0,0
 Huang Chen-Yi,2020-Q4,0,0,0
@@ -20095,8 +17583,6 @@ Huang Chen-Yi,2018-Q4,0,0,0
 Huang Chen-Yi,2018-Q3,0,0,0
 Huang Chen-Yi,2018-Q2,0,0,0
 Huang Chen-Yi,2018-Q1,0,0,0
-Nick Hamatake,2021-Q4,0,0,0
-Nick Hamatake,2021-Q3,0,0,0
 Nick Hamatake,2021-Q2,0,0,0
 Nick Hamatake,2021-Q1,0,0,0
 Nick Hamatake,2020-Q4,0,0,0
@@ -20111,8 +17597,6 @@ Nick Hamatake,2018-Q4,19,577,0
 Nick Hamatake,2018-Q3,0,0,0
 Nick Hamatake,2018-Q2,0,0,0
 Nick Hamatake,2018-Q1,0,0,0
-Alex Torres,2021-Q4,0,0,0
-Alex Torres,2021-Q3,0,0,0
 Alex Torres,2021-Q2,0,0,0
 Alex Torres,2021-Q1,0,0,0
 Alex Torres,2020-Q4,0,0,0
@@ -20127,8 +17611,6 @@ Alex Torres,2018-Q4,0,0,0
 Alex Torres,2018-Q3,0,0,0
 Alex Torres,2018-Q2,0,0,0
 Alex Torres,2018-Q1,0,0,0
-Colle,2021-Q4,0,0,0
-Colle,2021-Q3,0,0,0
 Colle,2021-Q2,0,0,0
 Colle,2021-Q1,0,0,0
 Colle,2020-Q4,0,0,0
@@ -20143,8 +17625,6 @@ Colle,2018-Q4,0,0,0
 Colle,2018-Q3,0,0,0
 Colle,2018-Q2,0,0,0
 Colle,2018-Q1,0,0,0
-candy.dc,2021-Q4,0,0,0
-candy.dc,2021-Q3,0,0,0
 candy.dc,2021-Q2,0,0,0
 candy.dc,2021-Q1,0,0,0
 candy.dc,2020-Q4,0,0,0
@@ -20159,8 +17639,6 @@ candy.dc,2018-Q4,1,0,2
 candy.dc,2018-Q3,3,12,9
 candy.dc,2018-Q2,1,0,0
 candy.dc,2018-Q1,0,0,0
-David Norman,2021-Q4,0,0,0
-David Norman,2021-Q3,0,0,0
 David Norman,2021-Q2,0,0,0
 David Norman,2021-Q1,0,0,0
 David Norman,2020-Q4,0,0,0
@@ -20175,8 +17653,6 @@ David Norman,2018-Q4,2,57,42
 David Norman,2018-Q3,3,29,26
 David Norman,2018-Q2,11,150,15
 David Norman,2018-Q1,3,28,8
-Ilham Firdausi Putra,2021-Q4,0,0,0
-Ilham Firdausi Putra,2021-Q3,0,0,0
 Ilham Firdausi Putra,2021-Q2,0,0,0
 Ilham Firdausi Putra,2021-Q1,0,0,0
 Ilham Firdausi Putra,2020-Q4,0,0,0
@@ -20191,8 +17667,6 @@ Ilham Firdausi Putra,2018-Q4,0,0,0
 Ilham Firdausi Putra,2018-Q3,0,0,0
 Ilham Firdausi Putra,2018-Q2,0,0,0
 Ilham Firdausi Putra,2018-Q1,0,0,0
-James Martens,2021-Q4,0,0,0
-James Martens,2021-Q3,0,0,0
 James Martens,2021-Q2,0,0,0
 James Martens,2021-Q1,0,0,0
 James Martens,2020-Q4,0,0,0
@@ -20207,8 +17681,6 @@ James Martens,2018-Q4,0,0,0
 James Martens,2018-Q3,0,0,0
 James Martens,2018-Q2,24,781,495
 James Martens,2018-Q1,0,0,0
-Anton Kachatkou,2021-Q4,0,0,0
-Anton Kachatkou,2021-Q3,0,0,0
 Anton Kachatkou,2021-Q2,0,0,0
 Anton Kachatkou,2021-Q1,0,0,0
 Anton Kachatkou,2020-Q4,0,0,0
@@ -20223,8 +17695,6 @@ Anton Kachatkou,2018-Q4,0,0,0
 Anton Kachatkou,2018-Q3,0,0,0
 Anton Kachatkou,2018-Q2,0,0,0
 Anton Kachatkou,2018-Q1,0,0,0
-Zaccharie Ramzi,2021-Q4,0,0,0
-Zaccharie Ramzi,2021-Q3,0,0,0
 Zaccharie Ramzi,2021-Q2,0,0,0
 Zaccharie Ramzi,2021-Q1,0,0,0
 Zaccharie Ramzi,2020-Q4,0,0,0
@@ -20239,8 +17709,6 @@ Zaccharie Ramzi,2018-Q4,0,0,0
 Zaccharie Ramzi,2018-Q3,0,0,0
 Zaccharie Ramzi,2018-Q2,0,0,0
 Zaccharie Ramzi,2018-Q1,0,0,0
-Ryan McCormick,2021-Q4,0,0,0
-Ryan McCormick,2021-Q3,0,0,0
 Ryan McCormick,2021-Q2,0,0,0
 Ryan McCormick,2021-Q1,0,0,0
 Ryan McCormick,2020-Q4,0,0,0
@@ -20255,8 +17723,6 @@ Ryan McCormick,2018-Q4,0,0,0
 Ryan McCormick,2018-Q3,0,0,0
 Ryan McCormick,2018-Q2,0,0,0
 Ryan McCormick,2018-Q1,0,0,0
-Artem Ryabov,2021-Q4,0,0,0
-Artem Ryabov,2021-Q3,0,0,0
 Artem Ryabov,2021-Q2,0,0,0
 Artem Ryabov,2021-Q1,0,0,0
 Artem Ryabov,2020-Q4,0,0,0
@@ -20271,8 +17737,6 @@ Artem Ryabov,2018-Q4,0,0,0
 Artem Ryabov,2018-Q3,0,0,0
 Artem Ryabov,2018-Q2,0,0,0
 Artem Ryabov,2018-Q1,0,0,0
-Paul Wais,2021-Q4,0,0,0
-Paul Wais,2021-Q3,0,0,0
 Paul Wais,2021-Q2,0,0,0
 Paul Wais,2021-Q1,0,0,0
 Paul Wais,2020-Q4,0,0,0
@@ -20287,8 +17751,6 @@ Paul Wais,2018-Q4,0,0,0
 Paul Wais,2018-Q3,0,0,0
 Paul Wais,2018-Q2,0,0,0
 Paul Wais,2018-Q1,0,0,0
-Alina Sbirlea,2021-Q4,0,0,0
-Alina Sbirlea,2021-Q3,0,0,0
 Alina Sbirlea,2021-Q2,0,0,0
 Alina Sbirlea,2021-Q1,0,0,0
 Alina Sbirlea,2020-Q4,0,0,0
@@ -20303,8 +17765,6 @@ Alina Sbirlea,2018-Q4,0,0,0
 Alina Sbirlea,2018-Q3,0,0,0
 Alina Sbirlea,2018-Q2,3,589,0
 Alina Sbirlea,2018-Q1,6,590,590
-Daniel Wong,2021-Q4,0,0,0
-Daniel Wong,2021-Q3,0,0,0
 Daniel Wong,2021-Q2,0,0,0
 Daniel Wong,2021-Q1,0,0,0
 Daniel Wong,2020-Q4,0,0,0
@@ -20319,8 +17779,6 @@ Daniel Wong,2018-Q4,0,0,0
 Daniel Wong,2018-Q3,0,0,0
 Daniel Wong,2018-Q2,0,0,0
 Daniel Wong,2018-Q1,0,0,0
-Chris Lattner,2021-Q4,0,0,0
-Chris Lattner,2021-Q3,0,0,0
 Chris Lattner,2021-Q2,0,0,0
 Chris Lattner,2021-Q1,0,0,0
 Chris Lattner,2020-Q4,0,0,0
@@ -20335,8 +17793,6 @@ Chris Lattner,2018-Q4,853,15546,14743
 Chris Lattner,2018-Q3,596,15261,6009
 Chris Lattner,2018-Q2,94,3766,501
 Chris Lattner,2018-Q1,0,0,0
-anubh-v,2021-Q4,0,0,0
-anubh-v,2021-Q3,0,0,0
 anubh-v,2021-Q2,0,0,0
 anubh-v,2021-Q1,0,0,0
 anubh-v,2020-Q4,0,0,0
@@ -20351,8 +17807,6 @@ anubh-v,2018-Q4,0,0,0
 anubh-v,2018-Q3,0,0,0
 anubh-v,2018-Q2,0,0,0
 anubh-v,2018-Q1,0,0,0
-Igor Saprykin,2021-Q4,0,0,0
-Igor Saprykin,2021-Q3,0,0,0
 Igor Saprykin,2021-Q2,0,0,0
 Igor Saprykin,2021-Q1,0,0,0
 Igor Saprykin,2020-Q4,0,0,0
@@ -20367,8 +17821,6 @@ Igor Saprykin,2018-Q4,0,0,0
 Igor Saprykin,2018-Q3,0,0,0
 Igor Saprykin,2018-Q2,41,815,3570
 Igor Saprykin,2018-Q1,30,3545,251
-Sundeep Gottipati,2021-Q4,0,0,0
-Sundeep Gottipati,2021-Q3,0,0,0
 Sundeep Gottipati,2021-Q2,0,0,0
 Sundeep Gottipati,2021-Q1,0,0,0
 Sundeep Gottipati,2020-Q4,0,0,0
@@ -20383,8 +17835,6 @@ Sundeep Gottipati,2018-Q4,0,0,0
 Sundeep Gottipati,2018-Q3,0,0,0
 Sundeep Gottipati,2018-Q2,0,0,0
 Sundeep Gottipati,2018-Q1,0,0,0
-Dan Ringwalt,2021-Q4,0,0,0
-Dan Ringwalt,2021-Q3,0,0,0
 Dan Ringwalt,2021-Q2,0,0,0
 Dan Ringwalt,2021-Q1,0,0,0
 Dan Ringwalt,2020-Q4,0,0,0
@@ -20399,8 +17849,6 @@ Dan Ringwalt,2018-Q4,0,0,0
 Dan Ringwalt,2018-Q3,10,245,76
 Dan Ringwalt,2018-Q2,0,0,0
 Dan Ringwalt,2018-Q1,16,1010,79
-Muhwan Kim,2021-Q4,0,0,0
-Muhwan Kim,2021-Q3,0,0,0
 Muhwan Kim,2021-Q2,0,0,0
 Muhwan Kim,2021-Q1,0,0,0
 Muhwan Kim,2020-Q4,0,0,0
@@ -20415,8 +17863,6 @@ Muhwan Kim,2018-Q4,0,0,0
 Muhwan Kim,2018-Q3,0,0,0
 Muhwan Kim,2018-Q2,0,0,0
 Muhwan Kim,2018-Q1,0,0,0
-Chintan Kaur,2021-Q4,0,0,0
-Chintan Kaur,2021-Q3,0,0,0
 Chintan Kaur,2021-Q2,0,0,0
 Chintan Kaur,2021-Q1,0,0,0
 Chintan Kaur,2020-Q4,0,0,0
@@ -20431,8 +17877,6 @@ Chintan Kaur,2018-Q4,0,0,0
 Chintan Kaur,2018-Q3,0,0,0
 Chintan Kaur,2018-Q2,0,0,0
 Chintan Kaur,2018-Q1,0,0,0
-HJYOO,2021-Q4,0,0,0
-HJYOO,2021-Q3,0,0,0
 HJYOO,2021-Q2,0,0,0
 HJYOO,2021-Q1,0,0,0
 HJYOO,2020-Q4,0,0,0
@@ -20447,8 +17891,6 @@ HJYOO,2018-Q4,0,0,0
 HJYOO,2018-Q3,0,0,0
 HJYOO,2018-Q2,0,0,0
 HJYOO,2018-Q1,0,0,0
-Siddhartha Bagaria,2021-Q4,0,0,0
-Siddhartha Bagaria,2021-Q3,0,0,0
 Siddhartha Bagaria,2021-Q2,0,0,0
 Siddhartha Bagaria,2021-Q1,0,0,0
 Siddhartha Bagaria,2020-Q4,0,0,0
@@ -20463,8 +17905,6 @@ Siddhartha Bagaria,2018-Q4,0,0,0
 Siddhartha Bagaria,2018-Q3,0,0,0
 Siddhartha Bagaria,2018-Q2,0,0,0
 Siddhartha Bagaria,2018-Q1,0,0,0
-Zhang,2021-Q4,0,0,0
-Zhang,2021-Q3,0,0,0
 Zhang,2021-Q2,0,0,0
 Zhang,2021-Q1,0,0,0
 Zhang,2020-Q4,0,0,0
@@ -20479,8 +17919,6 @@ Zhang,2018-Q4,0,0,0
 Zhang,2018-Q3,0,0,0
 Zhang,2018-Q2,0,0,0
 Zhang,2018-Q1,0,0,0
-王振华 (Zhenhua WANG),2021-Q4,0,0,0
-王振华 (Zhenhua WANG),2021-Q3,0,0,0
 王振华 (Zhenhua WANG),2021-Q2,0,0,0
 王振华 (Zhenhua WANG),2021-Q1,0,0,0
 王振华 (Zhenhua WANG),2020-Q4,0,0,0
@@ -20495,8 +17933,6 @@ Zhang,2018-Q1,0,0,0
 王振华 (Zhenhua WANG),2018-Q3,0,0,0
 王振华 (Zhenhua WANG),2018-Q2,0,0,0
 王振华 (Zhenhua WANG),2018-Q1,0,0,0
-Karthik Muthuraman,2021-Q4,0,0,0
-Karthik Muthuraman,2021-Q3,0,0,0
 Karthik Muthuraman,2021-Q2,0,0,0
 Karthik Muthuraman,2021-Q1,0,0,0
 Karthik Muthuraman,2020-Q4,0,0,0
@@ -20511,8 +17947,6 @@ Karthik Muthuraman,2018-Q4,0,0,0
 Karthik Muthuraman,2018-Q3,0,0,0
 Karthik Muthuraman,2018-Q2,0,0,0
 Karthik Muthuraman,2018-Q1,0,0,0
-Camillo Lugaresi,2021-Q4,0,0,0
-Camillo Lugaresi,2021-Q3,0,0,0
 Camillo Lugaresi,2021-Q2,0,0,0
 Camillo Lugaresi,2021-Q1,0,0,0
 Camillo Lugaresi,2020-Q4,0,0,0
@@ -20527,8 +17961,6 @@ Camillo Lugaresi,2018-Q4,0,0,0
 Camillo Lugaresi,2018-Q3,0,0,0
 Camillo Lugaresi,2018-Q2,0,0,0
 Camillo Lugaresi,2018-Q1,0,0,0
-Jue Wang,2021-Q4,0,0,0
-Jue Wang,2021-Q3,0,0,0
 Jue Wang,2021-Q2,0,0,0
 Jue Wang,2021-Q1,0,0,0
 Jue Wang,2020-Q4,0,0,0
@@ -20543,8 +17975,6 @@ Jue Wang,2018-Q4,0,0,0
 Jue Wang,2018-Q3,0,0,0
 Jue Wang,2018-Q2,0,0,0
 Jue Wang,2018-Q1,0,0,0
-Oscar Ramirez,2021-Q4,0,0,0
-Oscar Ramirez,2021-Q3,0,0,0
 Oscar Ramirez,2021-Q2,0,0,0
 Oscar Ramirez,2021-Q1,0,0,0
 Oscar Ramirez,2020-Q4,0,0,0
@@ -20559,8 +17989,6 @@ Oscar Ramirez,2018-Q4,0,0,0
 Oscar Ramirez,2018-Q3,0,0,0
 Oscar Ramirez,2018-Q2,0,0,0
 Oscar Ramirez,2018-Q1,0,0,0
-Brendan McMahan,2021-Q4,0,0,0
-Brendan McMahan,2021-Q3,0,0,0
 Brendan McMahan,2021-Q2,0,0,0
 Brendan McMahan,2021-Q1,0,0,0
 Brendan McMahan,2020-Q4,0,0,0
@@ -20575,8 +18003,6 @@ Brendan McMahan,2018-Q4,0,0,0
 Brendan McMahan,2018-Q3,0,0,0
 Brendan McMahan,2018-Q2,0,0,0
 Brendan McMahan,2018-Q1,0,0,0
-Takeshi Watanabe,2021-Q4,0,0,0
-Takeshi Watanabe,2021-Q3,0,0,0
 Takeshi Watanabe,2021-Q2,0,0,0
 Takeshi Watanabe,2021-Q1,0,0,0
 Takeshi Watanabe,2020-Q4,0,0,0
@@ -20591,8 +18017,6 @@ Takeshi Watanabe,2018-Q4,0,0,0
 Takeshi Watanabe,2018-Q3,0,0,0
 Takeshi Watanabe,2018-Q2,0,0,0
 Takeshi Watanabe,2018-Q1,0,0,0
-Bhavani Subramanian,2021-Q4,0,0,0
-Bhavani Subramanian,2021-Q3,0,0,0
 Bhavani Subramanian,2021-Q2,0,0,0
 Bhavani Subramanian,2021-Q1,0,0,0
 Bhavani Subramanian,2020-Q4,0,0,0
@@ -20607,8 +18031,6 @@ Bhavani Subramanian,2018-Q4,11,835,219
 Bhavani Subramanian,2018-Q3,0,0,0
 Bhavani Subramanian,2018-Q2,0,0,0
 Bhavani Subramanian,2018-Q1,0,0,0
-TensorFlower Gardener,2021-Q4,0,0,0
-TensorFlower Gardener,2021-Q3,0,0,0
 TensorFlower Gardener,2021-Q2,0,0,0
 TensorFlower Gardener,2021-Q1,0,0,0
 TensorFlower Gardener,2020-Q4,0,0,0
@@ -20623,8 +18045,6 @@ TensorFlower Gardener,2018-Q4,0,0,0
 TensorFlower Gardener,2018-Q3,0,0,0
 TensorFlower Gardener,2018-Q2,0,0,0
 TensorFlower Gardener,2018-Q1,0,0,0
-Ivan Habernal,2021-Q4,0,0,0
-Ivan Habernal,2021-Q3,0,0,0
 Ivan Habernal,2021-Q2,0,0,0
 Ivan Habernal,2021-Q1,0,0,0
 Ivan Habernal,2020-Q4,0,0,0
@@ -20639,8 +18059,6 @@ Ivan Habernal,2018-Q4,0,0,0
 Ivan Habernal,2018-Q3,0,0,0
 Ivan Habernal,2018-Q2,0,0,0
 Ivan Habernal,2018-Q1,0,0,0
-Emily Glanz,2021-Q4,0,0,0
-Emily Glanz,2021-Q3,0,0,0
 Emily Glanz,2021-Q2,0,0,0
 Emily Glanz,2021-Q1,0,0,0
 Emily Glanz,2020-Q4,0,0,0
@@ -20655,8 +18073,6 @@ Emily Glanz,2018-Q4,0,0,0
 Emily Glanz,2018-Q3,0,0,0
 Emily Glanz,2018-Q2,0,0,0
 Emily Glanz,2018-Q1,0,0,0
-Matthew Denton,2021-Q4,0,0,0
-Matthew Denton,2021-Q3,0,0,0
 Matthew Denton,2021-Q2,0,0,0
 Matthew Denton,2021-Q1,0,0,0
 Matthew Denton,2020-Q4,0,0,0
@@ -20671,8 +18087,6 @@ Matthew Denton,2018-Q4,0,0,0
 Matthew Denton,2018-Q3,0,0,0
 Matthew Denton,2018-Q2,0,0,0
 Matthew Denton,2018-Q1,0,0,0
-Vinu Rajashekhar,2021-Q4,0,0,0
-Vinu Rajashekhar,2021-Q3,0,0,0
 Vinu Rajashekhar,2021-Q2,0,0,0
 Vinu Rajashekhar,2021-Q1,0,0,0
 Vinu Rajashekhar,2020-Q4,0,0,0
@@ -20687,8 +18101,6 @@ Vinu Rajashekhar,2018-Q4,1,17,0
 Vinu Rajashekhar,2018-Q3,2,3,9
 Vinu Rajashekhar,2018-Q2,10,732,82
 Vinu Rajashekhar,2018-Q1,0,0,0
-Jun Wan,2021-Q4,0,0,0
-Jun Wan,2021-Q3,0,0,0
 Jun Wan,2021-Q2,0,0,0
 Jun Wan,2021-Q1,0,0,0
 Jun Wan,2020-Q4,0,0,0
@@ -20703,8 +18115,6 @@ Jun Wan,2018-Q4,0,0,0
 Jun Wan,2018-Q3,0,0,0
 Jun Wan,2018-Q2,0,0,0
 Jun Wan,2018-Q1,0,0,0
-Andrii Prymostka,2021-Q4,0,0,0
-Andrii Prymostka,2021-Q3,0,0,0
 Andrii Prymostka,2021-Q2,0,0,0
 Andrii Prymostka,2021-Q1,0,0,0
 Andrii Prymostka,2020-Q4,0,0,0
@@ -20719,8 +18129,6 @@ Andrii Prymostka,2018-Q4,0,0,0
 Andrii Prymostka,2018-Q3,13,751,346
 Andrii Prymostka,2018-Q2,0,0,0
 Andrii Prymostka,2018-Q1,0,0,0
-jpienaar,2021-Q4,0,0,0
-jpienaar,2021-Q3,0,0,0
 jpienaar,2021-Q2,0,0,0
 jpienaar,2021-Q1,0,0,0
 jpienaar,2020-Q4,0,0,0
@@ -20735,8 +18143,6 @@ jpienaar,2018-Q4,0,0,0
 jpienaar,2018-Q3,0,0,0
 jpienaar,2018-Q2,0,0,0
 jpienaar,2018-Q1,0,0,0
-kstuedem,2021-Q4,0,0,0
-kstuedem,2021-Q3,0,0,0
 kstuedem,2021-Q2,0,0,0
 kstuedem,2021-Q1,0,0,0
 kstuedem,2020-Q4,0,0,0
@@ -20751,8 +18157,6 @@ kstuedem,2018-Q4,0,0,0
 kstuedem,2018-Q3,0,0,0
 kstuedem,2018-Q2,0,0,0
 kstuedem,2018-Q1,0,0,0
-Matthew Bentham,2021-Q4,0,0,0
-Matthew Bentham,2021-Q3,0,0,0
 Matthew Bentham,2021-Q2,0,0,0
 Matthew Bentham,2021-Q1,0,0,0
 Matthew Bentham,2020-Q4,0,0,0
@@ -20767,8 +18171,6 @@ Matthew Bentham,2018-Q4,0,0,0
 Matthew Bentham,2018-Q3,0,0,0
 Matthew Bentham,2018-Q2,0,0,0
 Matthew Bentham,2018-Q1,0,0,0
-Timothy Liu,2021-Q4,0,0,0
-Timothy Liu,2021-Q3,0,0,0
 Timothy Liu,2021-Q2,0,0,0
 Timothy Liu,2021-Q1,0,0,0
 Timothy Liu,2020-Q4,0,0,0
@@ -20783,8 +18185,6 @@ Timothy Liu,2018-Q4,0,0,0
 Timothy Liu,2018-Q3,0,0,0
 Timothy Liu,2018-Q2,0,0,0
 Timothy Liu,2018-Q1,0,0,0
-Tomer Gafner,2021-Q4,0,0,0
-Tomer Gafner,2021-Q3,0,0,0
 Tomer Gafner,2021-Q2,0,0,0
 Tomer Gafner,2021-Q1,0,0,0
 Tomer Gafner,2020-Q4,0,0,0
@@ -20799,8 +18199,6 @@ Tomer Gafner,2018-Q4,0,0,0
 Tomer Gafner,2018-Q3,0,0,0
 Tomer Gafner,2018-Q2,0,0,0
 Tomer Gafner,2018-Q1,0,0,0
-Aaron Ma,2021-Q4,0,0,0
-Aaron Ma,2021-Q3,0,0,0
 Aaron Ma,2021-Q2,0,0,0
 Aaron Ma,2021-Q1,0,0,0
 Aaron Ma,2020-Q4,0,0,0
@@ -20815,8 +18213,6 @@ Aaron Ma,2018-Q4,0,0,0
 Aaron Ma,2018-Q3,0,0,0
 Aaron Ma,2018-Q2,0,0,0
 Aaron Ma,2018-Q1,0,0,0
-captain-pool,2021-Q4,0,0,0
-captain-pool,2021-Q3,0,0,0
 captain-pool,2021-Q2,0,0,0
 captain-pool,2021-Q1,0,0,0
 captain-pool,2020-Q4,0,0,0
@@ -20831,8 +18227,6 @@ captain-pool,2018-Q4,0,0,0
 captain-pool,2018-Q3,0,0,0
 captain-pool,2018-Q2,0,0,0
 captain-pool,2018-Q1,0,0,0
-olramde,2021-Q4,0,0,0
-olramde,2021-Q3,0,0,0
 olramde,2021-Q2,0,0,0
 olramde,2021-Q1,0,0,0
 olramde,2020-Q4,0,0,0
@@ -20847,8 +18241,6 @@ olramde,2018-Q4,0,0,0
 olramde,2018-Q3,0,0,0
 olramde,2018-Q2,0,0,0
 olramde,2018-Q1,0,0,0
-Lukas Folle,2021-Q4,0,0,0
-Lukas Folle,2021-Q3,0,0,0
 Lukas Folle,2021-Q2,0,0,0
 Lukas Folle,2021-Q1,0,0,0
 Lukas Folle,2020-Q4,0,0,0
@@ -20863,8 +18255,6 @@ Lukas Folle,2018-Q4,0,0,0
 Lukas Folle,2018-Q3,0,0,0
 Lukas Folle,2018-Q2,0,0,0
 Lukas Folle,2018-Q1,0,0,0
-Eileen Mao,2021-Q4,0,0,0
-Eileen Mao,2021-Q3,0,0,0
 Eileen Mao,2021-Q2,0,0,0
 Eileen Mao,2021-Q1,0,0,0
 Eileen Mao,2020-Q4,0,0,0
@@ -20879,8 +18269,6 @@ Eileen Mao,2018-Q4,0,0,0
 Eileen Mao,2018-Q3,0,0,0
 Eileen Mao,2018-Q2,0,0,0
 Eileen Mao,2018-Q1,0,0,0
-Dan Ganea,2021-Q4,0,0,0
-Dan Ganea,2021-Q3,0,0,0
 Dan Ganea,2021-Q2,0,0,0
 Dan Ganea,2021-Q1,0,0,0
 Dan Ganea,2020-Q4,0,0,0
@@ -20895,8 +18283,6 @@ Dan Ganea,2018-Q4,0,0,0
 Dan Ganea,2018-Q3,0,0,0
 Dan Ganea,2018-Q2,0,0,0
 Dan Ganea,2018-Q1,0,0,0
-richardbrks,2021-Q4,0,0,0
-richardbrks,2021-Q3,0,0,0
 richardbrks,2021-Q2,0,0,0
 richardbrks,2021-Q1,0,0,0
 richardbrks,2020-Q4,0,0,0
@@ -20911,8 +18297,6 @@ richardbrks,2018-Q4,0,0,0
 richardbrks,2018-Q3,0,0,0
 richardbrks,2018-Q2,0,0,0
 richardbrks,2018-Q1,0,0,0
-Trevor Morris,2021-Q4,0,0,0
-Trevor Morris,2021-Q3,0,0,0
 Trevor Morris,2021-Q2,0,0,0
 Trevor Morris,2021-Q1,0,0,0
 Trevor Morris,2020-Q4,0,0,0
@@ -20927,8 +18311,6 @@ Trevor Morris,2018-Q4,137,3691,1072
 Trevor Morris,2018-Q3,18,590,56
 Trevor Morris,2018-Q2,0,0,0
 Trevor Morris,2018-Q1,0,0,0
-Kan Chen,2021-Q4,0,0,0
-Kan Chen,2021-Q3,0,0,0
 Kan Chen,2021-Q2,0,0,0
 Kan Chen,2021-Q1,0,0,0
 Kan Chen,2020-Q4,0,0,0
@@ -20943,8 +18325,6 @@ Kan Chen,2018-Q4,0,0,0
 Kan Chen,2018-Q3,0,0,0
 Kan Chen,2018-Q2,0,0,0
 Kan Chen,2018-Q1,0,0,0
-Pete Blacker,2021-Q4,0,0,0
-Pete Blacker,2021-Q3,0,0,0
 Pete Blacker,2021-Q2,0,0,0
 Pete Blacker,2021-Q1,0,0,0
 Pete Blacker,2020-Q4,0,0,0
@@ -20959,8 +18339,6 @@ Pete Blacker,2018-Q4,0,0,0
 Pete Blacker,2018-Q3,0,0,0
 Pete Blacker,2018-Q2,0,0,0
 Pete Blacker,2018-Q1,0,0,0
-Mehrdad Khatir,2021-Q4,0,0,0
-Mehrdad Khatir,2021-Q3,0,0,0
 Mehrdad Khatir,2021-Q2,0,0,0
 Mehrdad Khatir,2021-Q1,0,0,0
 Mehrdad Khatir,2020-Q4,0,0,0
@@ -20975,8 +18353,6 @@ Mehrdad Khatir,2018-Q4,0,0,0
 Mehrdad Khatir,2018-Q3,0,0,0
 Mehrdad Khatir,2018-Q2,0,0,0
 Mehrdad Khatir,2018-Q1,0,0,0
-Saket Khandelwal,2021-Q4,0,0,0
-Saket Khandelwal,2021-Q3,0,0,0
 Saket Khandelwal,2021-Q2,0,0,0
 Saket Khandelwal,2021-Q1,0,0,0
 Saket Khandelwal,2020-Q4,0,0,0
@@ -20991,8 +18367,6 @@ Saket Khandelwal,2018-Q4,0,0,0
 Saket Khandelwal,2018-Q3,0,0,0
 Saket Khandelwal,2018-Q2,0,0,0
 Saket Khandelwal,2018-Q1,0,0,0
-I-Hong,2021-Q4,0,0,0
-I-Hong,2021-Q3,0,0,0
 I-Hong,2021-Q2,0,0,0
 I-Hong,2021-Q1,0,0,0
 I-Hong,2020-Q4,0,0,0
@@ -21007,8 +18381,6 @@ I-Hong,2018-Q4,0,0,0
 I-Hong,2018-Q3,0,0,0
 I-Hong,2018-Q2,0,0,0
 I-Hong,2018-Q1,0,0,0
-Shining Sun,2021-Q4,0,0,0
-Shining Sun,2021-Q3,0,0,0
 Shining Sun,2021-Q2,0,0,0
 Shining Sun,2021-Q1,0,0,0
 Shining Sun,2020-Q4,0,0,0
@@ -21023,8 +18395,6 @@ Shining Sun,2018-Q4,20,203,117
 Shining Sun,2018-Q3,0,0,0
 Shining Sun,2018-Q2,0,0,0
 Shining Sun,2018-Q1,0,0,0
-Choong Yin Thong,2021-Q4,0,0,0
-Choong Yin Thong,2021-Q3,0,0,0
 Choong Yin Thong,2021-Q2,0,0,0
 Choong Yin Thong,2021-Q1,0,0,0
 Choong Yin Thong,2020-Q4,0,0,0
@@ -21039,8 +18409,6 @@ Choong Yin Thong,2018-Q4,0,0,0
 Choong Yin Thong,2018-Q3,0,0,0
 Choong Yin Thong,2018-Q2,0,0,0
 Choong Yin Thong,2018-Q1,0,0,0
-4d55397500,2021-Q4,0,0,0
-4d55397500,2021-Q3,0,0,0
 4d55397500,2021-Q2,0,0,0
 4d55397500,2021-Q1,0,0,0
 4d55397500,2020-Q4,0,0,0
@@ -21055,8 +18423,6 @@ Choong Yin Thong,2018-Q1,0,0,0
 4d55397500,2018-Q3,0,0,0
 4d55397500,2018-Q2,0,0,0
 4d55397500,2018-Q1,3,4,3
-Edd Wilder-James,2021-Q4,0,0,0
-Edd Wilder-James,2021-Q3,0,0,0
 Edd Wilder-James,2021-Q2,0,0,0
 Edd Wilder-James,2021-Q1,0,0,0
 Edd Wilder-James,2020-Q4,0,0,0
@@ -21071,8 +18437,6 @@ Edd Wilder-James,2018-Q4,0,0,0
 Edd Wilder-James,2018-Q3,0,0,0
 Edd Wilder-James,2018-Q2,0,0,0
 Edd Wilder-James,2018-Q1,2,6,0
-Kashif Rasul,2021-Q4,0,0,0
-Kashif Rasul,2021-Q3,0,0,0
 Kashif Rasul,2021-Q2,0,0,0
 Kashif Rasul,2021-Q1,0,0,0
 Kashif Rasul,2020-Q4,0,0,0
@@ -21087,8 +18451,6 @@ Kashif Rasul,2018-Q4,0,0,0
 Kashif Rasul,2018-Q3,0,0,0
 Kashif Rasul,2018-Q2,0,0,0
 Kashif Rasul,2018-Q1,0,0,0
-Dr. Kashif Rasul,2021-Q4,0,0,0
-Dr. Kashif Rasul,2021-Q3,0,0,0
 Dr. Kashif Rasul,2021-Q2,0,0,0
 Dr. Kashif Rasul,2021-Q1,0,0,0
 Dr. Kashif Rasul,2020-Q4,0,0,0
@@ -21103,8 +18465,6 @@ Dr. Kashif Rasul,2018-Q4,0,0,0
 Dr. Kashif Rasul,2018-Q3,0,0,0
 Dr. Kashif Rasul,2018-Q2,0,0,0
 Dr. Kashif Rasul,2018-Q1,0,0,0
-Chong Yan,2021-Q4,0,0,0
-Chong Yan,2021-Q3,0,0,0
 Chong Yan,2021-Q2,0,0,0
 Chong Yan,2021-Q1,0,0,0
 Chong Yan,2020-Q4,0,0,0
@@ -21119,8 +18479,6 @@ Chong Yan,2018-Q4,0,0,0
 Chong Yan,2018-Q3,0,0,0
 Chong Yan,2018-Q2,0,0,0
 Chong Yan,2018-Q1,0,0,0
-fwcore,2021-Q4,0,0,0
-fwcore,2021-Q3,0,0,0
 fwcore,2021-Q2,0,0,0
 fwcore,2021-Q1,0,0,0
 fwcore,2020-Q4,0,0,0
@@ -21135,8 +18493,6 @@ fwcore,2018-Q4,0,0,0
 fwcore,2018-Q3,0,0,0
 fwcore,2018-Q2,0,0,0
 fwcore,2018-Q1,0,0,0
-Shubham Goyal,2021-Q4,0,0,0
-Shubham Goyal,2021-Q3,0,0,0
 Shubham Goyal,2021-Q2,0,0,0
 Shubham Goyal,2021-Q1,0,0,0
 Shubham Goyal,2020-Q4,0,0,0
@@ -21151,8 +18507,6 @@ Shubham Goyal,2018-Q4,0,0,0
 Shubham Goyal,2018-Q3,0,0,0
 Shubham Goyal,2018-Q2,0,0,0
 Shubham Goyal,2018-Q1,0,0,0
-ThisIsIsaac,2021-Q4,0,0,0
-ThisIsIsaac,2021-Q3,0,0,0
 ThisIsIsaac,2021-Q2,0,0,0
 ThisIsIsaac,2021-Q1,0,0,0
 ThisIsIsaac,2020-Q4,0,0,0
@@ -21167,8 +18521,6 @@ ThisIsIsaac,2018-Q4,0,0,0
 ThisIsIsaac,2018-Q3,0,0,0
 ThisIsIsaac,2018-Q2,0,0,0
 ThisIsIsaac,2018-Q1,0,0,0
-jojimon.varghese,2021-Q4,0,0,0
-jojimon.varghese,2021-Q3,0,0,0
 jojimon.varghese,2021-Q2,0,0,0
 jojimon.varghese,2021-Q1,0,0,0
 jojimon.varghese,2020-Q4,0,0,0
@@ -21183,8 +18535,6 @@ jojimon.varghese,2018-Q4,0,0,0
 jojimon.varghese,2018-Q3,0,0,0
 jojimon.varghese,2018-Q2,0,0,0
 jojimon.varghese,2018-Q1,0,0,0
-Neil,2021-Q4,0,0,0
-Neil,2021-Q3,0,0,0
 Neil,2021-Q2,0,0,0
 Neil,2021-Q1,0,0,0
 Neil,2020-Q4,0,0,0
@@ -21199,8 +18549,6 @@ Neil,2018-Q4,0,0,0
 Neil,2018-Q3,0,0,0
 Neil,2018-Q2,0,0,0
 Neil,2018-Q1,0,0,0
-Johan Gunnarsson,2021-Q4,0,0,0
-Johan Gunnarsson,2021-Q3,0,0,0
 Johan Gunnarsson,2021-Q2,0,0,0
 Johan Gunnarsson,2021-Q1,0,0,0
 Johan Gunnarsson,2020-Q4,0,0,0
@@ -21215,8 +18563,6 @@ Johan Gunnarsson,2018-Q4,0,0,0
 Johan Gunnarsson,2018-Q3,0,0,0
 Johan Gunnarsson,2018-Q2,0,0,0
 Johan Gunnarsson,2018-Q1,0,0,0
-Junyuan Xie,2021-Q4,0,0,0
-Junyuan Xie,2021-Q3,0,0,0
 Junyuan Xie,2021-Q2,0,0,0
 Junyuan Xie,2021-Q1,0,0,0
 Junyuan Xie,2020-Q4,0,0,0
@@ -21231,8 +18577,6 @@ Junyuan Xie,2018-Q4,0,0,0
 Junyuan Xie,2018-Q3,0,0,0
 Junyuan Xie,2018-Q2,0,0,0
 Junyuan Xie,2018-Q1,0,0,0
-ocjosen,2021-Q4,0,0,0
-ocjosen,2021-Q3,0,0,0
 ocjosen,2021-Q2,0,0,0
 ocjosen,2021-Q1,0,0,0
 ocjosen,2020-Q4,0,0,0
@@ -21247,8 +18591,6 @@ ocjosen,2018-Q4,0,0,0
 ocjosen,2018-Q3,0,0,0
 ocjosen,2018-Q2,0,0,0
 ocjosen,2018-Q1,0,0,0
-Alexey Romanov,2021-Q4,0,0,0
-Alexey Romanov,2021-Q3,0,0,0
 Alexey Romanov,2021-Q2,0,0,0
 Alexey Romanov,2021-Q1,0,0,0
 Alexey Romanov,2020-Q4,0,0,0
@@ -21263,8 +18605,6 @@ Alexey Romanov,2018-Q4,0,0,0
 Alexey Romanov,2018-Q3,0,0,0
 Alexey Romanov,2018-Q2,0,0,0
 Alexey Romanov,2018-Q1,0,0,0
-Reuben Morais,2021-Q4,0,0,0
-Reuben Morais,2021-Q3,0,0,0
 Reuben Morais,2021-Q2,0,0,0
 Reuben Morais,2021-Q1,0,0,0
 Reuben Morais,2020-Q4,0,0,0
@@ -21279,8 +18619,6 @@ Reuben Morais,2018-Q4,0,0,0
 Reuben Morais,2018-Q3,0,0,0
 Reuben Morais,2018-Q2,0,0,0
 Reuben Morais,2018-Q1,0,0,0
-Krzysztof Drewniak,2021-Q4,0,0,0
-Krzysztof Drewniak,2021-Q3,0,0,0
 Krzysztof Drewniak,2021-Q2,0,0,0
 Krzysztof Drewniak,2021-Q1,0,0,0
 Krzysztof Drewniak,2020-Q4,0,0,0
@@ -21295,8 +18633,6 @@ Krzysztof Drewniak,2018-Q4,0,0,0
 Krzysztof Drewniak,2018-Q3,0,0,0
 Krzysztof Drewniak,2018-Q2,0,0,0
 Krzysztof Drewniak,2018-Q1,0,0,0
-Saran Tunyasuvunakool,2021-Q4,0,0,0
-Saran Tunyasuvunakool,2021-Q3,0,0,0
 Saran Tunyasuvunakool,2021-Q2,0,0,0
 Saran Tunyasuvunakool,2021-Q1,0,0,0
 Saran Tunyasuvunakool,2020-Q4,0,0,0
@@ -21311,8 +18647,6 @@ Saran Tunyasuvunakool,2018-Q4,0,0,0
 Saran Tunyasuvunakool,2018-Q3,0,0,0
 Saran Tunyasuvunakool,2018-Q2,0,0,0
 Saran Tunyasuvunakool,2018-Q1,0,0,0
-Ben Lee,2021-Q4,0,0,0
-Ben Lee,2021-Q3,0,0,0
 Ben Lee,2021-Q2,0,0,0
 Ben Lee,2021-Q1,0,0,0
 Ben Lee,2020-Q4,0,0,0
@@ -21327,8 +18661,6 @@ Ben Lee,2018-Q4,0,0,0
 Ben Lee,2018-Q3,1,0,0
 Ben Lee,2018-Q2,2,3,0
 Ben Lee,2018-Q1,0,0,0
-Phillip Kravtsov,2021-Q4,0,0,0
-Phillip Kravtsov,2021-Q3,0,0,0
 Phillip Kravtsov,2021-Q2,0,0,0
 Phillip Kravtsov,2021-Q1,0,0,0
 Phillip Kravtsov,2020-Q4,0,0,0
@@ -21343,8 +18675,6 @@ Phillip Kravtsov,2018-Q4,0,0,0
 Phillip Kravtsov,2018-Q3,0,0,0
 Phillip Kravtsov,2018-Q2,0,0,0
 Phillip Kravtsov,2018-Q1,0,0,0
-Stephen McGroarty,2021-Q4,0,0,0
-Stephen McGroarty,2021-Q3,0,0,0
 Stephen McGroarty,2021-Q2,0,0,0
 Stephen McGroarty,2021-Q1,0,0,0
 Stephen McGroarty,2020-Q4,0,0,0
@@ -21359,8 +18689,6 @@ Stephen McGroarty,2018-Q4,0,0,0
 Stephen McGroarty,2018-Q3,0,0,0
 Stephen McGroarty,2018-Q2,0,0,0
 Stephen McGroarty,2018-Q1,0,0,0
-Patrick J. LoPresti,2021-Q4,0,0,0
-Patrick J. LoPresti,2021-Q3,0,0,0
 Patrick J. LoPresti,2021-Q2,0,0,0
 Patrick J. LoPresti,2021-Q1,0,0,0
 Patrick J. LoPresti,2020-Q4,0,0,0
@@ -21375,8 +18703,6 @@ Patrick J. LoPresti,2018-Q4,0,0,0
 Patrick J. LoPresti,2018-Q3,0,0,0
 Patrick J. LoPresti,2018-Q2,0,0,0
 Patrick J. LoPresti,2018-Q1,0,0,0
-jiakai,2021-Q4,0,0,0
-jiakai,2021-Q3,0,0,0
 jiakai,2021-Q2,0,0,0
 jiakai,2021-Q1,0,0,0
 jiakai,2020-Q4,0,0,0
@@ -21391,8 +18717,6 @@ jiakai,2018-Q4,0,0,0
 jiakai,2018-Q3,0,0,0
 jiakai,2018-Q2,0,0,0
 jiakai,2018-Q1,0,0,0
-Andrew Lihonosov,2021-Q4,0,0,0
-Andrew Lihonosov,2021-Q3,0,0,0
 Andrew Lihonosov,2021-Q2,0,0,0
 Andrew Lihonosov,2021-Q1,0,0,0
 Andrew Lihonosov,2020-Q4,0,0,0
@@ -21407,8 +18731,6 @@ Andrew Lihonosov,2018-Q4,0,0,0
 Andrew Lihonosov,2018-Q3,0,0,0
 Andrew Lihonosov,2018-Q2,0,0,0
 Andrew Lihonosov,2018-Q1,0,0,0
-Amit Srivastava,2021-Q4,0,0,0
-Amit Srivastava,2021-Q3,0,0,0
 Amit Srivastava,2021-Q2,0,0,0
 Amit Srivastava,2021-Q1,0,0,0
 Amit Srivastava,2020-Q4,0,0,0
@@ -21423,8 +18745,6 @@ Amit Srivastava,2018-Q4,0,0,0
 Amit Srivastava,2018-Q3,0,0,0
 Amit Srivastava,2018-Q2,0,0,0
 Amit Srivastava,2018-Q1,0,0,0
-Mei Jie,2021-Q4,0,0,0
-Mei Jie,2021-Q3,0,0,0
 Mei Jie,2021-Q2,0,0,0
 Mei Jie,2021-Q1,0,0,0
 Mei Jie,2020-Q4,0,0,0
@@ -21439,8 +18759,6 @@ Mei Jie,2018-Q4,0,0,0
 Mei Jie,2018-Q3,0,0,0
 Mei Jie,2018-Q2,0,0,0
 Mei Jie,2018-Q1,0,0,0
-Till Hoffmann,2021-Q4,0,0,0
-Till Hoffmann,2021-Q3,0,0,0
 Till Hoffmann,2021-Q2,0,0,0
 Till Hoffmann,2021-Q1,0,0,0
 Till Hoffmann,2020-Q4,0,0,0
@@ -21455,8 +18773,6 @@ Till Hoffmann,2018-Q4,0,0,0
 Till Hoffmann,2018-Q3,0,0,0
 Till Hoffmann,2018-Q2,0,0,0
 Till Hoffmann,2018-Q1,0,0,0
-Gianluca Varisco,2021-Q4,0,0,0
-Gianluca Varisco,2021-Q3,0,0,0
 Gianluca Varisco,2021-Q2,0,0,0
 Gianluca Varisco,2021-Q1,0,0,0
 Gianluca Varisco,2020-Q4,0,0,0
@@ -21471,8 +18787,6 @@ Gianluca Varisco,2018-Q4,0,0,0
 Gianluca Varisco,2018-Q3,0,0,0
 Gianluca Varisco,2018-Q2,0,0,0
 Gianluca Varisco,2018-Q1,0,0,0
-Nathan Wells,2021-Q4,0,0,0
-Nathan Wells,2021-Q3,0,0,0
 Nathan Wells,2021-Q2,0,0,0
 Nathan Wells,2021-Q1,0,0,0
 Nathan Wells,2020-Q4,0,0,0
@@ -21487,8 +18801,6 @@ Nathan Wells,2018-Q4,0,0,0
 Nathan Wells,2018-Q3,0,0,0
 Nathan Wells,2018-Q2,0,0,0
 Nathan Wells,2018-Q1,0,0,0
-jayhpark530,2021-Q4,0,0,0
-jayhpark530,2021-Q3,0,0,0
 jayhpark530,2021-Q2,0,0,0
 jayhpark530,2021-Q1,0,0,0
 jayhpark530,2020-Q4,0,0,0
@@ -21503,8 +18815,6 @@ jayhpark530,2018-Q4,0,0,0
 jayhpark530,2018-Q3,0,0,0
 jayhpark530,2018-Q2,0,0,0
 jayhpark530,2018-Q1,0,0,0
-jim.meyer,2021-Q4,0,0,0
-jim.meyer,2021-Q3,0,0,0
 jim.meyer,2021-Q2,0,0,0
 jim.meyer,2021-Q1,0,0,0
 jim.meyer,2020-Q4,0,0,0
@@ -21519,8 +18829,6 @@ jim.meyer,2018-Q4,0,0,0
 jim.meyer,2018-Q3,0,0,0
 jim.meyer,2018-Q2,0,0,0
 jim.meyer,2018-Q1,0,0,0
-Yuchen Ying,2021-Q4,0,0,0
-Yuchen Ying,2021-Q3,0,0,0
 Yuchen Ying,2021-Q2,0,0,0
 Yuchen Ying,2021-Q1,0,0,0
 Yuchen Ying,2020-Q4,0,0,0
@@ -21535,8 +18843,6 @@ Yuchen Ying,2018-Q4,0,0,0
 Yuchen Ying,2018-Q3,0,0,0
 Yuchen Ying,2018-Q2,0,0,0
 Yuchen Ying,2018-Q1,0,0,0
-Sudip Roy,2021-Q4,0,0,0
-Sudip Roy,2021-Q3,0,0,0
 Sudip Roy,2021-Q2,0,0,0
 Sudip Roy,2021-Q1,0,0,0
 Sudip Roy,2020-Q4,0,0,0
@@ -21551,8 +18857,6 @@ Sudip Roy,2018-Q4,0,0,0
 Sudip Roy,2018-Q3,0,0,0
 Sudip Roy,2018-Q2,0,0,0
 Sudip Roy,2018-Q1,0,0,0
-Jeroen Bédorf,2021-Q4,0,0,0
-Jeroen Bédorf,2021-Q3,0,0,0
 Jeroen Bédorf,2021-Q2,0,0,0
 Jeroen Bédorf,2021-Q1,0,0,0
 Jeroen Bédorf,2020-Q4,0,0,0
@@ -21567,8 +18871,6 @@ Jeroen Bédorf,2018-Q4,0,0,0
 Jeroen Bédorf,2018-Q3,0,0,0
 Jeroen Bédorf,2018-Q2,0,0,0
 Jeroen Bédorf,2018-Q1,0,0,0
-Siju Samuel,2021-Q4,0,0,0
-Siju Samuel,2021-Q3,0,0,0
 Siju Samuel,2021-Q2,0,0,0
 Siju Samuel,2021-Q1,0,0,0
 Siju Samuel,2020-Q4,0,0,0
@@ -21583,8 +18885,6 @@ Siju Samuel,2018-Q4,62,708,438
 Siju Samuel,2018-Q3,0,0,0
 Siju Samuel,2018-Q2,0,0,0
 Siju Samuel,2018-Q1,0,0,0
-RonLek,2021-Q4,0,0,0
-RonLek,2021-Q3,0,0,0
 RonLek,2021-Q2,0,0,0
 RonLek,2021-Q1,0,0,0
 RonLek,2020-Q4,0,0,0
@@ -21599,8 +18899,6 @@ RonLek,2018-Q4,0,0,0
 RonLek,2018-Q3,0,0,0
 RonLek,2018-Q2,0,0,0
 RonLek,2018-Q1,0,0,0
-Masaki Kozuki,2021-Q4,0,0,0
-Masaki Kozuki,2021-Q3,0,0,0
 Masaki Kozuki,2021-Q2,0,0,0
 Masaki Kozuki,2021-Q1,0,0,0
 Masaki Kozuki,2020-Q4,0,0,0
@@ -21615,8 +18913,6 @@ Masaki Kozuki,2018-Q4,0,0,0
 Masaki Kozuki,2018-Q3,0,0,0
 Masaki Kozuki,2018-Q2,0,0,0
 Masaki Kozuki,2018-Q1,0,0,0
-Alex Ilchenko,2021-Q4,0,0,0
-Alex Ilchenko,2021-Q3,0,0,0
 Alex Ilchenko,2021-Q2,0,0,0
 Alex Ilchenko,2021-Q1,0,0,0
 Alex Ilchenko,2020-Q4,0,0,0
@@ -21631,8 +18927,6 @@ Alex Ilchenko,2018-Q4,2,5,2
 Alex Ilchenko,2018-Q3,0,0,0
 Alex Ilchenko,2018-Q2,0,0,0
 Alex Ilchenko,2018-Q1,0,0,0
-vivek suryamurthy,2021-Q4,0,0,0
-vivek suryamurthy,2021-Q3,0,0,0
 vivek suryamurthy,2021-Q2,0,0,0
 vivek suryamurthy,2021-Q1,0,0,0
 vivek suryamurthy,2020-Q4,0,0,0
@@ -21647,8 +18941,6 @@ vivek suryamurthy,2018-Q4,0,0,0
 vivek suryamurthy,2018-Q3,0,0,0
 vivek suryamurthy,2018-Q2,0,0,0
 vivek suryamurthy,2018-Q1,0,0,0
-Alex Itkes,2021-Q4,0,0,0
-Alex Itkes,2021-Q3,0,0,0
 Alex Itkes,2021-Q2,0,0,0
 Alex Itkes,2021-Q1,0,0,0
 Alex Itkes,2020-Q4,0,0,0
@@ -21663,8 +18955,6 @@ Alex Itkes,2018-Q4,0,0,0
 Alex Itkes,2018-Q3,1,2,2
 Alex Itkes,2018-Q2,0,0,0
 Alex Itkes,2018-Q1,0,0,0
-Martin Mlostek,2021-Q4,0,0,0
-Martin Mlostek,2021-Q3,0,0,0
 Martin Mlostek,2021-Q2,0,0,0
 Martin Mlostek,2021-Q1,0,0,0
 Martin Mlostek,2020-Q4,0,0,0
@@ -21679,8 +18969,6 @@ Martin Mlostek,2018-Q4,0,0,0
 Martin Mlostek,2018-Q3,0,0,0
 Martin Mlostek,2018-Q2,0,0,0
 Martin Mlostek,2018-Q1,0,0,0
-Jekyll Lai,2021-Q4,0,0,0
-Jekyll Lai,2021-Q3,0,0,0
 Jekyll Lai,2021-Q2,0,0,0
 Jekyll Lai,2021-Q1,0,0,0
 Jekyll Lai,2020-Q4,0,0,0
@@ -21695,8 +18983,6 @@ Jekyll Lai,2018-Q4,0,0,0
 Jekyll Lai,2018-Q3,0,0,0
 Jekyll Lai,2018-Q2,0,0,0
 Jekyll Lai,2018-Q1,0,0,0
-Qingqing Cao,2021-Q4,0,0,0
-Qingqing Cao,2021-Q3,0,0,0
 Qingqing Cao,2021-Q2,0,0,0
 Qingqing Cao,2021-Q1,0,0,0
 Qingqing Cao,2020-Q4,0,0,0
@@ -21711,8 +18997,6 @@ Qingqing Cao,2018-Q4,0,0,0
 Qingqing Cao,2018-Q3,0,0,0
 Qingqing Cao,2018-Q2,0,0,0
 Qingqing Cao,2018-Q1,0,0,0
-Tae-Hwan Jung,2021-Q4,0,0,0
-Tae-Hwan Jung,2021-Q3,0,0,0
 Tae-Hwan Jung,2021-Q2,0,0,0
 Tae-Hwan Jung,2021-Q1,0,0,0
 Tae-Hwan Jung,2020-Q4,0,0,0
@@ -21727,8 +19011,6 @@ Tae-Hwan Jung,2018-Q4,0,0,0
 Tae-Hwan Jung,2018-Q3,0,0,0
 Tae-Hwan Jung,2018-Q2,0,0,0
 Tae-Hwan Jung,2018-Q1,0,0,0
-vbvg2008,2021-Q4,0,0,0
-vbvg2008,2021-Q3,0,0,0
 vbvg2008,2021-Q2,0,0,0
 vbvg2008,2021-Q1,0,0,0
 vbvg2008,2020-Q4,0,0,0
@@ -21743,8 +19025,6 @@ vbvg2008,2018-Q4,0,0,0
 vbvg2008,2018-Q3,1,0,0
 vbvg2008,2018-Q2,0,0,0
 vbvg2008,2018-Q1,0,0,0
-Casper da Costa-Luis,2021-Q4,0,0,0
-Casper da Costa-Luis,2021-Q3,0,0,0
 Casper da Costa-Luis,2021-Q2,0,0,0
 Casper da Costa-Luis,2021-Q1,0,0,0
 Casper da Costa-Luis,2020-Q4,0,0,0
@@ -21759,8 +19039,6 @@ Casper da Costa-Luis,2018-Q4,0,0,0
 Casper da Costa-Luis,2018-Q3,0,0,0
 Casper da Costa-Luis,2018-Q2,0,0,0
 Casper da Costa-Luis,2018-Q1,0,0,0
-Rishabh Kabra,2021-Q4,0,0,0
-Rishabh Kabra,2021-Q3,0,0,0
 Rishabh Kabra,2021-Q2,0,0,0
 Rishabh Kabra,2021-Q1,0,0,0
 Rishabh Kabra,2020-Q4,0,0,0
@@ -21775,8 +19053,6 @@ Rishabh Kabra,2018-Q4,0,0,0
 Rishabh Kabra,2018-Q3,0,0,0
 Rishabh Kabra,2018-Q2,0,0,0
 Rishabh Kabra,2018-Q1,0,0,0
-Dayananda-V,2021-Q4,0,0,0
-Dayananda-V,2021-Q3,0,0,0
 Dayananda-V,2021-Q2,0,0,0
 Dayananda-V,2021-Q1,0,0,0
 Dayananda-V,2020-Q4,0,0,0
@@ -21791,8 +19067,6 @@ Dayananda-V,2018-Q4,0,0,0
 Dayananda-V,2018-Q3,0,0,0
 Dayananda-V,2018-Q2,0,0,0
 Dayananda-V,2018-Q1,0,0,0
-Srini511,2021-Q4,0,0,0
-Srini511,2021-Q3,0,0,0
 Srini511,2021-Q2,0,0,0
 Srini511,2021-Q1,0,0,0
 Srini511,2020-Q4,0,0,0
@@ -21807,8 +19081,6 @@ Srini511,2018-Q4,0,0,0
 Srini511,2018-Q3,0,0,0
 Srini511,2018-Q2,0,0,0
 Srini511,2018-Q1,0,0,0
-Taehoon Lee,2021-Q4,0,0,0
-Taehoon Lee,2021-Q3,0,0,0
 Taehoon Lee,2021-Q2,0,0,0
 Taehoon Lee,2021-Q1,0,0,0
 Taehoon Lee,2020-Q4,0,0,0
@@ -21823,8 +19095,6 @@ Taehoon Lee,2018-Q4,0,0,0
 Taehoon Lee,2018-Q3,24,32,32
 Taehoon Lee,2018-Q2,9,9,9
 Taehoon Lee,2018-Q1,24,24,24
-Patrik Gustavsson,2021-Q4,0,0,0
-Patrik Gustavsson,2021-Q3,0,0,0
 Patrik Gustavsson,2021-Q2,0,0,0
 Patrik Gustavsson,2021-Q1,0,0,0
 Patrik Gustavsson,2020-Q4,0,0,0
@@ -21839,8 +19109,6 @@ Patrik Gustavsson,2018-Q4,0,0,0
 Patrik Gustavsson,2018-Q3,0,0,0
 Patrik Gustavsson,2018-Q2,0,0,0
 Patrik Gustavsson,2018-Q1,0,0,0
-Imran Salam,2021-Q4,0,0,0
-Imran Salam,2021-Q3,0,0,0
 Imran Salam,2021-Q2,0,0,0
 Imran Salam,2021-Q1,0,0,0
 Imran Salam,2020-Q4,0,0,0
@@ -21855,8 +19123,6 @@ Imran Salam,2018-Q4,0,0,0
 Imran Salam,2018-Q3,0,0,0
 Imran Salam,2018-Q2,0,0,0
 Imran Salam,2018-Q1,0,0,0
-Abdullah Selek,2021-Q4,0,0,0
-Abdullah Selek,2021-Q3,0,0,0
 Abdullah Selek,2021-Q2,0,0,0
 Abdullah Selek,2021-Q1,0,0,0
 Abdullah Selek,2020-Q4,0,0,0
@@ -21871,8 +19137,6 @@ Abdullah Selek,2018-Q4,0,0,0
 Abdullah Selek,2018-Q3,0,0,0
 Abdullah Selek,2018-Q2,0,0,0
 Abdullah Selek,2018-Q1,0,0,0
-Karl Lessard,2021-Q4,0,0,0
-Karl Lessard,2021-Q3,0,0,0
 Karl Lessard,2021-Q2,0,0,0
 Karl Lessard,2021-Q1,0,0,0
 Karl Lessard,2020-Q4,0,0,0
@@ -21887,8 +19151,6 @@ Karl Lessard,2018-Q4,1309,6613,1166
 Karl Lessard,2018-Q3,0,0,0
 Karl Lessard,2018-Q2,2,6,5
 Karl Lessard,2018-Q1,22,2455,295
-Rasmus Diederichsen,2021-Q4,0,0,0
-Rasmus Diederichsen,2021-Q3,0,0,0
 Rasmus Diederichsen,2021-Q2,0,0,0
 Rasmus Diederichsen,2021-Q1,0,0,0
 Rasmus Diederichsen,2020-Q4,0,0,0
@@ -21903,8 +19165,6 @@ Rasmus Diederichsen,2018-Q4,0,0,0
 Rasmus Diederichsen,2018-Q3,0,0,0
 Rasmus Diederichsen,2018-Q2,0,0,0
 Rasmus Diederichsen,2018-Q1,0,0,0
-Zantares,2021-Q4,0,0,0
-Zantares,2021-Q3,0,0,0
 Zantares,2021-Q2,0,0,0
 Zantares,2021-Q1,0,0,0
 Zantares,2020-Q4,0,0,0
@@ -21919,8 +19179,6 @@ Zantares,2018-Q4,0,0,0
 Zantares,2018-Q3,0,0,0
 Zantares,2018-Q2,0,0,0
 Zantares,2018-Q1,0,0,0
-Jojimon Varghese,2021-Q4,0,0,0
-Jojimon Varghese,2021-Q3,0,0,0
 Jojimon Varghese,2021-Q2,0,0,0
 Jojimon Varghese,2021-Q1,0,0,0
 Jojimon Varghese,2020-Q4,0,0,0
@@ -21935,8 +19193,6 @@ Jojimon Varghese,2018-Q4,0,0,0
 Jojimon Varghese,2018-Q3,0,0,0
 Jojimon Varghese,2018-Q2,0,0,0
 Jojimon Varghese,2018-Q1,0,0,0
-alhkad,2021-Q4,0,0,0
-alhkad,2021-Q3,0,0,0
 alhkad,2021-Q2,0,0,0
 alhkad,2021-Q1,0,0,0
 alhkad,2020-Q4,0,0,0
@@ -21951,8 +19207,6 @@ alhkad,2018-Q4,0,0,0
 alhkad,2018-Q3,0,0,0
 alhkad,2018-Q2,0,0,0
 alhkad,2018-Q1,0,0,0
-Daryl Ng,2021-Q4,0,0,0
-Daryl Ng,2021-Q3,0,0,0
 Daryl Ng,2021-Q2,0,0,0
 Daryl Ng,2021-Q1,0,0,0
 Daryl Ng,2020-Q4,0,0,0
@@ -21967,8 +19221,6 @@ Daryl Ng,2018-Q4,0,0,0
 Daryl Ng,2018-Q3,16,1203,338
 Daryl Ng,2018-Q2,0,0,0
 Daryl Ng,2018-Q1,0,0,0
-Siju,2021-Q4,0,0,0
-Siju,2021-Q3,0,0,0
 Siju,2021-Q2,0,0,0
 Siju,2021-Q1,0,0,0
 Siju,2020-Q4,0,0,0
@@ -21983,8 +19235,6 @@ Siju,2018-Q4,8,2,2
 Siju,2018-Q3,0,0,0
 Siju,2018-Q2,0,0,0
 Siju,2018-Q1,0,0,0
-khanhlvg,2021-Q4,0,0,0
-khanhlvg,2021-Q3,0,0,0
 khanhlvg,2021-Q2,0,0,0
 khanhlvg,2021-Q1,0,0,0
 khanhlvg,2020-Q4,0,0,0
@@ -21999,8 +19249,6 @@ khanhlvg,2018-Q4,0,0,0
 khanhlvg,2018-Q3,0,0,0
 khanhlvg,2018-Q2,0,0,0
 khanhlvg,2018-Q1,0,0,0
-Martijn Vels,2021-Q4,0,0,0
-Martijn Vels,2021-Q3,0,0,0
 Martijn Vels,2021-Q2,0,0,0
 Martijn Vels,2021-Q1,0,0,0
 Martijn Vels,2020-Q4,0,0,0
@@ -22015,8 +19263,6 @@ Martijn Vels,2018-Q4,0,0,0
 Martijn Vels,2018-Q3,0,0,0
 Martijn Vels,2018-Q2,0,0,0
 Martijn Vels,2018-Q1,0,0,0
-Taylor Jakobson,2021-Q4,0,0,0
-Taylor Jakobson,2021-Q3,0,0,0
 Taylor Jakobson,2021-Q2,0,0,0
 Taylor Jakobson,2021-Q1,0,0,0
 Taylor Jakobson,2020-Q4,0,0,0
@@ -22031,8 +19277,6 @@ Taylor Jakobson,2018-Q4,22,1216,119
 Taylor Jakobson,2018-Q3,0,0,0
 Taylor Jakobson,2018-Q2,0,0,0
 Taylor Jakobson,2018-Q1,0,0,0
-Gabriel,2021-Q4,0,0,0
-Gabriel,2021-Q3,0,0,0
 Gabriel,2021-Q2,0,0,0
 Gabriel,2021-Q1,0,0,0
 Gabriel,2020-Q4,0,0,0
@@ -22047,8 +19291,6 @@ Gabriel,2018-Q4,0,0,0
 Gabriel,2018-Q3,0,0,0
 Gabriel,2018-Q2,0,0,0
 Gabriel,2018-Q1,0,0,0
-Manraj Singh Grover,2021-Q4,0,0,0
-Manraj Singh Grover,2021-Q3,0,0,0
 Manraj Singh Grover,2021-Q2,0,0,0
 Manraj Singh Grover,2021-Q1,0,0,0
 Manraj Singh Grover,2020-Q4,0,0,0
@@ -22063,8 +19305,6 @@ Manraj Singh Grover,2018-Q4,0,0,0
 Manraj Singh Grover,2018-Q3,0,0,0
 Manraj Singh Grover,2018-Q2,0,0,0
 Manraj Singh Grover,2018-Q1,0,0,0
-pkanwar23,2021-Q4,0,0,0
-pkanwar23,2021-Q3,0,0,0
 pkanwar23,2021-Q2,0,0,0
 pkanwar23,2021-Q1,0,0,0
 pkanwar23,2020-Q4,0,0,0
@@ -22079,8 +19319,6 @@ pkanwar23,2018-Q4,0,0,0
 pkanwar23,2018-Q3,0,0,0
 pkanwar23,2018-Q2,0,0,0
 pkanwar23,2018-Q1,0,0,0
-Zi Yang,2021-Q4,0,0,0
-Zi Yang,2021-Q3,0,0,0
 Zi Yang,2021-Q2,0,0,0
 Zi Yang,2021-Q1,0,0,0
 Zi Yang,2020-Q4,0,0,0
@@ -22095,8 +19333,6 @@ Zi Yang,2018-Q4,0,0,0
 Zi Yang,2018-Q3,0,0,0
 Zi Yang,2018-Q2,0,0,0
 Zi Yang,2018-Q1,0,0,0
-Rasmus Munk Larsen,2021-Q4,0,0,0
-Rasmus Munk Larsen,2021-Q3,0,0,0
 Rasmus Munk Larsen,2021-Q2,0,0,0
 Rasmus Munk Larsen,2021-Q1,0,0,0
 Rasmus Munk Larsen,2020-Q4,0,0,0
@@ -22111,8 +19347,6 @@ Rasmus Munk Larsen,2018-Q4,0,0,0
 Rasmus Munk Larsen,2018-Q3,2,2,2
 Rasmus Munk Larsen,2018-Q2,207,5394,1928
 Rasmus Munk Larsen,2018-Q1,329,4772,4432
-Jeremiah Harmsen,2021-Q4,0,0,0
-Jeremiah Harmsen,2021-Q3,0,0,0
 Jeremiah Harmsen,2021-Q2,0,0,0
 Jeremiah Harmsen,2021-Q1,0,0,0
 Jeremiah Harmsen,2020-Q4,0,0,0
@@ -22127,8 +19361,6 @@ Jeremiah Harmsen,2018-Q4,0,0,0
 Jeremiah Harmsen,2018-Q3,14,615,80
 Jeremiah Harmsen,2018-Q2,0,0,0
 Jeremiah Harmsen,2018-Q1,0,0,0
-Sourabh Bajaj,2021-Q4,0,0,0
-Sourabh Bajaj,2021-Q3,0,0,0
 Sourabh Bajaj,2021-Q2,0,0,0
 Sourabh Bajaj,2021-Q1,0,0,0
 Sourabh Bajaj,2020-Q4,0,0,0
@@ -22143,8 +19375,6 @@ Sourabh Bajaj,2018-Q4,88,3022,1200
 Sourabh Bajaj,2018-Q3,33,529,183
 Sourabh Bajaj,2018-Q2,12,374,50
 Sourabh Bajaj,2018-Q1,101,2129,204
-Joel Shapiro,2021-Q4,0,0,0
-Joel Shapiro,2021-Q3,0,0,0
 Joel Shapiro,2021-Q2,0,0,0
 Joel Shapiro,2021-Q1,0,0,0
 Joel Shapiro,2020-Q4,0,0,0
@@ -22159,8 +19389,6 @@ Joel Shapiro,2018-Q4,0,0,0
 Joel Shapiro,2018-Q3,0,0,0
 Joel Shapiro,2018-Q2,0,0,0
 Joel Shapiro,2018-Q1,0,0,0
-musikisomorphie,2021-Q4,0,0,0
-musikisomorphie,2021-Q3,0,0,0
 musikisomorphie,2021-Q2,0,0,0
 musikisomorphie,2021-Q1,0,0,0
 musikisomorphie,2020-Q4,0,0,0
@@ -22175,8 +19403,6 @@ musikisomorphie,2018-Q4,0,0,0
 musikisomorphie,2018-Q3,0,0,0
 musikisomorphie,2018-Q2,0,0,0
 musikisomorphie,2018-Q1,0,0,0
-Kyuwon Kim,2021-Q4,0,0,0
-Kyuwon Kim,2021-Q3,0,0,0
 Kyuwon Kim,2021-Q2,0,0,0
 Kyuwon Kim,2021-Q1,0,0,0
 Kyuwon Kim,2020-Q4,0,0,0
@@ -22191,8 +19417,6 @@ Kyuwon Kim,2018-Q4,0,0,0
 Kyuwon Kim,2018-Q3,0,0,0
 Kyuwon Kim,2018-Q2,0,0,0
 Kyuwon Kim,2018-Q1,0,0,0
-Son Tran,2021-Q4,0,0,0
-Son Tran,2021-Q3,0,0,0
 Son Tran,2021-Q2,0,0,0
 Son Tran,2021-Q1,0,0,0
 Son Tran,2020-Q4,0,0,0
@@ -22207,8 +19431,6 @@ Son Tran,2018-Q4,0,0,0
 Son Tran,2018-Q3,0,0,0
 Son Tran,2018-Q2,0,0,0
 Son Tran,2018-Q1,0,0,0
-Suyog Gupta,2021-Q4,0,0,0
-Suyog Gupta,2021-Q3,0,0,0
 Suyog Gupta,2021-Q2,0,0,0
 Suyog Gupta,2021-Q1,0,0,0
 Suyog Gupta,2020-Q4,0,0,0
@@ -22223,8 +19445,6 @@ Suyog Gupta,2018-Q4,10,52,215
 Suyog Gupta,2018-Q3,18,795,76
 Suyog Gupta,2018-Q2,0,0,0
 Suyog Gupta,2018-Q1,0,0,0
-Jesper Dramsch,2021-Q4,0,0,0
-Jesper Dramsch,2021-Q3,0,0,0
 Jesper Dramsch,2021-Q2,0,0,0
 Jesper Dramsch,2021-Q1,0,0,0
 Jesper Dramsch,2020-Q4,0,0,0
@@ -22239,8 +19459,6 @@ Jesper Dramsch,2018-Q4,0,0,0
 Jesper Dramsch,2018-Q3,0,0,0
 Jesper Dramsch,2018-Q2,0,0,0
 Jesper Dramsch,2018-Q1,0,0,0
-Cao Zongyan,2021-Q4,0,0,0
-Cao Zongyan,2021-Q3,0,0,0
 Cao Zongyan,2021-Q2,0,0,0
 Cao Zongyan,2021-Q1,0,0,0
 Cao Zongyan,2020-Q4,0,0,0
@@ -22255,8 +19473,6 @@ Cao Zongyan,2018-Q4,0,0,0
 Cao Zongyan,2018-Q3,43,724,219
 Cao Zongyan,2018-Q2,0,0,0
 Cao Zongyan,2018-Q1,0,0,0
-Gleb Popov,2021-Q4,0,0,0
-Gleb Popov,2021-Q3,0,0,0
 Gleb Popov,2021-Q2,0,0,0
 Gleb Popov,2021-Q1,0,0,0
 Gleb Popov,2020-Q4,0,0,0
@@ -22271,8 +19487,6 @@ Gleb Popov,2018-Q4,0,0,0
 Gleb Popov,2018-Q3,0,0,0
 Gleb Popov,2018-Q2,0,0,0
 Gleb Popov,2018-Q1,0,0,0
-Severen Redwood,2021-Q4,0,0,0
-Severen Redwood,2021-Q3,0,0,0
 Severen Redwood,2021-Q2,0,0,0
 Severen Redwood,2021-Q1,0,0,0
 Severen Redwood,2020-Q4,0,0,0
@@ -22287,8 +19501,6 @@ Severen Redwood,2018-Q4,0,0,0
 Severen Redwood,2018-Q3,0,0,0
 Severen Redwood,2018-Q2,0,0,0
 Severen Redwood,2018-Q1,0,0,0
-Putra Manggala,2021-Q4,0,0,0
-Putra Manggala,2021-Q3,0,0,0
 Putra Manggala,2021-Q2,0,0,0
 Putra Manggala,2021-Q1,0,0,0
 Putra Manggala,2020-Q4,0,0,0
@@ -22303,8 +19515,6 @@ Putra Manggala,2018-Q4,0,0,0
 Putra Manggala,2018-Q3,0,0,0
 Putra Manggala,2018-Q2,0,0,0
 Putra Manggala,2018-Q1,0,0,0
-Vasileios Lioutas,2021-Q4,0,0,0
-Vasileios Lioutas,2021-Q3,0,0,0
 Vasileios Lioutas,2021-Q2,0,0,0
 Vasileios Lioutas,2021-Q1,0,0,0
 Vasileios Lioutas,2020-Q4,0,0,0
@@ -22319,8 +19529,6 @@ Vasileios Lioutas,2018-Q4,0,0,0
 Vasileios Lioutas,2018-Q3,0,0,0
 Vasileios Lioutas,2018-Q2,0,0,0
 Vasileios Lioutas,2018-Q1,0,0,0
-Bjarke Hammersholt Roune,2021-Q4,0,0,0
-Bjarke Hammersholt Roune,2021-Q3,0,0,0
 Bjarke Hammersholt Roune,2021-Q2,0,0,0
 Bjarke Hammersholt Roune,2021-Q1,0,0,0
 Bjarke Hammersholt Roune,2020-Q4,0,0,0
@@ -22335,8 +19543,6 @@ Bjarke Hammersholt Roune,2018-Q4,1,2,0
 Bjarke Hammersholt Roune,2018-Q3,0,0,0
 Bjarke Hammersholt Roune,2018-Q2,35,954,251
 Bjarke Hammersholt Roune,2018-Q1,16,528,184
-Pranav Marathe,2021-Q4,0,0,0
-Pranav Marathe,2021-Q3,0,0,0
 Pranav Marathe,2021-Q2,0,0,0
 Pranav Marathe,2021-Q1,0,0,0
 Pranav Marathe,2020-Q4,0,0,0
@@ -22351,8 +19557,6 @@ Pranav Marathe,2018-Q4,0,0,0
 Pranav Marathe,2018-Q3,0,0,0
 Pranav Marathe,2018-Q2,0,0,0
 Pranav Marathe,2018-Q1,0,0,0
-Nayana Thorat,2021-Q4,0,0,0
-Nayana Thorat,2021-Q3,0,0,0
 Nayana Thorat,2021-Q2,0,0,0
 Nayana Thorat,2021-Q1,0,0,0
 Nayana Thorat,2020-Q4,0,0,0
@@ -22367,8 +19571,6 @@ Nayana Thorat,2018-Q4,0,0,0
 Nayana Thorat,2018-Q3,0,0,0
 Nayana Thorat,2018-Q2,0,0,0
 Nayana Thorat,2018-Q1,0,0,0
-terryky,2021-Q4,0,0,0
-terryky,2021-Q3,0,0,0
 terryky,2021-Q2,0,0,0
 terryky,2021-Q1,0,0,0
 terryky,2020-Q4,0,0,0
@@ -22383,8 +19585,6 @@ terryky,2018-Q4,0,0,0
 terryky,2018-Q3,0,0,0
 terryky,2018-Q2,0,0,0
 terryky,2018-Q1,0,0,0
-Greg Peatfield,2021-Q4,0,0,0
-Greg Peatfield,2021-Q3,0,0,0
 Greg Peatfield,2021-Q2,0,0,0
 Greg Peatfield,2021-Q1,0,0,0
 Greg Peatfield,2020-Q4,0,0,0
@@ -22399,8 +19599,6 @@ Greg Peatfield,2018-Q4,0,0,0
 Greg Peatfield,2018-Q3,0,0,0
 Greg Peatfield,2018-Q2,0,0,0
 Greg Peatfield,2018-Q1,0,0,0
-per1234,2021-Q4,0,0,0
-per1234,2021-Q3,0,0,0
 per1234,2021-Q2,0,0,0
 per1234,2021-Q1,0,0,0
 per1234,2020-Q4,0,0,0
@@ -22415,8 +19613,6 @@ per1234,2018-Q4,0,0,0
 per1234,2018-Q3,0,0,0
 per1234,2018-Q2,0,0,0
 per1234,2018-Q1,0,0,0
-Julian Niedermeier,2021-Q4,0,0,0
-Julian Niedermeier,2021-Q3,0,0,0
 Julian Niedermeier,2021-Q2,0,0,0
 Julian Niedermeier,2021-Q1,0,0,0
 Julian Niedermeier,2020-Q4,0,0,0
@@ -22431,8 +19627,6 @@ Julian Niedermeier,2018-Q4,6,38,16
 Julian Niedermeier,2018-Q3,0,0,0
 Julian Niedermeier,2018-Q2,0,0,0
 Julian Niedermeier,2018-Q1,0,0,0
-Gaurav Mishra,2021-Q4,0,0,0
-Gaurav Mishra,2021-Q3,0,0,0
 Gaurav Mishra,2021-Q2,0,0,0
 Gaurav Mishra,2021-Q1,0,0,0
 Gaurav Mishra,2020-Q4,0,0,0
@@ -22447,8 +19641,6 @@ Gaurav Mishra,2018-Q4,0,0,0
 Gaurav Mishra,2018-Q3,0,0,0
 Gaurav Mishra,2018-Q2,0,0,0
 Gaurav Mishra,2018-Q1,0,0,0
-mpppk,2021-Q4,0,0,0
-mpppk,2021-Q3,0,0,0
 mpppk,2021-Q2,0,0,0
 mpppk,2021-Q1,0,0,0
 mpppk,2020-Q4,0,0,0
@@ -22463,8 +19655,6 @@ mpppk,2018-Q4,0,0,0
 mpppk,2018-Q3,0,0,0
 mpppk,2018-Q2,0,0,0
 mpppk,2018-Q1,0,0,0
-G. Hussain Chinoy,2021-Q4,0,0,0
-G. Hussain Chinoy,2021-Q3,0,0,0
 G. Hussain Chinoy,2021-Q2,0,0,0
 G. Hussain Chinoy,2021-Q1,0,0,0
 G. Hussain Chinoy,2020-Q4,0,0,0
@@ -22479,8 +19669,6 @@ G. Hussain Chinoy,2018-Q4,0,0,0
 G. Hussain Chinoy,2018-Q3,0,0,0
 G. Hussain Chinoy,2018-Q2,0,0,0
 G. Hussain Chinoy,2018-Q1,0,0,0
-jefby,2021-Q4,0,0,0
-jefby,2021-Q3,0,0,0
 jefby,2021-Q2,0,0,0
 jefby,2021-Q1,0,0,0
 jefby,2020-Q4,0,0,0
@@ -22495,8 +19683,6 @@ jefby,2018-Q4,0,0,0
 jefby,2018-Q3,0,0,0
 jefby,2018-Q2,0,0,0
 jefby,2018-Q1,0,0,0
-Alex Sergeev,2021-Q4,0,0,0
-Alex Sergeev,2021-Q3,0,0,0
 Alex Sergeev,2021-Q2,0,0,0
 Alex Sergeev,2021-Q1,0,0,0
 Alex Sergeev,2020-Q4,0,0,0
@@ -22511,8 +19697,6 @@ Alex Sergeev,2018-Q4,0,0,0
 Alex Sergeev,2018-Q3,0,0,0
 Alex Sergeev,2018-Q2,0,0,0
 Alex Sergeev,2018-Q1,0,0,0
-haison,2021-Q4,0,0,0
-haison,2021-Q3,0,0,0
 haison,2021-Q2,0,0,0
 haison,2021-Q1,0,0,0
 haison,2020-Q4,0,0,0
@@ -22527,8 +19711,6 @@ haison,2018-Q4,0,0,0
 haison,2018-Q3,0,0,0
 haison,2018-Q2,0,0,0
 haison,2018-Q1,0,0,0
-sleighsoft,2021-Q4,0,0,0
-sleighsoft,2021-Q3,0,0,0
 sleighsoft,2021-Q2,0,0,0
 sleighsoft,2021-Q1,0,0,0
 sleighsoft,2020-Q4,0,0,0
@@ -22543,8 +19725,6 @@ sleighsoft,2018-Q4,0,0,0
 sleighsoft,2018-Q3,0,0,0
 sleighsoft,2018-Q2,0,0,0
 sleighsoft,2018-Q1,0,0,0
-Eddie Zhou,2021-Q4,0,0,0
-Eddie Zhou,2021-Q3,0,0,0
 Eddie Zhou,2021-Q2,0,0,0
 Eddie Zhou,2021-Q1,0,0,0
 Eddie Zhou,2020-Q4,0,0,0
@@ -22559,8 +19739,6 @@ Eddie Zhou,2018-Q4,7,110,33
 Eddie Zhou,2018-Q3,22,541,82
 Eddie Zhou,2018-Q2,0,0,0
 Eddie Zhou,2018-Q1,0,0,0
-Cheng Chang,2021-Q4,0,0,0
-Cheng Chang,2021-Q3,0,0,0
 Cheng Chang,2021-Q2,0,0,0
 Cheng Chang,2021-Q1,0,0,0
 Cheng Chang,2020-Q4,0,0,0
@@ -22575,8 +19753,6 @@ Cheng Chang,2018-Q4,0,0,0
 Cheng Chang,2018-Q3,0,0,0
 Cheng Chang,2018-Q2,0,0,0
 Cheng Chang,2018-Q1,0,0,0
-JiangXIAO,2021-Q4,0,0,0
-JiangXIAO,2021-Q3,0,0,0
 JiangXIAO,2021-Q2,0,0,0
 JiangXIAO,2021-Q1,0,0,0
 JiangXIAO,2020-Q4,0,0,0
@@ -22591,8 +19767,6 @@ JiangXIAO,2018-Q4,0,0,0
 JiangXIAO,2018-Q3,0,0,0
 JiangXIAO,2018-Q2,0,0,0
 JiangXIAO,2018-Q1,0,0,0
-sumesh udayakumaran,2021-Q4,0,0,0
-sumesh udayakumaran,2021-Q3,0,0,0
 sumesh udayakumaran,2021-Q2,0,0,0
 sumesh udayakumaran,2021-Q1,0,0,0
 sumesh udayakumaran,2020-Q4,0,0,0
@@ -22607,8 +19781,6 @@ sumesh udayakumaran,2018-Q4,0,0,0
 sumesh udayakumaran,2018-Q3,0,0,0
 sumesh udayakumaran,2018-Q2,0,0,0
 sumesh udayakumaran,2018-Q1,0,0,0
-zyeric,2021-Q4,0,0,0
-zyeric,2021-Q3,0,0,0
 zyeric,2021-Q2,0,0,0
 zyeric,2021-Q1,0,0,0
 zyeric,2020-Q4,0,0,0
@@ -22623,8 +19795,6 @@ zyeric,2018-Q4,0,0,0
 zyeric,2018-Q3,0,0,0
 zyeric,2018-Q2,0,0,0
 zyeric,2018-Q1,0,0,0
-Dwight J Lyle,2021-Q4,0,0,0
-Dwight J Lyle,2021-Q3,0,0,0
 Dwight J Lyle,2021-Q2,0,0,0
 Dwight J Lyle,2021-Q1,0,0,0
 Dwight J Lyle,2020-Q4,0,0,0
@@ -22639,8 +19809,6 @@ Dwight J Lyle,2018-Q4,0,0,0
 Dwight J Lyle,2018-Q3,0,0,0
 Dwight J Lyle,2018-Q2,0,0,0
 Dwight J Lyle,2018-Q1,0,0,0
-gehring,2021-Q4,0,0,0
-gehring,2021-Q3,0,0,0
 gehring,2021-Q2,0,0,0
 gehring,2021-Q1,0,0,0
 gehring,2020-Q4,0,0,0
@@ -22655,8 +19823,6 @@ gehring,2018-Q4,2,0,0
 gehring,2018-Q3,0,0,0
 gehring,2018-Q2,0,0,0
 gehring,2018-Q1,0,0,0
-Elroy Ashtian Jr,2021-Q4,0,0,0
-Elroy Ashtian Jr,2021-Q3,0,0,0
 Elroy Ashtian Jr,2021-Q2,0,0,0
 Elroy Ashtian Jr,2021-Q1,0,0,0
 Elroy Ashtian Jr,2020-Q4,0,0,0
@@ -22671,8 +19837,6 @@ Elroy Ashtian Jr,2018-Q4,0,0,0
 Elroy Ashtian Jr,2018-Q3,0,0,0
 Elroy Ashtian Jr,2018-Q2,0,0,0
 Elroy Ashtian Jr,2018-Q1,0,0,0
-Eamon Ito-Fisher,2021-Q4,0,0,0
-Eamon Ito-Fisher,2021-Q3,0,0,0
 Eamon Ito-Fisher,2021-Q2,0,0,0
 Eamon Ito-Fisher,2021-Q1,0,0,0
 Eamon Ito-Fisher,2020-Q4,0,0,0
@@ -22687,8 +19851,6 @@ Eamon Ito-Fisher,2018-Q4,0,0,0
 Eamon Ito-Fisher,2018-Q3,0,0,0
 Eamon Ito-Fisher,2018-Q2,0,0,0
 Eamon Ito-Fisher,2018-Q1,0,0,0
-kbhute-ibm,2021-Q4,0,0,0
-kbhute-ibm,2021-Q3,0,0,0
 kbhute-ibm,2021-Q2,0,0,0
 kbhute-ibm,2021-Q1,0,0,0
 kbhute-ibm,2020-Q4,0,0,0
@@ -22703,8 +19865,6 @@ kbhute-ibm,2018-Q4,0,0,0
 kbhute-ibm,2018-Q3,0,0,0
 kbhute-ibm,2018-Q2,0,0,0
 kbhute-ibm,2018-Q1,0,0,0
-eashtian3,2021-Q4,0,0,0
-eashtian3,2021-Q3,0,0,0
 eashtian3,2021-Q2,0,0,0
 eashtian3,2021-Q1,0,0,0
 eashtian3,2020-Q4,0,0,0
@@ -22719,8 +19879,6 @@ eashtian3,2018-Q4,0,0,0
 eashtian3,2018-Q3,0,0,0
 eashtian3,2018-Q2,0,0,0
 eashtian3,2018-Q1,0,0,0
-David Bieber,2021-Q4,0,0,0
-David Bieber,2021-Q3,0,0,0
 David Bieber,2021-Q2,0,0,0
 David Bieber,2021-Q1,0,0,0
 David Bieber,2020-Q4,0,0,0
@@ -22735,8 +19893,6 @@ David Bieber,2018-Q4,0,0,0
 David Bieber,2018-Q3,0,0,0
 David Bieber,2018-Q2,0,0,0
 David Bieber,2018-Q1,0,0,0
-Kabir Kwatra,2021-Q4,0,0,0
-Kabir Kwatra,2021-Q3,0,0,0
 Kabir Kwatra,2021-Q2,0,0,0
 Kabir Kwatra,2021-Q1,0,0,0
 Kabir Kwatra,2020-Q4,0,0,0
@@ -22751,8 +19907,6 @@ Kabir Kwatra,2018-Q4,0,0,0
 Kabir Kwatra,2018-Q3,0,0,0
 Kabir Kwatra,2018-Q2,0,0,0
 Kabir Kwatra,2018-Q1,0,0,0
-Gustavo Lima Chaves,2021-Q4,0,0,0
-Gustavo Lima Chaves,2021-Q3,0,0,0
 Gustavo Lima Chaves,2021-Q2,0,0,0
 Gustavo Lima Chaves,2021-Q1,0,0,0
 Gustavo Lima Chaves,2020-Q4,0,0,0
@@ -22767,8 +19921,6 @@ Gustavo Lima Chaves,2018-Q4,0,0,0
 Gustavo Lima Chaves,2018-Q3,0,0,0
 Gustavo Lima Chaves,2018-Q2,0,0,0
 Gustavo Lima Chaves,2018-Q1,0,0,0
-Sigrid Keydana,2021-Q4,0,0,0
-Sigrid Keydana,2021-Q3,0,0,0
 Sigrid Keydana,2021-Q2,0,0,0
 Sigrid Keydana,2021-Q1,0,0,0
 Sigrid Keydana,2020-Q4,0,0,0
@@ -22783,8 +19935,6 @@ Sigrid Keydana,2018-Q4,0,0,0
 Sigrid Keydana,2018-Q3,0,0,0
 Sigrid Keydana,2018-Q2,0,0,0
 Sigrid Keydana,2018-Q1,0,0,0
-Grzegorz Pawelczak,2021-Q4,0,0,0
-Grzegorz Pawelczak,2021-Q3,0,0,0
 Grzegorz Pawelczak,2021-Q2,0,0,0
 Grzegorz Pawelczak,2021-Q1,0,0,0
 Grzegorz Pawelczak,2020-Q4,0,0,0
@@ -22799,8 +19949,6 @@ Grzegorz Pawelczak,2018-Q4,21,639,172
 Grzegorz Pawelczak,2018-Q3,8,245,148
 Grzegorz Pawelczak,2018-Q2,4,14,0
 Grzegorz Pawelczak,2018-Q1,0,0,0
-sana-damani,2021-Q4,0,0,0
-sana-damani,2021-Q3,0,0,0
 sana-damani,2021-Q2,0,0,0
 sana-damani,2021-Q1,0,0,0
 sana-damani,2020-Q4,0,0,0
@@ -22815,8 +19963,6 @@ sana-damani,2018-Q4,0,0,0
 sana-damani,2018-Q3,0,0,0
 sana-damani,2018-Q2,0,0,0
 sana-damani,2018-Q1,0,0,0
-Alexander Pivovarov,2021-Q4,0,0,0
-Alexander Pivovarov,2021-Q3,0,0,0
 Alexander Pivovarov,2021-Q2,0,0,0
 Alexander Pivovarov,2021-Q1,0,0,0
 Alexander Pivovarov,2020-Q4,0,0,0
@@ -22831,8 +19977,6 @@ Alexander Pivovarov,2018-Q4,0,0,0
 Alexander Pivovarov,2018-Q3,0,0,0
 Alexander Pivovarov,2018-Q2,0,0,0
 Alexander Pivovarov,2018-Q1,0,0,0
-Chen Guoyin,2021-Q4,0,0,0
-Chen Guoyin,2021-Q3,0,0,0
 Chen Guoyin,2021-Q2,0,0,0
 Chen Guoyin,2021-Q1,0,0,0
 Chen Guoyin,2020-Q4,0,0,0
@@ -22847,8 +19991,6 @@ Chen Guoyin,2018-Q4,0,0,0
 Chen Guoyin,2018-Q3,0,0,0
 Chen Guoyin,2018-Q2,0,0,0
 Chen Guoyin,2018-Q1,0,0,0
-zhengdi,2021-Q4,0,0,0
-zhengdi,2021-Q3,0,0,0
 zhengdi,2021-Q2,0,0,0
 zhengdi,2021-Q1,0,0,0
 zhengdi,2020-Q4,0,0,0
@@ -22863,8 +20005,6 @@ zhengdi,2018-Q4,0,0,0
 zhengdi,2018-Q3,0,0,0
 zhengdi,2018-Q2,0,0,0
 zhengdi,2018-Q1,0,0,0
-Joon,2021-Q4,0,0,0
-Joon,2021-Q3,0,0,0
 Joon,2021-Q2,0,0,0
 Joon,2021-Q1,0,0,0
 Joon,2020-Q4,0,0,0
@@ -22879,8 +20019,6 @@ Joon,2018-Q4,0,0,0
 Joon,2018-Q3,0,0,0
 Joon,2018-Q2,0,0,0
 Joon,2018-Q1,0,0,0
-Amit Sabne,2021-Q4,0,0,0
-Amit Sabne,2021-Q3,0,0,0
 Amit Sabne,2021-Q2,0,0,0
 Amit Sabne,2021-Q1,0,0,0
 Amit Sabne,2020-Q4,0,0,0
@@ -22895,8 +20033,6 @@ Amit Sabne,2018-Q4,0,0,0
 Amit Sabne,2018-Q3,0,0,0
 Amit Sabne,2018-Q2,0,0,0
 Amit Sabne,2018-Q1,0,0,0
-Junqin Zhang,2021-Q4,0,0,0
-Junqin Zhang,2021-Q3,0,0,0
 Junqin Zhang,2021-Q2,0,0,0
 Junqin Zhang,2021-Q1,0,0,0
 Junqin Zhang,2020-Q4,0,0,0
@@ -22911,8 +20047,6 @@ Junqin Zhang,2018-Q4,0,0,0
 Junqin Zhang,2018-Q3,0,0,0
 Junqin Zhang,2018-Q2,0,0,0
 Junqin Zhang,2018-Q1,0,0,0
-ejot,2021-Q4,0,0,0
-ejot,2021-Q3,0,0,0
 ejot,2021-Q2,0,0,0
 ejot,2021-Q1,0,0,0
 ejot,2020-Q4,0,0,0
@@ -22927,8 +20061,6 @@ ejot,2018-Q4,0,0,0
 ejot,2018-Q3,0,0,0
 ejot,2018-Q2,0,0,0
 ejot,2018-Q1,0,0,0
-merturl,2021-Q4,0,0,0
-merturl,2021-Q3,0,0,0
 merturl,2021-Q2,0,0,0
 merturl,2021-Q1,0,0,0
 merturl,2020-Q4,0,0,0
@@ -22943,8 +20075,6 @@ merturl,2018-Q4,0,0,0
 merturl,2018-Q3,0,0,0
 merturl,2018-Q2,0,0,0
 merturl,2018-Q1,0,0,0
-koock yoon,2021-Q4,0,0,0
-koock yoon,2021-Q3,0,0,0
 koock yoon,2021-Q2,0,0,0
 koock yoon,2021-Q1,0,0,0
 koock yoon,2020-Q4,0,0,0
@@ -22959,8 +20089,6 @@ koock yoon,2018-Q4,0,0,0
 koock yoon,2018-Q3,0,0,0
 koock yoon,2018-Q2,0,0,0
 koock yoon,2018-Q1,0,0,0
-Haraldur Tómas Hallgrímsson,2021-Q4,0,0,0
-Haraldur Tómas Hallgrímsson,2021-Q3,0,0,0
 Haraldur Tómas Hallgrímsson,2021-Q2,0,0,0
 Haraldur Tómas Hallgrímsson,2021-Q1,0,0,0
 Haraldur Tómas Hallgrímsson,2020-Q4,0,0,0
@@ -22975,8 +20103,6 @@ Haraldur Tómas Hallgrímsson,2018-Q4,0,0,0
 Haraldur Tómas Hallgrímsson,2018-Q3,0,0,0
 Haraldur Tómas Hallgrímsson,2018-Q2,0,0,0
 Haraldur Tómas Hallgrímsson,2018-Q1,0,0,0
-yann-yy,2021-Q4,0,0,0
-yann-yy,2021-Q3,0,0,0
 yann-yy,2021-Q2,0,0,0
 yann-yy,2021-Q1,0,0,0
 yann-yy,2020-Q4,0,0,0
@@ -22991,8 +20117,6 @@ yann-yy,2018-Q4,0,0,0
 yann-yy,2018-Q3,0,0,0
 yann-yy,2018-Q2,0,0,0
 yann-yy,2018-Q1,0,0,0
-ymodak,2021-Q4,0,0,0
-ymodak,2021-Q3,0,0,0
 ymodak,2021-Q2,0,0,0
 ymodak,2021-Q1,0,0,0
 ymodak,2020-Q4,0,0,0
@@ -23007,8 +20131,6 @@ ymodak,2018-Q4,0,0,0
 ymodak,2018-Q3,0,0,0
 ymodak,2018-Q2,0,0,0
 ymodak,2018-Q1,0,0,0
-Jeffrey Poznanovic,2021-Q4,0,0,0
-Jeffrey Poznanovic,2021-Q3,0,0,0
 Jeffrey Poznanovic,2021-Q2,0,0,0
 Jeffrey Poznanovic,2021-Q1,0,0,0
 Jeffrey Poznanovic,2020-Q4,0,0,0
@@ -23023,8 +20145,6 @@ Jeffrey Poznanovic,2018-Q4,3,181,14
 Jeffrey Poznanovic,2018-Q3,0,0,0
 Jeffrey Poznanovic,2018-Q2,0,0,0
 Jeffrey Poznanovic,2018-Q1,0,0,0
-Joe Bowser,2021-Q4,0,0,0
-Joe Bowser,2021-Q3,0,0,0
 Joe Bowser,2021-Q2,0,0,0
 Joe Bowser,2021-Q1,0,0,0
 Joe Bowser,2020-Q4,0,0,0
@@ -23039,8 +20159,6 @@ Joe Bowser,2018-Q4,0,0,0
 Joe Bowser,2018-Q3,0,0,0
 Joe Bowser,2018-Q2,0,0,0
 Joe Bowser,2018-Q1,0,0,0
-Phan Van Nguyen Duc,2021-Q4,0,0,0
-Phan Van Nguyen Duc,2021-Q3,0,0,0
 Phan Van Nguyen Duc,2021-Q2,0,0,0
 Phan Van Nguyen Duc,2021-Q1,0,0,0
 Phan Van Nguyen Duc,2020-Q4,0,0,0
@@ -23055,8 +20173,6 @@ Phan Van Nguyen Duc,2018-Q4,0,0,0
 Phan Van Nguyen Duc,2018-Q3,0,0,0
 Phan Van Nguyen Duc,2018-Q2,0,0,0
 Phan Van Nguyen Duc,2018-Q1,0,0,0
-Niklas Silfverström,2021-Q4,0,0,0
-Niklas Silfverström,2021-Q3,0,0,0
 Niklas Silfverström,2021-Q2,0,0,0
 Niklas Silfverström,2021-Q1,0,0,0
 Niklas Silfverström,2020-Q4,0,0,0
@@ -23071,8 +20187,6 @@ Niklas Silfverström,2018-Q4,0,0,0
 Niklas Silfverström,2018-Q3,0,0,0
 Niklas Silfverström,2018-Q2,0,0,0
 Niklas Silfverström,2018-Q1,0,0,0
-Yan Facai (颜发才),2021-Q4,0,0,0
-Yan Facai (颜发才),2021-Q3,0,0,0
 Yan Facai (颜发才),2021-Q2,0,0,0
 Yan Facai (颜发才),2021-Q1,0,0,0
 Yan Facai (颜发才),2020-Q4,0,0,0
@@ -23087,8 +20201,6 @@ Yan Facai (颜发才),2018-Q4,17,145,117
 Yan Facai (颜发才),2018-Q3,153,2306,1235
 Yan Facai (颜发才),2018-Q2,106,1851,737
 Yan Facai (颜发才),2018-Q1,44,1695,69
-Christopher Yeh,2021-Q4,0,0,0
-Christopher Yeh,2021-Q3,0,0,0
 Christopher Yeh,2021-Q2,0,0,0
 Christopher Yeh,2021-Q1,0,0,0
 Christopher Yeh,2020-Q4,0,0,0
@@ -23103,8 +20215,6 @@ Christopher Yeh,2018-Q4,0,0,0
 Christopher Yeh,2018-Q3,0,0,0
 Christopher Yeh,2018-Q2,0,0,0
 Christopher Yeh,2018-Q1,4,16,20
-leonard951,2021-Q4,0,0,0
-leonard951,2021-Q3,0,0,0
 leonard951,2021-Q2,0,0,0
 leonard951,2021-Q1,0,0,0
 leonard951,2020-Q4,0,0,0
@@ -23119,8 +20229,6 @@ leonard951,2018-Q4,0,0,0
 leonard951,2018-Q3,0,0,0
 leonard951,2018-Q2,0,0,0
 leonard951,2018-Q1,0,0,0
-Justin Tunis,2021-Q4,0,0,0
-Justin Tunis,2021-Q3,0,0,0
 Justin Tunis,2021-Q2,0,0,0
 Justin Tunis,2021-Q1,0,0,0
 Justin Tunis,2020-Q4,0,0,0
@@ -23135,8 +20243,6 @@ Justin Tunis,2018-Q4,0,0,0
 Justin Tunis,2018-Q3,0,0,0
 Justin Tunis,2018-Q2,0,0,0
 Justin Tunis,2018-Q1,0,0,0
-Astropeak,2021-Q4,0,0,0
-Astropeak,2021-Q3,0,0,0
 Astropeak,2021-Q2,0,0,0
 Astropeak,2021-Q1,0,0,0
 Astropeak,2020-Q4,0,0,0
@@ -23151,8 +20257,6 @@ Astropeak,2018-Q4,0,0,0
 Astropeak,2018-Q3,0,0,0
 Astropeak,2018-Q2,0,0,0
 Astropeak,2018-Q1,0,0,0
-Tamas Berghammer,2021-Q4,0,0,0
-Tamas Berghammer,2021-Q3,0,0,0
 Tamas Berghammer,2021-Q2,0,0,0
 Tamas Berghammer,2021-Q1,0,0,0
 Tamas Berghammer,2020-Q4,0,0,0
@@ -23167,8 +20271,6 @@ Tamas Berghammer,2018-Q4,0,0,0
 Tamas Berghammer,2018-Q3,0,0,0
 Tamas Berghammer,2018-Q2,0,0,0
 Tamas Berghammer,2018-Q1,0,0,0
-Gurpreet singh,2021-Q4,0,0,0
-Gurpreet singh,2021-Q3,0,0,0
 Gurpreet singh,2021-Q2,0,0,0
 Gurpreet singh,2021-Q1,0,0,0
 Gurpreet singh,2020-Q4,0,0,0
@@ -23183,8 +20285,6 @@ Gurpreet singh,2018-Q4,0,0,0
 Gurpreet singh,2018-Q3,0,0,0
 Gurpreet singh,2018-Q2,0,0,0
 Gurpreet singh,2018-Q1,0,0,0
-chengchingwen,2021-Q4,0,0,0
-chengchingwen,2021-Q3,0,0,0
 chengchingwen,2021-Q2,0,0,0
 chengchingwen,2021-Q1,0,0,0
 chengchingwen,2020-Q4,0,0,0
@@ -23199,8 +20299,6 @@ chengchingwen,2018-Q4,0,0,0
 chengchingwen,2018-Q3,0,0,0
 chengchingwen,2018-Q2,0,0,0
 chengchingwen,2018-Q1,0,0,0
-Dominik Schlösser,2021-Q4,0,0,0
-Dominik Schlösser,2021-Q3,0,0,0
 Dominik Schlösser,2021-Q2,0,0,0
 Dominik Schlösser,2021-Q1,0,0,0
 Dominik Schlösser,2020-Q4,0,0,0
@@ -23215,8 +20313,6 @@ Dominik Schlösser,2018-Q4,0,0,0
 Dominik Schlösser,2018-Q3,0,0,0
 Dominik Schlösser,2018-Q2,0,0,0
 Dominik Schlösser,2018-Q1,0,0,0
-Michal W. Tarnowski,2021-Q4,0,0,0
-Michal W. Tarnowski,2021-Q3,0,0,0
 Michal W. Tarnowski,2021-Q2,0,0,0
 Michal W. Tarnowski,2021-Q1,0,0,0
 Michal W. Tarnowski,2020-Q4,0,0,0
@@ -23231,8 +20327,6 @@ Michal W. Tarnowski,2018-Q4,0,0,0
 Michal W. Tarnowski,2018-Q3,0,0,0
 Michal W. Tarnowski,2018-Q2,0,0,0
 Michal W. Tarnowski,2018-Q1,0,0,0
-zhuoryin,2021-Q4,0,0,0
-zhuoryin,2021-Q3,0,0,0
 zhuoryin,2021-Q2,0,0,0
 zhuoryin,2021-Q1,0,0,0
 zhuoryin,2020-Q4,0,0,0
@@ -23247,8 +20341,6 @@ zhuoryin,2018-Q4,0,0,0
 zhuoryin,2018-Q3,0,0,0
 zhuoryin,2018-Q2,0,0,0
 zhuoryin,2018-Q1,0,0,0
-gurpreetsingh9465,2021-Q4,0,0,0
-gurpreetsingh9465,2021-Q3,0,0,0
 gurpreetsingh9465,2021-Q2,0,0,0
 gurpreetsingh9465,2021-Q1,0,0,0
 gurpreetsingh9465,2020-Q4,0,0,0
@@ -23263,8 +20355,6 @@ gurpreetsingh9465,2018-Q4,0,0,0
 gurpreetsingh9465,2018-Q3,0,0,0
 gurpreetsingh9465,2018-Q2,0,0,0
 gurpreetsingh9465,2018-Q1,0,0,0
-jhalakp,2021-Q4,0,0,0
-jhalakp,2021-Q3,0,0,0
 jhalakp,2021-Q2,0,0,0
 jhalakp,2021-Q1,0,0,0
 jhalakp,2020-Q4,0,0,0
@@ -23279,8 +20369,6 @@ jhalakp,2018-Q4,0,0,0
 jhalakp,2018-Q3,0,0,0
 jhalakp,2018-Q2,0,0,0
 jhalakp,2018-Q1,0,0,0
-smilu97,2021-Q4,0,0,0
-smilu97,2021-Q3,0,0,0
 smilu97,2021-Q2,0,0,0
 smilu97,2021-Q1,0,0,0
 smilu97,2020-Q4,0,0,0
@@ -23295,8 +20383,6 @@ smilu97,2018-Q4,3,14,0
 smilu97,2018-Q3,0,0,0
 smilu97,2018-Q2,0,0,0
 smilu97,2018-Q1,0,0,0
-TheMindVirus,2021-Q4,0,0,0
-TheMindVirus,2021-Q3,0,0,0
 TheMindVirus,2021-Q2,0,0,0
 TheMindVirus,2021-Q1,0,0,0
 TheMindVirus,2020-Q4,0,0,0
@@ -23311,8 +20397,6 @@ TheMindVirus,2018-Q4,0,0,0
 TheMindVirus,2018-Q3,0,0,0
 TheMindVirus,2018-Q2,0,0,0
 TheMindVirus,2018-Q1,0,0,0
-Mike Dreves,2021-Q4,0,0,0
-Mike Dreves,2021-Q3,0,0,0
 Mike Dreves,2021-Q2,0,0,0
 Mike Dreves,2021-Q1,0,0,0
 Mike Dreves,2020-Q4,0,0,0
@@ -23327,8 +20411,6 @@ Mike Dreves,2018-Q4,0,0,0
 Mike Dreves,2018-Q3,0,0,0
 Mike Dreves,2018-Q2,0,0,0
 Mike Dreves,2018-Q1,0,0,0
-Charles Weill,2021-Q4,0,0,0
-Charles Weill,2021-Q3,0,0,0
 Charles Weill,2021-Q2,0,0,0
 Charles Weill,2021-Q1,0,0,0
 Charles Weill,2020-Q4,0,0,0
@@ -23343,8 +20425,6 @@ Charles Weill,2018-Q4,0,0,0
 Charles Weill,2018-Q3,0,0,0
 Charles Weill,2018-Q2,0,0,0
 Charles Weill,2018-Q1,0,0,0
-Arpit Shah,2021-Q4,0,0,0
-Arpit Shah,2021-Q3,0,0,0
 Arpit Shah,2021-Q2,0,0,0
 Arpit Shah,2021-Q1,0,0,0
 Arpit Shah,2020-Q4,0,0,0
@@ -23359,8 +20439,6 @@ Arpit Shah,2018-Q4,29,136,23850
 Arpit Shah,2018-Q3,0,0,0
 Arpit Shah,2018-Q2,0,0,0
 Arpit Shah,2018-Q1,0,0,0
-Adam Richter,2021-Q4,0,0,0
-Adam Richter,2021-Q3,0,0,0
 Adam Richter,2021-Q2,0,0,0
 Adam Richter,2021-Q1,0,0,0
 Adam Richter,2020-Q4,0,0,0
@@ -23375,8 +20453,6 @@ Adam Richter,2018-Q4,0,0,0
 Adam Richter,2018-Q3,0,0,0
 Adam Richter,2018-Q2,0,0,0
 Adam Richter,2018-Q1,0,0,0
-Bin Fan,2021-Q4,0,0,0
-Bin Fan,2021-Q3,0,0,0
 Bin Fan,2021-Q2,0,0,0
 Bin Fan,2021-Q1,0,0,0
 Bin Fan,2020-Q4,0,0,0
@@ -23391,8 +20467,6 @@ Bin Fan,2018-Q4,0,0,0
 Bin Fan,2018-Q3,0,0,0
 Bin Fan,2018-Q2,0,0,0
 Bin Fan,2018-Q1,0,0,0
-Takeo Sawada,2021-Q4,0,0,0
-Takeo Sawada,2021-Q3,0,0,0
 Takeo Sawada,2021-Q2,0,0,0
 Takeo Sawada,2021-Q1,0,0,0
 Takeo Sawada,2020-Q4,0,0,0
@@ -23407,8 +20481,6 @@ Takeo Sawada,2018-Q4,0,0,0
 Takeo Sawada,2018-Q3,0,0,0
 Takeo Sawada,2018-Q2,0,0,0
 Takeo Sawada,2018-Q1,0,0,0
-André Susano Pinto,2021-Q4,0,0,0
-André Susano Pinto,2021-Q3,0,0,0
 André Susano Pinto,2021-Q2,0,0,0
 André Susano Pinto,2021-Q1,0,0,0
 André Susano Pinto,2020-Q4,0,0,0
@@ -23423,8 +20495,6 @@ André Susano Pinto,2018-Q4,0,0,0
 André Susano Pinto,2018-Q3,0,0,0
 André Susano Pinto,2018-Q2,0,0,0
 André Susano Pinto,2018-Q1,0,0,0
-Paul Suganthan,2021-Q4,0,0,0
-Paul Suganthan,2021-Q3,0,0,0
 Paul Suganthan,2021-Q2,0,0,0
 Paul Suganthan,2021-Q1,0,0,0
 Paul Suganthan,2020-Q4,0,0,0
@@ -23439,8 +20509,6 @@ Paul Suganthan,2018-Q4,0,0,0
 Paul Suganthan,2018-Q3,0,0,0
 Paul Suganthan,2018-Q2,0,0,0
 Paul Suganthan,2018-Q1,0,0,0
-Tongxuan Liu,2021-Q4,0,0,0
-Tongxuan Liu,2021-Q3,0,0,0
 Tongxuan Liu,2021-Q2,0,0,0
 Tongxuan Liu,2021-Q1,0,0,0
 Tongxuan Liu,2020-Q4,0,0,0
@@ -23455,8 +20523,6 @@ Tongxuan Liu,2018-Q4,4,23,6
 Tongxuan Liu,2018-Q3,0,0,0
 Tongxuan Liu,2018-Q2,0,0,0
 Tongxuan Liu,2018-Q1,0,0,0
-Ramon Viñas,2021-Q4,0,0,0
-Ramon Viñas,2021-Q3,0,0,0
 Ramon Viñas,2021-Q2,0,0,0
 Ramon Viñas,2021-Q1,0,0,0
 Ramon Viñas,2020-Q4,0,0,0
@@ -23471,8 +20537,6 @@ Ramon Viñas,2018-Q4,0,0,0
 Ramon Viñas,2018-Q3,0,0,0
 Ramon Viñas,2018-Q2,0,0,0
 Ramon Viñas,2018-Q1,0,0,0
-Maksym Kysylov,2021-Q4,0,0,0
-Maksym Kysylov,2021-Q3,0,0,0
 Maksym Kysylov,2021-Q2,0,0,0
 Maksym Kysylov,2021-Q1,0,0,0
 Maksym Kysylov,2020-Q4,0,0,0
@@ -23487,8 +20551,6 @@ Maksym Kysylov,2018-Q4,0,0,0
 Maksym Kysylov,2018-Q3,0,0,0
 Maksym Kysylov,2018-Q2,0,0,0
 Maksym Kysylov,2018-Q1,0,0,0
-Pariksheet,2021-Q4,0,0,0
-Pariksheet,2021-Q3,0,0,0
 Pariksheet,2021-Q2,0,0,0
 Pariksheet,2021-Q1,0,0,0
 Pariksheet,2020-Q4,0,0,0
@@ -23503,8 +20565,6 @@ Pariksheet,2018-Q4,0,0,0
 Pariksheet,2018-Q3,0,0,0
 Pariksheet,2018-Q2,0,0,0
 Pariksheet,2018-Q1,0,0,0
-winstonq,2021-Q4,0,0,0
-winstonq,2021-Q3,0,0,0
 winstonq,2021-Q2,0,0,0
 winstonq,2021-Q1,0,0,0
 winstonq,2020-Q4,0,0,0
@@ -23519,8 +20579,6 @@ winstonq,2018-Q4,0,0,0
 winstonq,2018-Q3,0,0,0
 winstonq,2018-Q2,0,0,0
 winstonq,2018-Q1,0,0,0
-aweers,2021-Q4,0,0,0
-aweers,2021-Q3,0,0,0
 aweers,2021-Q2,0,0,0
 aweers,2021-Q1,0,0,0
 aweers,2020-Q4,0,0,0
@@ -23535,8 +20593,6 @@ aweers,2018-Q4,0,0,0
 aweers,2018-Q3,0,0,0
 aweers,2018-Q2,0,0,0
 aweers,2018-Q1,0,0,0
-Musikisomorphie,2021-Q4,0,0,0
-Musikisomorphie,2021-Q3,0,0,0
 Musikisomorphie,2021-Q2,0,0,0
 Musikisomorphie,2021-Q1,0,0,0
 Musikisomorphie,2020-Q4,0,0,0
@@ -23551,8 +20607,6 @@ Musikisomorphie,2018-Q4,0,0,0
 Musikisomorphie,2018-Q3,0,0,0
 Musikisomorphie,2018-Q2,0,0,0
 Musikisomorphie,2018-Q1,0,0,0
-Augustina Ragwitz,2021-Q4,0,0,0
-Augustina Ragwitz,2021-Q3,0,0,0
 Augustina Ragwitz,2021-Q2,0,0,0
 Augustina Ragwitz,2021-Q1,0,0,0
 Augustina Ragwitz,2020-Q4,0,0,0
@@ -23567,8 +20621,6 @@ Augustina Ragwitz,2018-Q4,0,0,0
 Augustina Ragwitz,2018-Q3,0,0,0
 Augustina Ragwitz,2018-Q2,0,0,0
 Augustina Ragwitz,2018-Q1,0,0,0
-Yuan (Terry) Tang,2021-Q4,0,0,0
-Yuan (Terry) Tang,2021-Q3,0,0,0
 Yuan (Terry) Tang,2021-Q2,0,0,0
 Yuan (Terry) Tang,2021-Q1,0,0,0
 Yuan (Terry) Tang,2020-Q4,0,0,0
@@ -23583,8 +20635,6 @@ Yuan (Terry) Tang,2018-Q4,1,7,6
 Yuan (Terry) Tang,2018-Q3,1,0,0
 Yuan (Terry) Tang,2018-Q2,2,17,13
 Yuan (Terry) Tang,2018-Q1,1,16,16
-Mikalai Drabovich,2021-Q4,0,0,0
-Mikalai Drabovich,2021-Q3,0,0,0
 Mikalai Drabovich,2021-Q2,0,0,0
 Mikalai Drabovich,2021-Q1,0,0,0
 Mikalai Drabovich,2020-Q4,0,0,0
@@ -23599,8 +20649,6 @@ Mikalai Drabovich,2018-Q4,0,0,0
 Mikalai Drabovich,2018-Q3,0,0,0
 Mikalai Drabovich,2018-Q2,0,0,0
 Mikalai Drabovich,2018-Q1,1,3,2
-Josh Beal,2021-Q4,0,0,0
-Josh Beal,2021-Q3,0,0,0
 Josh Beal,2021-Q2,0,0,0
 Josh Beal,2021-Q1,0,0,0
 Josh Beal,2020-Q4,0,0,0
@@ -23615,8 +20663,6 @@ Josh Beal,2018-Q4,0,0,0
 Josh Beal,2018-Q3,0,0,0
 Josh Beal,2018-Q2,0,0,0
 Josh Beal,2018-Q1,0,0,0
-Goutham Bhat,2021-Q4,0,0,0
-Goutham Bhat,2021-Q3,0,0,0
 Goutham Bhat,2021-Q2,0,0,0
 Goutham Bhat,2021-Q1,0,0,0
 Goutham Bhat,2020-Q4,0,0,0
@@ -23631,8 +20677,6 @@ Goutham Bhat,2018-Q4,0,0,0
 Goutham Bhat,2018-Q3,8,793,4
 Goutham Bhat,2018-Q2,3,97,59
 Goutham Bhat,2018-Q1,0,0,0
-Filip Matzner,2021-Q4,0,0,0
-Filip Matzner,2021-Q3,0,0,0
 Filip Matzner,2021-Q2,0,0,0
 Filip Matzner,2021-Q1,0,0,0
 Filip Matzner,2020-Q4,0,0,0
@@ -23647,8 +20691,6 @@ Filip Matzner,2018-Q4,2,2,0
 Filip Matzner,2018-Q3,0,0,0
 Filip Matzner,2018-Q2,0,0,0
 Filip Matzner,2018-Q1,0,0,0
-sxwang,2021-Q4,0,0,0
-sxwang,2021-Q3,0,0,0
 sxwang,2021-Q2,0,0,0
 sxwang,2021-Q1,0,0,0
 sxwang,2020-Q4,0,0,0
@@ -23663,8 +20705,6 @@ sxwang,2018-Q4,0,0,0
 sxwang,2018-Q3,0,0,0
 sxwang,2018-Q2,0,0,0
 sxwang,2018-Q1,0,0,0
-Brennan Saeta,2021-Q4,0,0,0
-Brennan Saeta,2021-Q3,0,0,0
 Brennan Saeta,2021-Q2,0,0,0
 Brennan Saeta,2021-Q1,0,0,0
 Brennan Saeta,2020-Q4,0,0,0
@@ -23679,8 +20719,6 @@ Brennan Saeta,2018-Q4,177,2792,769
 Brennan Saeta,2018-Q3,51,3775,212
 Brennan Saeta,2018-Q2,147,4418,572
 Brennan Saeta,2018-Q1,85,3332,580
-bodin-e,2021-Q4,0,0,0
-bodin-e,2021-Q3,0,0,0
 bodin-e,2021-Q2,0,0,0
 bodin-e,2021-Q1,0,0,0
 bodin-e,2020-Q4,0,0,0
@@ -23695,8 +20733,6 @@ bodin-e,2018-Q4,0,0,0
 bodin-e,2018-Q3,0,0,0
 bodin-e,2018-Q2,0,0,0
 bodin-e,2018-Q1,0,0,0
-Duncan Dean,2021-Q4,0,0,0
-Duncan Dean,2021-Q3,0,0,0
 Duncan Dean,2021-Q2,0,0,0
 Duncan Dean,2021-Q1,0,0,0
 Duncan Dean,2020-Q4,0,0,0
@@ -23711,8 +20747,6 @@ Duncan Dean,2018-Q4,0,0,0
 Duncan Dean,2018-Q3,0,0,0
 Duncan Dean,2018-Q2,0,0,0
 Duncan Dean,2018-Q1,0,0,0
-Neal Wu,2021-Q4,0,0,0
-Neal Wu,2021-Q3,0,0,0
 Neal Wu,2021-Q2,0,0,0
 Neal Wu,2021-Q1,0,0,0
 Neal Wu,2020-Q4,0,0,0
@@ -23727,8 +20761,6 @@ Neal Wu,2018-Q4,0,0,0
 Neal Wu,2018-Q3,0,0,0
 Neal Wu,2018-Q2,0,0,0
 Neal Wu,2018-Q1,3,5,5
-v1incent,2021-Q4,0,0,0
-v1incent,2021-Q3,0,0,0
 v1incent,2021-Q2,0,0,0
 v1incent,2021-Q1,0,0,0
 v1incent,2020-Q4,0,0,0
@@ -23743,8 +20775,6 @@ v1incent,2018-Q4,0,0,0
 v1incent,2018-Q3,0,0,0
 v1incent,2018-Q2,0,0,0
 v1incent,2018-Q1,0,0,0
-Vincent,2021-Q4,0,0,0
-Vincent,2021-Q3,0,0,0
 Vincent,2021-Q2,0,0,0
 Vincent,2021-Q1,0,0,0
 Vincent,2020-Q4,0,0,0
@@ -23759,8 +20789,6 @@ Vincent,2018-Q4,0,0,0
 Vincent,2018-Q3,0,0,0
 Vincent,2018-Q2,2,11,0
 Vincent,2018-Q1,0,0,0
-Cong Liu,2021-Q4,0,0,0
-Cong Liu,2021-Q3,0,0,0
 Cong Liu,2021-Q2,0,0,0
 Cong Liu,2021-Q1,0,0,0
 Cong Liu,2020-Q4,0,0,0
@@ -23775,8 +20803,6 @@ Cong Liu,2018-Q4,62,944,144
 Cong Liu,2018-Q3,0,0,0
 Cong Liu,2018-Q2,0,0,0
 Cong Liu,2018-Q1,0,0,0
-Shashank Gupta,2021-Q4,0,0,0
-Shashank Gupta,2021-Q3,0,0,0
 Shashank Gupta,2021-Q2,0,0,0
 Shashank Gupta,2021-Q1,0,0,0
 Shashank Gupta,2020-Q4,0,0,0
@@ -23791,8 +20817,6 @@ Shashank Gupta,2018-Q4,0,0,0
 Shashank Gupta,2018-Q3,0,0,0
 Shashank Gupta,2018-Q2,0,0,0
 Shashank Gupta,2018-Q1,0,0,0
-FlashTek,2021-Q4,0,0,0
-FlashTek,2021-Q3,0,0,0
 FlashTek,2021-Q2,0,0,0
 FlashTek,2021-Q1,0,0,0
 FlashTek,2020-Q4,0,0,0
@@ -23807,8 +20831,6 @@ FlashTek,2018-Q4,0,0,0
 FlashTek,2018-Q3,0,0,0
 FlashTek,2018-Q2,0,0,0
 FlashTek,2018-Q1,0,0,0
-Anshuman Tripathy,2021-Q4,0,0,0
-Anshuman Tripathy,2021-Q3,0,0,0
 Anshuman Tripathy,2021-Q2,0,0,0
 Anshuman Tripathy,2021-Q1,0,0,0
 Anshuman Tripathy,2020-Q4,0,0,0
@@ -23823,8 +20845,6 @@ Anshuman Tripathy,2018-Q4,0,0,0
 Anshuman Tripathy,2018-Q3,0,0,0
 Anshuman Tripathy,2018-Q2,0,0,0
 Anshuman Tripathy,2018-Q1,0,0,0
-Anthony Hsu,2021-Q4,0,0,0
-Anthony Hsu,2021-Q3,0,0,0
 Anthony Hsu,2021-Q2,0,0,0
 Anthony Hsu,2021-Q1,0,0,0
 Anthony Hsu,2020-Q4,0,0,0
@@ -23839,8 +20859,6 @@ Anthony Hsu,2018-Q4,0,0,0
 Anthony Hsu,2018-Q3,0,0,0
 Anthony Hsu,2018-Q2,0,0,0
 Anthony Hsu,2018-Q1,0,0,0
-Justin DuJardin,2021-Q4,0,0,0
-Justin DuJardin,2021-Q3,0,0,0
 Justin DuJardin,2021-Q2,0,0,0
 Justin DuJardin,2021-Q1,0,0,0
 Justin DuJardin,2020-Q4,0,0,0
@@ -23855,8 +20873,6 @@ Justin DuJardin,2018-Q4,0,0,0
 Justin DuJardin,2018-Q3,0,0,0
 Justin DuJardin,2018-Q2,0,0,0
 Justin DuJardin,2018-Q1,0,0,0
-Subin,2021-Q4,0,0,0
-Subin,2021-Q3,0,0,0
 Subin,2021-Q2,0,0,0
 Subin,2021-Q1,0,0,0
 Subin,2020-Q4,0,0,0
@@ -23871,8 +20887,6 @@ Subin,2018-Q4,0,0,0
 Subin,2018-Q3,0,0,0
 Subin,2018-Q2,0,0,0
 Subin,2018-Q1,0,0,0
-GimYeongJin,2021-Q4,0,0,0
-GimYeongJin,2021-Q3,0,0,0
 GimYeongJin,2021-Q2,0,0,0
 GimYeongJin,2021-Q1,0,0,0
 GimYeongJin,2020-Q4,0,0,0
@@ -23887,8 +20901,6 @@ GimYeongJin,2018-Q4,0,0,0
 GimYeongJin,2018-Q3,0,0,0
 GimYeongJin,2018-Q2,0,0,0
 GimYeongJin,2018-Q1,0,0,0
-Geoffrey Irving,2021-Q4,0,0,0
-Geoffrey Irving,2021-Q3,0,0,0
 Geoffrey Irving,2021-Q2,0,0,0
 Geoffrey Irving,2021-Q1,0,0,0
 Geoffrey Irving,2020-Q4,0,0,0
@@ -23903,8 +20915,6 @@ Geoffrey Irving,2018-Q4,78,435,300
 Geoffrey Irving,2018-Q3,18,580,225
 Geoffrey Irving,2018-Q2,4,29,30
 Geoffrey Irving,2018-Q1,0,0,0
-Thang Luong,2021-Q4,0,0,0
-Thang Luong,2021-Q3,0,0,0
 Thang Luong,2021-Q2,0,0,0
 Thang Luong,2021-Q1,0,0,0
 Thang Luong,2020-Q4,0,0,0
@@ -23919,8 +20929,6 @@ Thang Luong,2018-Q4,0,0,0
 Thang Luong,2018-Q3,0,0,0
 Thang Luong,2018-Q2,0,0,0
 Thang Luong,2018-Q1,0,0,0
-Pasquale Minervini,2021-Q4,0,0,0
-Pasquale Minervini,2021-Q3,0,0,0
 Pasquale Minervini,2021-Q2,0,0,0
 Pasquale Minervini,2021-Q1,0,0,0
 Pasquale Minervini,2020-Q4,0,0,0
@@ -23935,8 +20943,6 @@ Pasquale Minervini,2018-Q4,0,0,0
 Pasquale Minervini,2018-Q3,0,0,0
 Pasquale Minervini,2018-Q2,0,0,0
 Pasquale Minervini,2018-Q1,0,0,0
-avasid,2021-Q4,0,0,0
-avasid,2021-Q3,0,0,0
 avasid,2021-Q2,0,0,0
 avasid,2021-Q1,0,0,0
 avasid,2020-Q4,0,0,0
@@ -23951,8 +20957,6 @@ avasid,2018-Q4,0,0,0
 avasid,2018-Q3,0,0,0
 avasid,2018-Q2,0,0,0
 avasid,2018-Q1,0,0,0
-Philipp Jund,2021-Q4,0,0,0
-Philipp Jund,2021-Q3,0,0,0
 Philipp Jund,2021-Q2,0,0,0
 Philipp Jund,2021-Q1,0,0,0
 Philipp Jund,2020-Q4,0,0,0
@@ -23967,8 +20971,6 @@ Philipp Jund,2018-Q4,0,0,0
 Philipp Jund,2018-Q3,1,3,2
 Philipp Jund,2018-Q2,5,110,80
 Philipp Jund,2018-Q1,4,511,0
-Bayberry Z,2021-Q4,0,0,0
-Bayberry Z,2021-Q3,0,0,0
 Bayberry Z,2021-Q2,0,0,0
 Bayberry Z,2021-Q1,0,0,0
 Bayberry Z,2020-Q4,0,0,0
@@ -23983,8 +20985,6 @@ Bayberry Z,2018-Q4,0,0,0
 Bayberry Z,2018-Q3,0,0,0
 Bayberry Z,2018-Q2,0,0,0
 Bayberry Z,2018-Q1,0,0,0
-shashvatshahi1998,2021-Q4,0,0,0
-shashvatshahi1998,2021-Q3,0,0,0
 shashvatshahi1998,2021-Q2,0,0,0
 shashvatshahi1998,2021-Q1,0,0,0
 shashvatshahi1998,2020-Q4,0,0,0
@@ -23999,8 +20999,6 @@ shashvatshahi1998,2018-Q4,0,0,0
 shashvatshahi1998,2018-Q3,0,0,0
 shashvatshahi1998,2018-Q2,0,0,0
 shashvatshahi1998,2018-Q1,0,0,0
-Tyorden,2021-Q4,0,0,0
-Tyorden,2021-Q3,0,0,0
 Tyorden,2021-Q2,0,0,0
 Tyorden,2021-Q1,0,0,0
 Tyorden,2020-Q4,0,0,0
@@ -24015,8 +21013,6 @@ Tyorden,2018-Q4,0,0,0
 Tyorden,2018-Q3,0,0,0
 Tyorden,2018-Q2,0,0,0
 Tyorden,2018-Q1,0,0,0
-Thomas Hagebols,2021-Q4,0,0,0
-Thomas Hagebols,2021-Q3,0,0,0
 Thomas Hagebols,2021-Q2,0,0,0
 Thomas Hagebols,2021-Q1,0,0,0
 Thomas Hagebols,2020-Q4,0,0,0
@@ -24031,8 +21027,6 @@ Thomas Hagebols,2018-Q4,0,0,0
 Thomas Hagebols,2018-Q3,0,0,0
 Thomas Hagebols,2018-Q2,0,0,0
 Thomas Hagebols,2018-Q1,0,0,0
-R S Nikhil Krishna,2021-Q4,0,0,0
-R S Nikhil Krishna,2021-Q3,0,0,0
 R S Nikhil Krishna,2021-Q2,0,0,0
 R S Nikhil Krishna,2021-Q1,0,0,0
 R S Nikhil Krishna,2020-Q4,0,0,0
@@ -24047,8 +21041,6 @@ R S Nikhil Krishna,2018-Q4,0,0,0
 R S Nikhil Krishna,2018-Q3,0,0,0
 R S Nikhil Krishna,2018-Q2,0,0,0
 R S Nikhil Krishna,2018-Q1,0,0,0
-TungJerry,2021-Q4,0,0,0
-TungJerry,2021-Q3,0,0,0
 TungJerry,2021-Q2,0,0,0
 TungJerry,2021-Q1,0,0,0
 TungJerry,2020-Q4,0,0,0
@@ -24063,8 +21055,6 @@ TungJerry,2018-Q4,0,0,0
 TungJerry,2018-Q3,0,0,0
 TungJerry,2018-Q2,0,0,0
 TungJerry,2018-Q1,0,0,0
-Ruizhe,2021-Q4,0,0,0
-Ruizhe,2021-Q3,0,0,0
 Ruizhe,2021-Q2,0,0,0
 Ruizhe,2021-Q1,0,0,0
 Ruizhe,2020-Q4,0,0,0
@@ -24079,8 +21069,6 @@ Ruizhe,2018-Q4,0,0,0
 Ruizhe,2018-Q3,0,0,0
 Ruizhe,2018-Q2,0,0,0
 Ruizhe,2018-Q1,0,0,0
-mosesmarin,2021-Q4,0,0,0
-mosesmarin,2021-Q3,0,0,0
 mosesmarin,2021-Q2,0,0,0
 mosesmarin,2021-Q1,0,0,0
 mosesmarin,2020-Q4,0,0,0
@@ -24095,8 +21083,6 @@ mosesmarin,2018-Q4,0,0,0
 mosesmarin,2018-Q3,0,0,0
 mosesmarin,2018-Q2,0,0,0
 mosesmarin,2018-Q1,0,0,0
-Moses Marin,2021-Q4,0,0,0
-Moses Marin,2021-Q3,0,0,0
 Moses Marin,2021-Q2,0,0,0
 Moses Marin,2021-Q1,0,0,0
 Moses Marin,2020-Q4,0,0,0
@@ -24111,8 +21097,6 @@ Moses Marin,2018-Q4,0,0,0
 Moses Marin,2018-Q3,0,0,0
 Moses Marin,2018-Q2,0,0,0
 Moses Marin,2018-Q1,0,0,0
-Lifeng Nai,2021-Q4,0,0,0
-Lifeng Nai,2021-Q3,0,0,0
 Lifeng Nai,2021-Q2,0,0,0
 Lifeng Nai,2021-Q1,0,0,0
 Lifeng Nai,2020-Q4,0,0,0
@@ -24127,8 +21111,6 @@ Lifeng Nai,2018-Q4,0,0,0
 Lifeng Nai,2018-Q3,0,0,0
 Lifeng Nai,2018-Q2,0,0,0
 Lifeng Nai,2018-Q1,0,0,0
-robert,2021-Q4,0,0,0
-robert,2021-Q3,0,0,0
 robert,2021-Q2,0,0,0
 robert,2021-Q1,0,0,0
 robert,2020-Q4,0,0,0
@@ -24143,8 +21125,6 @@ robert,2018-Q4,0,0,0
 robert,2018-Q3,0,0,0
 robert,2018-Q2,0,0,0
 robert,2018-Q1,0,0,0
-Roman Soldatow,2021-Q4,0,0,0
-Roman Soldatow,2021-Q3,0,0,0
 Roman Soldatow,2021-Q2,0,0,0
 Roman Soldatow,2021-Q1,0,0,0
 Roman Soldatow,2020-Q4,0,0,0
@@ -24159,8 +21139,6 @@ Roman Soldatow,2018-Q4,0,0,0
 Roman Soldatow,2018-Q3,0,0,0
 Roman Soldatow,2018-Q2,0,0,0
 Roman Soldatow,2018-Q1,0,0,0
-Blénesi Attila,2021-Q4,0,0,0
-Blénesi Attila,2021-Q3,0,0,0
 Blénesi Attila,2021-Q2,0,0,0
 Blénesi Attila,2021-Q1,0,0,0
 Blénesi Attila,2020-Q4,0,0,0
@@ -24175,8 +21153,6 @@ Blénesi Attila,2018-Q4,0,0,0
 Blénesi Attila,2018-Q3,0,0,0
 Blénesi Attila,2018-Q2,0,0,0
 Blénesi Attila,2018-Q1,0,0,0
-Pengchong Jin,2021-Q4,0,0,0
-Pengchong Jin,2021-Q3,0,0,0
 Pengchong Jin,2021-Q2,0,0,0
 Pengchong Jin,2021-Q1,0,0,0
 Pengchong Jin,2020-Q4,0,0,0
@@ -24191,8 +21167,6 @@ Pengchong Jin,2018-Q4,0,0,0
 Pengchong Jin,2018-Q3,0,0,0
 Pengchong Jin,2018-Q2,0,0,0
 Pengchong Jin,2018-Q1,0,0,0
-Dustin Neighly,2021-Q4,0,0,0
-Dustin Neighly,2021-Q3,0,0,0
 Dustin Neighly,2021-Q2,0,0,0
 Dustin Neighly,2021-Q1,0,0,0
 Dustin Neighly,2020-Q4,0,0,0
@@ -24207,8 +21181,6 @@ Dustin Neighly,2018-Q4,0,0,0
 Dustin Neighly,2018-Q3,0,0,0
 Dustin Neighly,2018-Q2,0,0,0
 Dustin Neighly,2018-Q1,0,0,0
-Pavel Akhtyamov,2021-Q4,0,0,0
-Pavel Akhtyamov,2021-Q3,0,0,0
 Pavel Akhtyamov,2021-Q2,0,0,0
 Pavel Akhtyamov,2021-Q1,0,0,0
 Pavel Akhtyamov,2020-Q4,0,0,0
@@ -24223,8 +21195,6 @@ Pavel Akhtyamov,2018-Q4,0,0,0
 Pavel Akhtyamov,2018-Q3,0,0,0
 Pavel Akhtyamov,2018-Q2,0,0,0
 Pavel Akhtyamov,2018-Q1,0,0,0
-黄鑫,2021-Q4,0,0,0
-黄鑫,2021-Q3,0,0,0
 黄鑫,2021-Q2,0,0,0
 黄鑫,2021-Q1,0,0,0
 黄鑫,2020-Q4,0,0,0
@@ -24239,8 +21209,6 @@ Pavel Akhtyamov,2018-Q1,0,0,0
 黄鑫,2018-Q3,0,0,0
 黄鑫,2018-Q2,0,0,0
 黄鑫,2018-Q1,0,0,0
-mrTsjolder,2021-Q4,0,0,0
-mrTsjolder,2021-Q3,0,0,0
 mrTsjolder,2021-Q2,0,0,0
 mrTsjolder,2021-Q1,0,0,0
 mrTsjolder,2020-Q4,0,0,0
@@ -24255,8 +21223,6 @@ mrTsjolder,2018-Q4,13,153,70
 mrTsjolder,2018-Q3,0,0,0
 mrTsjolder,2018-Q2,3,42,14
 mrTsjolder,2018-Q1,0,0,0
-Hanton Yang,2021-Q4,0,0,0
-Hanton Yang,2021-Q3,0,0,0
 Hanton Yang,2021-Q2,0,0,0
 Hanton Yang,2021-Q1,0,0,0
 Hanton Yang,2020-Q4,0,0,0
@@ -24271,8 +21237,6 @@ Hanton Yang,2018-Q4,0,0,0
 Hanton Yang,2018-Q3,0,0,0
 Hanton Yang,2018-Q2,0,0,0
 Hanton Yang,2018-Q1,0,0,0
-luxupu,2021-Q4,0,0,0
-luxupu,2021-Q3,0,0,0
 luxupu,2021-Q2,0,0,0
 luxupu,2021-Q1,0,0,0
 luxupu,2020-Q4,0,0,0
@@ -24287,8 +21251,6 @@ luxupu,2018-Q4,0,0,0
 luxupu,2018-Q3,0,0,0
 luxupu,2018-Q2,0,0,0
 luxupu,2018-Q1,0,0,0
-Christian Hansen,2021-Q4,0,0,0
-Christian Hansen,2021-Q3,0,0,0
 Christian Hansen,2021-Q2,0,0,0
 Christian Hansen,2021-Q1,0,0,0
 Christian Hansen,2020-Q4,0,0,0
@@ -24303,8 +21265,6 @@ Christian Hansen,2018-Q4,0,0,0
 Christian Hansen,2018-Q3,0,0,0
 Christian Hansen,2018-Q2,0,0,0
 Christian Hansen,2018-Q1,0,0,0
-Vijay Ravichandran,2021-Q4,0,0,0
-Vijay Ravichandran,2021-Q3,0,0,0
 Vijay Ravichandran,2021-Q2,0,0,0
 Vijay Ravichandran,2021-Q1,0,0,0
 Vijay Ravichandran,2020-Q4,0,0,0
@@ -24319,8 +21279,6 @@ Vijay Ravichandran,2018-Q4,0,0,0
 Vijay Ravichandran,2018-Q3,0,0,0
 Vijay Ravichandran,2018-Q2,0,0,0
 Vijay Ravichandran,2018-Q1,0,0,0
-Brad Huang,2021-Q4,0,0,0
-Brad Huang,2021-Q3,0,0,0
 Brad Huang,2021-Q2,0,0,0
 Brad Huang,2021-Q1,0,0,0
 Brad Huang,2020-Q4,0,0,0
@@ -24335,8 +21293,6 @@ Brad Huang,2018-Q4,0,0,0
 Brad Huang,2018-Q3,0,0,0
 Brad Huang,2018-Q2,0,0,0
 Brad Huang,2018-Q1,0,0,0
-Nick,2021-Q4,0,0,0
-Nick,2021-Q3,0,0,0
 Nick,2021-Q2,0,0,0
 Nick,2021-Q1,0,0,0
 Nick,2020-Q4,0,0,0
@@ -24351,8 +21307,6 @@ Nick,2018-Q4,0,0,0
 Nick,2018-Q3,0,0,0
 Nick,2018-Q2,0,0,0
 Nick,2018-Q1,0,0,0
-KDR,2021-Q4,0,0,0
-KDR,2021-Q3,0,0,0
 KDR,2021-Q2,0,0,0
 KDR,2021-Q1,0,0,0
 KDR,2020-Q4,0,0,0
@@ -24367,8 +21321,6 @@ KDR,2018-Q4,0,0,0
 KDR,2018-Q3,0,0,0
 KDR,2018-Q2,0,0,0
 KDR,2018-Q1,0,0,0
-Sebastien Iooss,2021-Q4,0,0,0
-Sebastien Iooss,2021-Q3,0,0,0
 Sebastien Iooss,2021-Q2,0,0,0
 Sebastien Iooss,2021-Q1,0,0,0
 Sebastien Iooss,2020-Q4,0,0,0
@@ -24383,8 +21335,6 @@ Sebastien Iooss,2018-Q4,0,0,0
 Sebastien Iooss,2018-Q3,0,0,0
 Sebastien Iooss,2018-Q2,0,0,0
 Sebastien Iooss,2018-Q1,0,0,0
-Alex,2021-Q4,0,0,0
-Alex,2021-Q3,0,0,0
 Alex,2021-Q2,0,0,0
 Alex,2021-Q1,0,0,0
 Alex,2020-Q4,0,0,0
@@ -24399,8 +21349,6 @@ Alex,2018-Q4,0,0,0
 Alex,2018-Q3,0,0,0
 Alex,2018-Q2,0,0,0
 Alex,2018-Q1,0,0,0
-Edward Forgacs,2021-Q4,0,0,0
-Edward Forgacs,2021-Q3,0,0,0
 Edward Forgacs,2021-Q2,0,0,0
 Edward Forgacs,2021-Q1,0,0,0
 Edward Forgacs,2020-Q4,0,0,0
@@ -24415,8 +21363,6 @@ Edward Forgacs,2018-Q4,0,0,0
 Edward Forgacs,2018-Q3,0,0,0
 Edward Forgacs,2018-Q2,0,0,0
 Edward Forgacs,2018-Q1,0,0,0
-serv-inc,2021-Q4,0,0,0
-serv-inc,2021-Q3,0,0,0
 serv-inc,2021-Q2,0,0,0
 serv-inc,2021-Q1,0,0,0
 serv-inc,2020-Q4,0,0,0
@@ -24431,8 +21377,6 @@ serv-inc,2018-Q4,0,0,0
 serv-inc,2018-Q3,0,0,0
 serv-inc,2018-Q2,0,0,0
 serv-inc,2018-Q1,0,0,0
-Jason Zavaglia,2021-Q4,0,0,0
-Jason Zavaglia,2021-Q3,0,0,0
 Jason Zavaglia,2021-Q2,0,0,0
 Jason Zavaglia,2021-Q1,0,0,0
 Jason Zavaglia,2020-Q4,0,0,0
@@ -24447,8 +21391,6 @@ Jason Zavaglia,2018-Q4,0,0,0
 Jason Zavaglia,2018-Q3,0,0,0
 Jason Zavaglia,2018-Q2,0,0,0
 Jason Zavaglia,2018-Q1,0,0,0
-Albert Z. Guo,2021-Q4,0,0,0
-Albert Z. Guo,2021-Q3,0,0,0
 Albert Z. Guo,2021-Q2,0,0,0
 Albert Z. Guo,2021-Q1,0,0,0
 Albert Z. Guo,2020-Q4,0,0,0
@@ -24463,8 +21405,6 @@ Albert Z. Guo,2018-Q4,0,0,0
 Albert Z. Guo,2018-Q3,0,0,0
 Albert Z. Guo,2018-Q2,0,0,0
 Albert Z. Guo,2018-Q1,0,0,0
-Aman Patel,2021-Q4,0,0,0
-Aman Patel,2021-Q3,0,0,0
 Aman Patel,2021-Q2,0,0,0
 Aman Patel,2021-Q1,0,0,0
 Aman Patel,2020-Q4,0,0,0
@@ -24479,8 +21419,6 @@ Aman Patel,2018-Q4,0,0,0
 Aman Patel,2018-Q3,0,0,0
 Aman Patel,2018-Q2,0,0,0
 Aman Patel,2018-Q1,0,0,0
-Aurélien Geron,2021-Q4,0,0,0
-Aurélien Geron,2021-Q3,0,0,0
 Aurélien Geron,2021-Q2,0,0,0
 Aurélien Geron,2021-Q1,0,0,0
 Aurélien Geron,2020-Q4,0,0,0
@@ -24495,8 +21433,6 @@ Aurélien Geron,2018-Q4,3,2,0
 Aurélien Geron,2018-Q3,0,0,0
 Aurélien Geron,2018-Q2,0,0,0
 Aurélien Geron,2018-Q1,0,0,0
-Albin Joy,2021-Q4,0,0,0
-Albin Joy,2021-Q3,0,0,0
 Albin Joy,2021-Q2,0,0,0
 Albin Joy,2021-Q1,0,0,0
 Albin Joy,2020-Q4,0,0,0
@@ -24511,8 +21447,6 @@ Albin Joy,2018-Q4,0,0,0
 Albin Joy,2018-Q3,0,0,0
 Albin Joy,2018-Q2,0,0,0
 Albin Joy,2018-Q1,0,0,0
-Haakan Younes,2021-Q4,0,0,0
-Haakan Younes,2021-Q3,0,0,0
 Haakan Younes,2021-Q2,0,0,0
 Haakan Younes,2021-Q1,0,0,0
 Haakan Younes,2020-Q4,0,0,0
@@ -24527,8 +21461,6 @@ Haakan Younes,2018-Q4,0,0,0
 Haakan Younes,2018-Q3,0,0,0
 Haakan Younes,2018-Q2,0,0,0
 Haakan Younes,2018-Q1,0,0,0
-Kevin Mader,2021-Q4,0,0,0
-Kevin Mader,2021-Q3,0,0,0
 Kevin Mader,2021-Q2,0,0,0
 Kevin Mader,2021-Q1,0,0,0
 Kevin Mader,2020-Q4,0,0,0
@@ -24543,8 +21475,6 @@ Kevin Mader,2018-Q4,0,0,0
 Kevin Mader,2018-Q3,0,0,0
 Kevin Mader,2018-Q2,0,0,0
 Kevin Mader,2018-Q1,0,0,0
-DavidNorman,2021-Q4,0,0,0
-DavidNorman,2021-Q3,0,0,0
 DavidNorman,2021-Q2,0,0,0
 DavidNorman,2021-Q1,0,0,0
 DavidNorman,2020-Q4,0,0,0
@@ -24559,8 +21489,6 @@ DavidNorman,2018-Q4,0,0,0
 DavidNorman,2018-Q3,0,0,0
 DavidNorman,2018-Q2,3,19,17
 DavidNorman,2018-Q1,3,38,13
-gurpreet singh,2021-Q4,0,0,0
-gurpreet singh,2021-Q3,0,0,0
 gurpreet singh,2021-Q2,0,0,0
 gurpreet singh,2021-Q1,0,0,0
 gurpreet singh,2020-Q4,0,0,0
@@ -24575,8 +21503,6 @@ gurpreet singh,2018-Q4,0,0,0
 gurpreet singh,2018-Q3,0,0,0
 gurpreet singh,2018-Q2,0,0,0
 gurpreet singh,2018-Q1,0,0,0
-Dimitrios Vytiniotis,2021-Q4,0,0,0
-Dimitrios Vytiniotis,2021-Q3,0,0,0
 Dimitrios Vytiniotis,2021-Q2,0,0,0
 Dimitrios Vytiniotis,2021-Q1,0,0,0
 Dimitrios Vytiniotis,2020-Q4,0,0,0
@@ -24591,8 +21517,6 @@ Dimitrios Vytiniotis,2018-Q4,0,0,0
 Dimitrios Vytiniotis,2018-Q3,0,0,0
 Dimitrios Vytiniotis,2018-Q2,0,0,0
 Dimitrios Vytiniotis,2018-Q1,0,0,0
-nlewycky,2021-Q4,0,0,0
-nlewycky,2021-Q3,0,0,0
 nlewycky,2021-Q2,0,0,0
 nlewycky,2021-Q1,0,0,0
 nlewycky,2020-Q4,0,0,0
@@ -24607,8 +21531,6 @@ nlewycky,2018-Q4,0,0,0
 nlewycky,2018-Q3,0,0,0
 nlewycky,2018-Q2,0,0,0
 nlewycky,2018-Q1,0,0,0
-Ayush Agrawal,2021-Q4,0,0,0
-Ayush Agrawal,2021-Q3,0,0,0
 Ayush Agrawal,2021-Q2,0,0,0
 Ayush Agrawal,2021-Q1,0,0,0
 Ayush Agrawal,2020-Q4,0,0,0
@@ -24623,8 +21545,6 @@ Ayush Agrawal,2018-Q4,0,0,0
 Ayush Agrawal,2018-Q3,0,0,0
 Ayush Agrawal,2018-Q2,0,0,0
 Ayush Agrawal,2018-Q1,0,0,0
-chenchc,2021-Q4,0,0,0
-chenchc,2021-Q3,0,0,0
 chenchc,2021-Q2,0,0,0
 chenchc,2021-Q1,0,0,0
 chenchc,2020-Q4,0,0,0
@@ -24639,8 +21559,6 @@ chenchc,2018-Q4,0,0,0
 chenchc,2018-Q3,0,0,0
 chenchc,2018-Q2,0,0,0
 chenchc,2018-Q1,0,0,0
-Nick Lewycky,2021-Q4,0,0,0
-Nick Lewycky,2021-Q3,0,0,0
 Nick Lewycky,2021-Q2,0,0,0
 Nick Lewycky,2021-Q1,0,0,0
 Nick Lewycky,2020-Q4,0,0,0
@@ -24655,8 +21573,6 @@ Nick Lewycky,2018-Q4,0,0,0
 Nick Lewycky,2018-Q3,0,0,0
 Nick Lewycky,2018-Q2,0,0,0
 Nick Lewycky,2018-Q1,0,0,0
-Xin Gao,2021-Q4,0,0,0
-Xin Gao,2021-Q3,0,0,0
 Xin Gao,2021-Q2,0,0,0
 Xin Gao,2021-Q1,0,0,0
 Xin Gao,2020-Q4,0,0,0
@@ -24671,8 +21587,6 @@ Xin Gao,2018-Q4,0,0,0
 Xin Gao,2018-Q3,0,0,0
 Xin Gao,2018-Q2,0,0,0
 Xin Gao,2018-Q1,0,0,0
-Xin,2021-Q4,0,0,0
-Xin,2021-Q3,0,0,0
 Xin,2021-Q2,0,0,0
 Xin,2021-Q1,0,0,0
 Xin,2020-Q4,0,0,0
@@ -24687,8 +21601,6 @@ Xin,2018-Q4,0,0,0
 Xin,2018-Q3,0,0,0
 Xin,2018-Q2,0,0,0
 Xin,2018-Q1,0,0,0
-shashvat,2021-Q4,0,0,0
-shashvat,2021-Q3,0,0,0
 shashvat,2021-Q2,0,0,0
 shashvat,2021-Q1,0,0,0
 shashvat,2020-Q4,0,0,0
@@ -24703,8 +21615,6 @@ shashvat,2018-Q4,0,0,0
 shashvat,2018-Q3,0,0,0
 shashvat,2018-Q2,0,0,0
 shashvat,2018-Q1,0,0,0
-Pariksheet Pinjari,2021-Q4,0,0,0
-Pariksheet Pinjari,2021-Q3,0,0,0
 Pariksheet Pinjari,2021-Q2,0,0,0
 Pariksheet Pinjari,2021-Q1,0,0,0
 Pariksheet Pinjari,2020-Q4,0,0,0
@@ -24719,8 +21629,6 @@ Pariksheet Pinjari,2018-Q4,0,0,0
 Pariksheet Pinjari,2018-Q3,0,0,0
 Pariksheet Pinjari,2018-Q2,0,0,0
 Pariksheet Pinjari,2018-Q1,0,0,0
-Irene Dea,2021-Q4,0,0,0
-Irene Dea,2021-Q3,0,0,0
 Irene Dea,2021-Q2,0,0,0
 Irene Dea,2021-Q1,0,0,0
 Irene Dea,2020-Q4,0,0,0
@@ -24735,8 +21643,6 @@ Irene Dea,2018-Q4,0,0,0
 Irene Dea,2018-Q3,0,0,0
 Irene Dea,2018-Q2,0,0,0
 Irene Dea,2018-Q1,0,0,0
-Letian Kang,2021-Q4,0,0,0
-Letian Kang,2021-Q3,0,0,0
 Letian Kang,2021-Q2,0,0,0
 Letian Kang,2021-Q1,0,0,0
 Letian Kang,2020-Q4,0,0,0
@@ -24751,8 +21657,6 @@ Letian Kang,2018-Q4,0,0,0
 Letian Kang,2018-Q3,0,0,0
 Letian Kang,2018-Q2,0,0,0
 Letian Kang,2018-Q1,0,0,0
-monklof,2021-Q4,0,0,0
-monklof,2021-Q3,0,0,0
 monklof,2021-Q2,0,0,0
 monklof,2021-Q1,0,0,0
 monklof,2020-Q4,0,0,0
@@ -24767,8 +21671,6 @@ monklof,2018-Q4,0,0,0
 monklof,2018-Q3,0,0,0
 monklof,2018-Q2,0,0,0
 monklof,2018-Q1,0,0,0
-Donovan Ong,2021-Q4,0,0,0
-Donovan Ong,2021-Q3,0,0,0
 Donovan Ong,2021-Q2,0,0,0
 Donovan Ong,2021-Q1,0,0,0
 Donovan Ong,2020-Q4,0,0,0
@@ -24783,8 +21685,6 @@ Donovan Ong,2018-Q4,0,0,0
 Donovan Ong,2018-Q3,0,0,0
 Donovan Ong,2018-Q2,0,0,0
 Donovan Ong,2018-Q1,0,0,0
-Noah Fiedel,2021-Q4,0,0,0
-Noah Fiedel,2021-Q3,0,0,0
 Noah Fiedel,2021-Q2,0,0,0
 Noah Fiedel,2021-Q1,0,0,0
 Noah Fiedel,2020-Q4,0,0,0
@@ -24799,8 +21699,6 @@ Noah Fiedel,2018-Q4,0,0,0
 Noah Fiedel,2018-Q3,0,0,0
 Noah Fiedel,2018-Q2,0,0,0
 Noah Fiedel,2018-Q1,1,25,0
-Mandar Deshpande,2021-Q4,0,0,0
-Mandar Deshpande,2021-Q3,0,0,0
 Mandar Deshpande,2021-Q2,0,0,0
 Mandar Deshpande,2021-Q1,0,0,0
 Mandar Deshpande,2020-Q4,0,0,0
@@ -24815,8 +21713,6 @@ Mandar Deshpande,2018-Q4,0,0,0
 Mandar Deshpande,2018-Q3,0,0,0
 Mandar Deshpande,2018-Q2,0,0,0
 Mandar Deshpande,2018-Q1,0,0,0
-chie8842,2021-Q4,0,0,0
-chie8842,2021-Q3,0,0,0
 chie8842,2021-Q2,0,0,0
 chie8842,2021-Q1,0,0,0
 chie8842,2020-Q4,0,0,0
@@ -24831,8 +21727,6 @@ chie8842,2018-Q4,0,0,0
 chie8842,2018-Q3,0,0,0
 chie8842,2018-Q2,0,0,0
 chie8842,2018-Q1,0,0,0
-PeterLee,2021-Q4,0,0,0
-PeterLee,2021-Q3,0,0,0
 PeterLee,2021-Q2,0,0,0
 PeterLee,2021-Q1,0,0,0
 PeterLee,2020-Q4,0,0,0
@@ -24847,8 +21741,6 @@ PeterLee,2018-Q4,0,0,0
 PeterLee,2018-Q3,0,0,0
 PeterLee,2018-Q2,1,0,0
 PeterLee,2018-Q1,0,0,0
-Tim Zaman,2021-Q4,0,0,0
-Tim Zaman,2021-Q3,0,0,0
 Tim Zaman,2021-Q2,0,0,0
 Tim Zaman,2021-Q1,0,0,0
 Tim Zaman,2020-Q4,0,0,0
@@ -24863,8 +21755,6 @@ Tim Zaman,2018-Q4,0,0,0
 Tim Zaman,2018-Q3,0,0,0
 Tim Zaman,2018-Q2,2,14,0
 Tim Zaman,2018-Q1,0,0,0
-Shohini Ghosh,2021-Q4,0,0,0
-Shohini Ghosh,2021-Q3,0,0,0
 Shohini Ghosh,2021-Q2,0,0,0
 Shohini Ghosh,2021-Q1,0,0,0
 Shohini Ghosh,2020-Q4,0,0,0
@@ -24879,8 +21769,6 @@ Shohini Ghosh,2018-Q4,0,0,0
 Shohini Ghosh,2018-Q3,0,0,0
 Shohini Ghosh,2018-Q2,0,0,0
 Shohini Ghosh,2018-Q1,0,0,0
-ted chang,2021-Q4,0,0,0
-ted chang,2021-Q3,0,0,0
 ted chang,2021-Q2,0,0,0
 ted chang,2021-Q1,0,0,0
 ted chang,2020-Q4,0,0,0
@@ -24895,8 +21783,6 @@ ted chang,2018-Q4,0,0,0
 ted chang,2018-Q3,0,0,0
 ted chang,2018-Q2,5,11,4
 ted chang,2018-Q1,6,31,11
-omeir1,2021-Q4,0,0,0
-omeir1,2021-Q3,0,0,0
 omeir1,2021-Q2,0,0,0
 omeir1,2021-Q1,0,0,0
 omeir1,2020-Q4,0,0,0
@@ -24911,8 +21797,6 @@ omeir1,2018-Q4,0,0,0
 omeir1,2018-Q3,0,0,0
 omeir1,2018-Q2,0,0,0
 omeir1,2018-Q1,0,0,0
-mandroid6,2021-Q4,0,0,0
-mandroid6,2021-Q3,0,0,0
 mandroid6,2021-Q2,0,0,0
 mandroid6,2021-Q1,0,0,0
 mandroid6,2020-Q4,0,0,0
@@ -24927,8 +21811,6 @@ mandroid6,2018-Q4,0,0,0
 mandroid6,2018-Q3,0,0,0
 mandroid6,2018-Q2,0,0,0
 mandroid6,2018-Q1,0,0,0
-blairhan,2021-Q4,0,0,0
-blairhan,2021-Q3,0,0,0
 blairhan,2021-Q2,0,0,0
 blairhan,2021-Q1,0,0,0
 blairhan,2020-Q4,0,0,0
@@ -24943,8 +21825,6 @@ blairhan,2018-Q4,0,0,0
 blairhan,2018-Q3,0,0,0
 blairhan,2018-Q2,0,0,0
 blairhan,2018-Q1,0,0,0
-Petros Mol,2021-Q4,0,0,0
-Petros Mol,2021-Q3,0,0,0
 Petros Mol,2021-Q2,0,0,0
 Petros Mol,2021-Q1,0,0,0
 Petros Mol,2020-Q4,0,0,0
@@ -24959,8 +21839,6 @@ Petros Mol,2018-Q4,0,0,0
 Petros Mol,2018-Q3,0,0,0
 Petros Mol,2018-Q2,4,22,21
 Petros Mol,2018-Q1,1,2,0
-nuka-137,2021-Q4,0,0,0
-nuka-137,2021-Q3,0,0,0
 nuka-137,2021-Q2,0,0,0
 nuka-137,2021-Q1,0,0,0
 nuka-137,2020-Q4,0,0,0
@@ -24975,8 +21853,6 @@ nuka-137,2018-Q4,0,0,0
 nuka-137,2018-Q3,0,0,0
 nuka-137,2018-Q2,0,0,0
 nuka-137,2018-Q1,0,0,0
-abenmao,2021-Q4,0,0,0
-abenmao,2021-Q3,0,0,0
 abenmao,2021-Q2,0,0,0
 abenmao,2021-Q1,0,0,0
 abenmao,2020-Q4,0,0,0
@@ -24991,8 +21867,6 @@ abenmao,2018-Q4,0,0,0
 abenmao,2018-Q3,0,0,0
 abenmao,2018-Q2,0,0,0
 abenmao,2018-Q1,0,0,0
-Viktor Gal,2021-Q4,0,0,0
-Viktor Gal,2021-Q3,0,0,0
 Viktor Gal,2021-Q2,0,0,0
 Viktor Gal,2021-Q1,0,0,0
 Viktor Gal,2020-Q4,0,0,0
@@ -25007,8 +21881,6 @@ Viktor Gal,2018-Q4,0,0,0
 Viktor Gal,2018-Q3,0,0,0
 Viktor Gal,2018-Q2,0,0,0
 Viktor Gal,2018-Q1,0,0,0
-Shashi Shekhar,2021-Q4,0,0,0
-Shashi Shekhar,2021-Q3,0,0,0
 Shashi Shekhar,2021-Q2,0,0,0
 Shashi Shekhar,2021-Q1,0,0,0
 Shashi Shekhar,2020-Q4,0,0,0
@@ -25023,8 +21895,6 @@ Shashi Shekhar,2018-Q4,48,1669,145
 Shashi Shekhar,2018-Q3,108,6616,670
 Shashi Shekhar,2018-Q2,195,5367,1577
 Shashi Shekhar,2018-Q1,4,19,6
-jer,2021-Q4,0,0,0
-jer,2021-Q3,0,0,0
 jer,2021-Q2,0,0,0
 jer,2021-Q1,0,0,0
 jer,2020-Q4,0,0,0
@@ -25039,8 +21909,6 @@ jer,2018-Q4,0,0,0
 jer,2018-Q3,0,0,0
 jer,2018-Q2,0,0,0
 jer,2018-Q1,0,0,0
-Matt Silverlock,2021-Q4,0,0,0
-Matt Silverlock,2021-Q3,0,0,0
 Matt Silverlock,2021-Q2,0,0,0
 Matt Silverlock,2021-Q1,0,0,0
 Matt Silverlock,2020-Q4,0,0,0
@@ -25055,8 +21923,6 @@ Matt Silverlock,2018-Q4,0,0,0
 Matt Silverlock,2018-Q3,0,0,0
 Matt Silverlock,2018-Q2,0,0,0
 Matt Silverlock,2018-Q1,0,0,0
-K Yasaswi Sri Chandra Gandhi,2021-Q4,0,0,0
-K Yasaswi Sri Chandra Gandhi,2021-Q3,0,0,0
 K Yasaswi Sri Chandra Gandhi,2021-Q2,0,0,0
 K Yasaswi Sri Chandra Gandhi,2021-Q1,0,0,0
 K Yasaswi Sri Chandra Gandhi,2020-Q4,0,0,0
@@ -25071,8 +21937,6 @@ K Yasaswi Sri Chandra Gandhi,2018-Q4,0,0,0
 K Yasaswi Sri Chandra Gandhi,2018-Q3,0,0,0
 K Yasaswi Sri Chandra Gandhi,2018-Q2,0,0,0
 K Yasaswi Sri Chandra Gandhi,2018-Q1,0,0,0
-sremedios,2021-Q4,0,0,0
-sremedios,2021-Q3,0,0,0
 sremedios,2021-Q2,0,0,0
 sremedios,2021-Q1,0,0,0
 sremedios,2020-Q4,0,0,0
@@ -25087,8 +21951,6 @@ sremedios,2018-Q4,0,0,0
 sremedios,2018-Q3,0,0,0
 sremedios,2018-Q2,0,0,0
 sremedios,2018-Q1,0,0,0
-Sumesh Udayakumaran,2021-Q4,0,0,0
-Sumesh Udayakumaran,2021-Q3,0,0,0
 Sumesh Udayakumaran,2021-Q2,0,0,0
 Sumesh Udayakumaran,2021-Q1,0,0,0
 Sumesh Udayakumaran,2020-Q4,0,0,0
@@ -25103,8 +21965,6 @@ Sumesh Udayakumaran,2018-Q4,0,0,0
 Sumesh Udayakumaran,2018-Q3,0,0,0
 Sumesh Udayakumaran,2018-Q2,0,0,0
 Sumesh Udayakumaran,2018-Q1,0,0,0
-P Sudeepam,2021-Q4,0,0,0
-P Sudeepam,2021-Q3,0,0,0
 P Sudeepam,2021-Q2,0,0,0
 P Sudeepam,2021-Q1,0,0,0
 P Sudeepam,2020-Q4,0,0,0
@@ -25119,8 +21979,6 @@ P Sudeepam,2018-Q4,0,0,0
 P Sudeepam,2018-Q3,0,0,0
 P Sudeepam,2018-Q2,0,0,0
 P Sudeepam,2018-Q1,0,0,0
-arp95,2021-Q4,0,0,0
-arp95,2021-Q3,0,0,0
 arp95,2021-Q2,0,0,0
 arp95,2021-Q1,0,0,0
 arp95,2020-Q4,0,0,0
@@ -25135,8 +21993,6 @@ arp95,2018-Q4,0,0,0
 arp95,2018-Q3,0,0,0
 arp95,2018-Q2,0,0,0
 arp95,2018-Q1,0,0,0
-seanshpark,2021-Q4,0,0,0
-seanshpark,2021-Q3,0,0,0
 seanshpark,2021-Q2,0,0,0
 seanshpark,2021-Q1,0,0,0
 seanshpark,2020-Q4,0,0,0
@@ -25151,8 +22007,6 @@ seanshpark,2018-Q4,0,0,0
 seanshpark,2018-Q3,0,0,0
 seanshpark,2018-Q2,0,0,0
 seanshpark,2018-Q1,0,0,0
-lvli,2021-Q4,0,0,0
-lvli,2021-Q3,0,0,0
 lvli,2021-Q2,0,0,0
 lvli,2021-Q1,0,0,0
 lvli,2020-Q4,0,0,0
@@ -25167,8 +22021,6 @@ lvli,2018-Q4,0,0,0
 lvli,2018-Q3,0,0,0
 lvli,2018-Q2,0,0,0
 lvli,2018-Q1,0,0,0
-Daniel Salvadori,2021-Q4,0,0,0
-Daniel Salvadori,2021-Q3,0,0,0
 Daniel Salvadori,2021-Q2,0,0,0
 Daniel Salvadori,2021-Q1,0,0,0
 Daniel Salvadori,2020-Q4,0,0,0
@@ -25183,8 +22035,6 @@ Daniel Salvadori,2018-Q4,0,0,0
 Daniel Salvadori,2018-Q3,0,0,0
 Daniel Salvadori,2018-Q2,0,0,0
 Daniel Salvadori,2018-Q1,0,0,0
-XinPing Wang,2021-Q4,0,0,0
-XinPing Wang,2021-Q3,0,0,0
 XinPing Wang,2021-Q2,0,0,0
 XinPing Wang,2021-Q1,0,0,0
 XinPing Wang,2020-Q4,0,0,0
@@ -25199,8 +22049,6 @@ XinPing Wang,2018-Q4,0,0,0
 XinPing Wang,2018-Q3,0,0,0
 XinPing Wang,2018-Q2,0,0,0
 XinPing Wang,2018-Q1,0,0,0
-Yeqing Li,2021-Q4,0,0,0
-Yeqing Li,2021-Q3,0,0,0
 Yeqing Li,2021-Q2,0,0,0
 Yeqing Li,2021-Q1,0,0,0
 Yeqing Li,2020-Q4,0,0,0
@@ -25215,8 +22063,6 @@ Yeqing Li,2018-Q4,0,0,0
 Yeqing Li,2018-Q3,0,0,0
 Yeqing Li,2018-Q2,0,0,0
 Yeqing Li,2018-Q1,0,0,0
-Aurelien Geron,2021-Q4,0,0,0
-Aurelien Geron,2021-Q3,0,0,0
 Aurelien Geron,2021-Q2,0,0,0
 Aurelien Geron,2021-Q1,0,0,0
 Aurelien Geron,2020-Q4,0,0,0
@@ -25231,8 +22077,6 @@ Aurelien Geron,2018-Q4,0,0,0
 Aurelien Geron,2018-Q3,7,30,25
 Aurelien Geron,2018-Q2,1,9,10
 Aurelien Geron,2018-Q1,0,0,0
-Neeraj Pradhan,2021-Q4,0,0,0
-Neeraj Pradhan,2021-Q3,0,0,0
 Neeraj Pradhan,2021-Q2,0,0,0
 Neeraj Pradhan,2021-Q1,0,0,0
 Neeraj Pradhan,2020-Q4,0,0,0
@@ -25247,8 +22091,6 @@ Neeraj Pradhan,2018-Q4,0,0,0
 Neeraj Pradhan,2018-Q3,0,0,0
 Neeraj Pradhan,2018-Q2,0,0,0
 Neeraj Pradhan,2018-Q1,0,0,0
-RJ Ryan,2021-Q4,0,0,0
-RJ Ryan,2021-Q3,0,0,0
 RJ Ryan,2021-Q2,0,0,0
 RJ Ryan,2021-Q1,0,0,0
 RJ Ryan,2020-Q4,0,0,0
@@ -25263,8 +22105,6 @@ RJ Ryan,2018-Q4,93,1107,748
 RJ Ryan,2018-Q3,3,22,23
 RJ Ryan,2018-Q2,51,728,220
 RJ Ryan,2018-Q1,11,65,11
-sdamani,2021-Q4,0,0,0
-sdamani,2021-Q3,0,0,0
 sdamani,2021-Q2,0,0,0
 sdamani,2021-Q1,0,0,0
 sdamani,2020-Q4,0,0,0
@@ -25279,8 +22119,6 @@ sdamani,2018-Q4,0,0,0
 sdamani,2018-Q3,0,0,0
 sdamani,2018-Q2,0,0,0
 sdamani,2018-Q1,0,0,0
-Mark Ryan,2021-Q4,0,0,0
-Mark Ryan,2021-Q3,0,0,0
 Mark Ryan,2021-Q2,0,0,0
 Mark Ryan,2021-Q1,0,0,0
 Mark Ryan,2020-Q4,0,0,0
@@ -25295,8 +22133,6 @@ Mark Ryan,2018-Q4,2,53,5
 Mark Ryan,2018-Q3,2,14,2
 Mark Ryan,2018-Q2,9,38,36
 Mark Ryan,2018-Q1,0,0,0
-Amit,2021-Q4,0,0,0
-Amit,2021-Q3,0,0,0
 Amit,2021-Q2,0,0,0
 Amit,2021-Q1,0,0,0
 Amit,2020-Q4,0,0,0
@@ -25311,8 +22147,6 @@ Amit,2018-Q4,0,0,0
 Amit,2018-Q3,0,0,0
 Amit,2018-Q2,0,0,0
 Amit,2018-Q1,0,0,0
-rthadur,2021-Q4,0,0,0
-rthadur,2021-Q3,0,0,0
 rthadur,2021-Q2,0,0,0
 rthadur,2021-Q1,0,0,0
 rthadur,2020-Q4,0,0,0
@@ -25327,8 +22161,6 @@ rthadur,2018-Q4,0,0,0
 rthadur,2018-Q3,0,0,0
 rthadur,2018-Q2,0,0,0
 rthadur,2018-Q1,0,0,0
-Gyoung-yoon Ryoo,2021-Q4,0,0,0
-Gyoung-yoon Ryoo,2021-Q3,0,0,0
 Gyoung-yoon Ryoo,2021-Q2,0,0,0
 Gyoung-yoon Ryoo,2021-Q1,0,0,0
 Gyoung-yoon Ryoo,2020-Q4,0,0,0
@@ -25343,8 +22175,6 @@ Gyoung-yoon Ryoo,2018-Q4,0,0,0
 Gyoung-yoon Ryoo,2018-Q3,0,0,0
 Gyoung-yoon Ryoo,2018-Q2,0,0,0
 Gyoung-yoon Ryoo,2018-Q1,0,0,0
-Alan Du,2021-Q4,0,0,0
-Alan Du,2021-Q3,0,0,0
 Alan Du,2021-Q2,0,0,0
 Alan Du,2021-Q1,0,0,0
 Alan Du,2020-Q4,0,0,0
@@ -25359,8 +22189,6 @@ Alan Du,2018-Q4,0,0,0
 Alan Du,2018-Q3,0,0,0
 Alan Du,2018-Q2,0,0,0
 Alan Du,2018-Q1,1,4,6
-jtressle,2021-Q4,0,0,0
-jtressle,2021-Q3,0,0,0
 jtressle,2021-Q2,0,0,0
 jtressle,2021-Q1,0,0,0
 jtressle,2020-Q4,0,0,0
@@ -25375,8 +22203,6 @@ jtressle,2018-Q4,0,0,0
 jtressle,2018-Q3,0,0,0
 jtressle,2018-Q2,0,0,0
 jtressle,2018-Q1,0,0,0
-a6802739,2021-Q4,0,0,0
-a6802739,2021-Q3,0,0,0
 a6802739,2021-Q2,0,0,0
 a6802739,2021-Q1,0,0,0
 a6802739,2020-Q4,0,0,0
@@ -25391,8 +22217,6 @@ a6802739,2018-Q4,0,0,0
 a6802739,2018-Q3,0,0,0
 a6802739,2018-Q2,0,0,0
 a6802739,2018-Q1,0,0,0
-Quan Wang,2021-Q4,0,0,0
-Quan Wang,2021-Q3,0,0,0
 Quan Wang,2021-Q2,0,0,0
 Quan Wang,2021-Q1,0,0,0
 Quan Wang,2020-Q4,0,0,0
@@ -25407,8 +22231,6 @@ Quan Wang,2018-Q4,0,0,0
 Quan Wang,2018-Q3,0,0,0
 Quan Wang,2018-Q2,0,0,0
 Quan Wang,2018-Q1,0,0,0
-Drew Szurko,2021-Q4,0,0,0
-Drew Szurko,2021-Q3,0,0,0
 Drew Szurko,2021-Q2,0,0,0
 Drew Szurko,2021-Q1,0,0,0
 Drew Szurko,2020-Q4,0,0,0
@@ -25423,8 +22245,6 @@ Drew Szurko,2018-Q4,0,0,0
 Drew Szurko,2018-Q3,0,0,0
 Drew Szurko,2018-Q2,0,0,0
 Drew Szurko,2018-Q1,0,0,0
-Margaret Maynard-Reid,2021-Q4,0,0,0
-Margaret Maynard-Reid,2021-Q3,0,0,0
 Margaret Maynard-Reid,2021-Q2,0,0,0
 Margaret Maynard-Reid,2021-Q1,0,0,0
 Margaret Maynard-Reid,2020-Q4,0,0,0
@@ -25439,8 +22259,6 @@ Margaret Maynard-Reid,2018-Q4,0,0,0
 Margaret Maynard-Reid,2018-Q3,0,0,0
 Margaret Maynard-Reid,2018-Q2,0,0,0
 Margaret Maynard-Reid,2018-Q1,0,0,0
-Brandon Carter,2021-Q4,0,0,0
-Brandon Carter,2021-Q3,0,0,0
 Brandon Carter,2021-Q2,0,0,0
 Brandon Carter,2021-Q1,0,0,0
 Brandon Carter,2020-Q4,0,0,0
@@ -25455,8 +22273,6 @@ Brandon Carter,2018-Q4,0,0,0
 Brandon Carter,2018-Q3,0,0,0
 Brandon Carter,2018-Q2,0,0,0
 Brandon Carter,2018-Q1,0,0,0
-Jacky,2021-Q4,0,0,0
-Jacky,2021-Q3,0,0,0
 Jacky,2021-Q2,0,0,0
 Jacky,2021-Q1,0,0,0
 Jacky,2020-Q4,0,0,0
@@ -25471,8 +22287,6 @@ Jacky,2018-Q4,0,0,0
 Jacky,2018-Q3,0,0,0
 Jacky,2018-Q2,13,49,32
 Jacky,2018-Q1,0,0,0
-karl@kubx.ca,2021-Q4,0,0,0
-karl@kubx.ca,2021-Q3,0,0,0
 karl@kubx.ca,2021-Q2,0,0,0
 karl@kubx.ca,2021-Q1,0,0,0
 karl@kubx.ca,2020-Q4,0,0,0
@@ -25487,8 +22301,6 @@ karl@kubx.ca,2018-Q4,7,293,15
 karl@kubx.ca,2018-Q3,68,1811,641
 karl@kubx.ca,2018-Q2,117,2323,1445
 karl@kubx.ca,2018-Q1,0,0,0
-Andreas Eberle,2021-Q4,0,0,0
-Andreas Eberle,2021-Q3,0,0,0
 Andreas Eberle,2021-Q2,0,0,0
 Andreas Eberle,2021-Q1,0,0,0
 Andreas Eberle,2020-Q4,0,0,0
@@ -25503,8 +22315,6 @@ Andreas Eberle,2018-Q4,0,0,0
 Andreas Eberle,2018-Q3,0,0,0
 Andreas Eberle,2018-Q2,0,0,0
 Andreas Eberle,2018-Q1,0,0,0
-Jiankang,2021-Q4,0,0,0
-Jiankang,2021-Q3,0,0,0
 Jiankang,2021-Q2,0,0,0
 Jiankang,2021-Q1,0,0,0
 Jiankang,2020-Q4,0,0,0
@@ -25519,8 +22329,6 @@ Jiankang,2018-Q4,0,0,0
 Jiankang,2018-Q3,0,0,0
 Jiankang,2018-Q2,0,0,0
 Jiankang,2018-Q1,0,0,0
-Pan Daoxin,2021-Q4,0,0,0
-Pan Daoxin,2021-Q3,0,0,0
 Pan Daoxin,2021-Q2,0,0,0
 Pan Daoxin,2021-Q1,0,0,0
 Pan Daoxin,2020-Q4,0,0,0
@@ -25535,8 +22343,6 @@ Pan Daoxin,2018-Q4,8,322,151
 Pan Daoxin,2018-Q3,21,669,234
 Pan Daoxin,2018-Q2,0,0,0
 Pan Daoxin,2018-Q1,0,0,0
-Lucas Hendren,2021-Q4,0,0,0
-Lucas Hendren,2021-Q3,0,0,0
 Lucas Hendren,2021-Q2,0,0,0
 Lucas Hendren,2021-Q1,0,0,0
 Lucas Hendren,2020-Q4,0,0,0
@@ -25551,8 +22357,6 @@ Lucas Hendren,2018-Q4,0,0,0
 Lucas Hendren,2018-Q3,0,0,0
 Lucas Hendren,2018-Q2,0,0,0
 Lucas Hendren,2018-Q1,0,0,0
-Huan LI (李卓桓),2021-Q4,0,0,0
-Huan LI (李卓桓),2021-Q3,0,0,0
 Huan LI (李卓桓),2021-Q2,0,0,0
 Huan LI (李卓桓),2021-Q1,0,0,0
 Huan LI (李卓桓),2020-Q4,0,0,0
@@ -25567,8 +22371,6 @@ Huan LI (李卓桓),2018-Q4,1,3,3
 Huan LI (李卓桓),2018-Q3,0,0,0
 Huan LI (李卓桓),2018-Q2,0,0,0
 Huan LI (李卓桓),2018-Q1,0,0,0
-Mike Arpaia,2021-Q4,0,0,0
-Mike Arpaia,2021-Q3,0,0,0
 Mike Arpaia,2021-Q2,0,0,0
 Mike Arpaia,2021-Q1,0,0,0
 Mike Arpaia,2020-Q4,0,0,0
@@ -25583,8 +22385,6 @@ Mike Arpaia,2018-Q4,0,0,0
 Mike Arpaia,2018-Q3,0,0,0
 Mike Arpaia,2018-Q2,0,0,0
 Mike Arpaia,2018-Q1,0,0,0
-Armen Poghosov,2021-Q4,0,0,0
-Armen Poghosov,2021-Q3,0,0,0
 Armen Poghosov,2021-Q2,0,0,0
 Armen Poghosov,2021-Q1,0,0,0
 Armen Poghosov,2020-Q4,0,0,0
@@ -25599,8 +22399,6 @@ Armen Poghosov,2018-Q4,0,0,0
 Armen Poghosov,2018-Q3,0,0,0
 Armen Poghosov,2018-Q2,0,0,0
 Armen Poghosov,2018-Q1,0,0,0
-Vladimir Moskva,2021-Q4,0,0,0
-Vladimir Moskva,2021-Q3,0,0,0
 Vladimir Moskva,2021-Q2,0,0,0
 Vladimir Moskva,2021-Q1,0,0,0
 Vladimir Moskva,2020-Q4,0,0,0
@@ -25615,8 +22413,6 @@ Vladimir Moskva,2018-Q4,0,0,0
 Vladimir Moskva,2018-Q3,0,0,0
 Vladimir Moskva,2018-Q2,0,0,0
 Vladimir Moskva,2018-Q1,0,0,0
-Melissa Grueter,2021-Q4,0,0,0
-Melissa Grueter,2021-Q3,0,0,0
 Melissa Grueter,2021-Q2,0,0,0
 Melissa Grueter,2021-Q1,0,0,0
 Melissa Grueter,2020-Q4,0,0,0
@@ -25631,8 +22427,6 @@ Melissa Grueter,2018-Q4,0,0,0
 Melissa Grueter,2018-Q3,0,0,0
 Melissa Grueter,2018-Q2,0,0,0
 Melissa Grueter,2018-Q1,0,0,0
-armenpoghosov,2021-Q4,0,0,0
-armenpoghosov,2021-Q3,0,0,0
 armenpoghosov,2021-Q2,0,0,0
 armenpoghosov,2021-Q1,0,0,0
 armenpoghosov,2020-Q4,0,0,0
@@ -25647,8 +22441,6 @@ armenpoghosov,2018-Q4,0,0,0
 armenpoghosov,2018-Q3,0,0,0
 armenpoghosov,2018-Q2,0,0,0
 armenpoghosov,2018-Q1,0,0,0
-Mustafa Ispir,2021-Q4,0,0,0
-Mustafa Ispir,2021-Q3,0,0,0
 Mustafa Ispir,2021-Q2,0,0,0
 Mustafa Ispir,2021-Q1,0,0,0
 Mustafa Ispir,2020-Q4,0,0,0
@@ -25663,8 +22455,6 @@ Mustafa Ispir,2018-Q4,6,25,61
 Mustafa Ispir,2018-Q3,14,217,11
 Mustafa Ispir,2018-Q2,37,1206,504
 Mustafa Ispir,2018-Q1,3,49,37
-ryan jiang,2021-Q4,0,0,0
-ryan jiang,2021-Q3,0,0,0
 ryan jiang,2021-Q2,0,0,0
 ryan jiang,2021-Q1,0,0,0
 ryan jiang,2020-Q4,0,0,0
@@ -25679,8 +22469,6 @@ ryan jiang,2018-Q4,0,0,0
 ryan jiang,2018-Q3,0,0,0
 ryan jiang,2018-Q2,0,0,0
 ryan jiang,2018-Q1,0,0,0
-Natalia Gimelshein,2021-Q4,0,0,0
-Natalia Gimelshein,2021-Q3,0,0,0
 Natalia Gimelshein,2021-Q2,0,0,0
 Natalia Gimelshein,2021-Q1,0,0,0
 Natalia Gimelshein,2020-Q4,0,0,0
@@ -25695,8 +22483,6 @@ Natalia Gimelshein,2018-Q4,0,0,0
 Natalia Gimelshein,2018-Q3,0,0,0
 Natalia Gimelshein,2018-Q2,0,0,0
 Natalia Gimelshein,2018-Q1,0,0,0
-zjjott,2021-Q4,0,0,0
-zjjott,2021-Q3,0,0,0
 zjjott,2021-Q2,0,0,0
 zjjott,2021-Q1,0,0,0
 zjjott,2020-Q4,0,0,0
@@ -25711,8 +22497,6 @@ zjjott,2018-Q4,0,0,0
 zjjott,2018-Q3,0,0,0
 zjjott,2018-Q2,0,0,0
 zjjott,2018-Q1,0,0,0
-csukuangfj,2021-Q4,0,0,0
-csukuangfj,2021-Q3,0,0,0
 csukuangfj,2021-Q2,0,0,0
 csukuangfj,2021-Q1,0,0,0
 csukuangfj,2020-Q4,0,0,0
@@ -25727,8 +22511,6 @@ csukuangfj,2018-Q4,0,0,0
 csukuangfj,2018-Q3,0,0,0
 csukuangfj,2018-Q2,0,0,0
 csukuangfj,2018-Q1,0,0,0
-Marco Gaido,2021-Q4,0,0,0
-Marco Gaido,2021-Q3,0,0,0
 Marco Gaido,2021-Q2,0,0,0
 Marco Gaido,2021-Q1,0,0,0
 Marco Gaido,2020-Q4,0,0,0
@@ -25743,8 +22525,6 @@ Marco Gaido,2018-Q4,0,0,0
 Marco Gaido,2018-Q3,0,0,0
 Marco Gaido,2018-Q2,0,0,0
 Marco Gaido,2018-Q1,0,0,0
-Rohit Gupta,2021-Q4,0,0,0
-Rohit Gupta,2021-Q3,0,0,0
 Rohit Gupta,2021-Q2,0,0,0
 Rohit Gupta,2021-Q1,0,0,0
 Rohit Gupta,2020-Q4,0,0,0
@@ -25759,8 +22539,6 @@ Rohit Gupta,2018-Q4,0,0,0
 Rohit Gupta,2018-Q3,0,0,0
 Rohit Gupta,2018-Q2,0,0,0
 Rohit Gupta,2018-Q1,0,0,0
-Seth Troisi,2021-Q4,0,0,0
-Seth Troisi,2021-Q3,0,0,0
 Seth Troisi,2021-Q2,0,0,0
 Seth Troisi,2021-Q1,0,0,0
 Seth Troisi,2020-Q4,0,0,0
@@ -25775,8 +22553,6 @@ Seth Troisi,2018-Q4,0,0,0
 Seth Troisi,2018-Q3,0,0,0
 Seth Troisi,2018-Q2,0,0,0
 Seth Troisi,2018-Q1,0,0,0
-Joe Q,2021-Q4,0,0,0
-Joe Q,2021-Q3,0,0,0
 Joe Q,2021-Q2,0,0,0
 Joe Q,2021-Q1,0,0,0
 Joe Q,2020-Q4,0,0,0
@@ -25791,8 +22567,6 @@ Joe Q,2018-Q4,0,0,0
 Joe Q,2018-Q3,0,0,0
 Joe Q,2018-Q2,0,0,0
 Joe Q,2018-Q1,0,0,0
-jwu,2021-Q4,0,0,0
-jwu,2021-Q3,0,0,0
 jwu,2021-Q2,0,0,0
 jwu,2021-Q1,0,0,0
 jwu,2020-Q4,0,0,0
@@ -25807,8 +22581,6 @@ jwu,2018-Q4,0,0,0
 jwu,2018-Q3,0,0,0
 jwu,2018-Q2,0,0,0
 jwu,2018-Q1,0,0,0
-hari,2021-Q4,0,0,0
-hari,2021-Q3,0,0,0
 hari,2021-Q2,0,0,0
 hari,2021-Q1,0,0,0
 hari,2020-Q4,0,0,0
@@ -25823,8 +22595,6 @@ hari,2018-Q4,13,1347,545
 hari,2018-Q3,0,0,0
 hari,2018-Q2,0,0,0
 hari,2018-Q1,0,0,0
-HARI SHANKAR,2021-Q4,0,0,0
-HARI SHANKAR,2021-Q3,0,0,0
 HARI SHANKAR,2021-Q2,0,0,0
 HARI SHANKAR,2021-Q1,0,0,0
 HARI SHANKAR,2020-Q4,0,0,0
@@ -25839,8 +22609,6 @@ HARI SHANKAR,2018-Q4,0,0,0
 HARI SHANKAR,2018-Q3,0,0,0
 HARI SHANKAR,2018-Q2,0,0,0
 HARI SHANKAR,2018-Q1,0,0,0
-1e100,2021-Q4,0,0,0
-1e100,2021-Q3,0,0,0
 1e100,2021-Q2,0,0,0
 1e100,2021-Q1,0,0,0
 1e100,2020-Q4,0,0,0
@@ -25855,8 +22623,6 @@ HARI SHANKAR,2018-Q1,0,0,0
 1e100,2018-Q3,0,0,0
 1e100,2018-Q2,0,0,0
 1e100,2018-Q1,0,0,0
-kaixih,2021-Q4,0,0,0
-kaixih,2021-Q3,0,0,0
 kaixih,2021-Q2,0,0,0
 kaixih,2021-Q1,0,0,0
 kaixih,2020-Q4,0,0,0
@@ -25871,8 +22637,6 @@ kaixih,2018-Q4,14,984,186
 kaixih,2018-Q3,0,0,0
 kaixih,2018-Q2,0,0,0
 kaixih,2018-Q1,0,0,0
-Jonathan Kyl,2021-Q4,0,0,0
-Jonathan Kyl,2021-Q3,0,0,0
 Jonathan Kyl,2021-Q2,0,0,0
 Jonathan Kyl,2021-Q1,0,0,0
 Jonathan Kyl,2020-Q4,0,0,0
@@ -25887,8 +22651,6 @@ Jonathan Kyl,2018-Q4,0,0,0
 Jonathan Kyl,2018-Q3,0,0,0
 Jonathan Kyl,2018-Q2,0,0,0
 Jonathan Kyl,2018-Q1,0,0,0
-Noah Eisen,2021-Q4,0,0,0
-Noah Eisen,2021-Q3,0,0,0
 Noah Eisen,2021-Q2,0,0,0
 Noah Eisen,2021-Q1,0,0,0
 Noah Eisen,2020-Q4,0,0,0
@@ -25903,8 +22665,6 @@ Noah Eisen,2018-Q4,4,19,10
 Noah Eisen,2018-Q3,11,455,55
 Noah Eisen,2018-Q2,23,153,873
 Noah Eisen,2018-Q1,11,315,225
-Yuan Lin,2021-Q4,0,0,0
-Yuan Lin,2021-Q3,0,0,0
 Yuan Lin,2021-Q2,0,0,0
 Yuan Lin,2021-Q1,0,0,0
 Yuan Lin,2020-Q4,0,0,0
@@ -25919,8 +22679,6 @@ Yuan Lin,2018-Q4,0,0,0
 Yuan Lin,2018-Q3,0,0,0
 Yuan Lin,2018-Q2,0,0,0
 Yuan Lin,2018-Q1,0,0,0
-HanGuo97,2021-Q4,0,0,0
-HanGuo97,2021-Q3,0,0,0
 HanGuo97,2021-Q2,0,0,0
 HanGuo97,2021-Q1,0,0,0
 HanGuo97,2020-Q4,0,0,0
@@ -25935,8 +22693,6 @@ HanGuo97,2018-Q4,0,0,0
 HanGuo97,2018-Q3,0,0,0
 HanGuo97,2018-Q2,0,0,0
 HanGuo97,2018-Q1,0,0,0
-Dan Lazewatsky,2021-Q4,0,0,0
-Dan Lazewatsky,2021-Q3,0,0,0
 Dan Lazewatsky,2021-Q2,0,0,0
 Dan Lazewatsky,2021-Q1,0,0,0
 Dan Lazewatsky,2020-Q4,0,0,0
@@ -25951,8 +22707,6 @@ Dan Lazewatsky,2018-Q4,0,0,0
 Dan Lazewatsky,2018-Q3,0,0,0
 Dan Lazewatsky,2018-Q2,0,0,0
 Dan Lazewatsky,2018-Q1,0,0,0
-Vagif,2021-Q4,0,0,0
-Vagif,2021-Q3,0,0,0
 Vagif,2021-Q2,0,0,0
 Vagif,2021-Q1,0,0,0
 Vagif,2020-Q4,0,0,0
@@ -25967,8 +22721,6 @@ Vagif,2018-Q4,0,0,0
 Vagif,2018-Q3,0,0,0
 Vagif,2018-Q2,0,0,0
 Vagif,2018-Q1,0,0,0
-Loo Rong Jie,2021-Q4,0,0,0
-Loo Rong Jie,2021-Q3,0,0,0
 Loo Rong Jie,2021-Q2,0,0,0
 Loo Rong Jie,2021-Q1,0,0,0
 Loo Rong Jie,2020-Q4,0,0,0
@@ -25983,8 +22735,6 @@ Loo Rong Jie,2018-Q4,0,0,0
 Loo Rong Jie,2018-Q3,48,437,190
 Loo Rong Jie,2018-Q2,20,46,56
 Loo Rong Jie,2018-Q1,14,59,34
-K. Hodges,2021-Q4,0,0,0
-K. Hodges,2021-Q3,0,0,0
 K. Hodges,2021-Q2,0,0,0
 K. Hodges,2021-Q1,0,0,0
 K. Hodges,2020-Q4,0,0,0
@@ -25999,8 +22749,6 @@ K. Hodges,2018-Q4,0,0,0
 K. Hodges,2018-Q3,0,0,0
 K. Hodges,2018-Q2,0,0,0
 K. Hodges,2018-Q1,0,0,0
-Karl Weinmeister,2021-Q4,0,0,0
-Karl Weinmeister,2021-Q3,0,0,0
 Karl Weinmeister,2021-Q2,0,0,0
 Karl Weinmeister,2021-Q1,0,0,0
 Karl Weinmeister,2020-Q4,0,0,0
@@ -26015,8 +22763,6 @@ Karl Weinmeister,2018-Q4,0,0,0
 Karl Weinmeister,2018-Q3,0,0,0
 Karl Weinmeister,2018-Q2,0,0,0
 Karl Weinmeister,2018-Q1,0,0,0
-Mihail Salnikov,2021-Q4,0,0,0
-Mihail Salnikov,2021-Q3,0,0,0
 Mihail Salnikov,2021-Q2,0,0,0
 Mihail Salnikov,2021-Q1,0,0,0
 Mihail Salnikov,2020-Q4,0,0,0
@@ -26031,8 +22777,6 @@ Mihail Salnikov,2018-Q4,0,0,0
 Mihail Salnikov,2018-Q3,0,0,0
 Mihail Salnikov,2018-Q2,0,0,0
 Mihail Salnikov,2018-Q1,0,0,0
-Eric Liu,2021-Q4,0,0,0
-Eric Liu,2021-Q3,0,0,0
 Eric Liu,2021-Q2,0,0,0
 Eric Liu,2021-Q1,0,0,0
 Eric Liu,2020-Q4,0,0,0
@@ -26047,8 +22791,6 @@ Eric Liu,2018-Q4,0,0,0
 Eric Liu,2018-Q3,0,0,0
 Eric Liu,2018-Q2,1,0,0
 Eric Liu,2018-Q1,2,16,16
-yonghuiguo,2021-Q4,0,0,0
-yonghuiguo,2021-Q3,0,0,0
 yonghuiguo,2021-Q2,0,0,0
 yonghuiguo,2021-Q1,0,0,0
 yonghuiguo,2020-Q4,0,0,0
@@ -26063,8 +22805,6 @@ yonghuiguo,2018-Q4,0,0,0
 yonghuiguo,2018-Q3,0,0,0
 yonghuiguo,2018-Q2,0,0,0
 yonghuiguo,2018-Q1,0,0,0
-Mani Varadarajan,2021-Q4,0,0,0
-Mani Varadarajan,2021-Q3,0,0,0
 Mani Varadarajan,2021-Q2,0,0,0
 Mani Varadarajan,2021-Q1,0,0,0
 Mani Varadarajan,2020-Q4,0,0,0
@@ -26079,8 +22819,6 @@ Mani Varadarajan,2018-Q4,0,0,0
 Mani Varadarajan,2018-Q3,0,0,0
 Mani Varadarajan,2018-Q2,0,0,0
 Mani Varadarajan,2018-Q1,0,0,0
-Hoeseong Kim,2021-Q4,0,0,0
-Hoeseong Kim,2021-Q3,0,0,0
 Hoeseong Kim,2021-Q2,0,0,0
 Hoeseong Kim,2021-Q1,0,0,0
 Hoeseong Kim,2020-Q4,0,0,0
@@ -26095,8 +22833,6 @@ Hoeseong Kim,2018-Q4,1,0,4
 Hoeseong Kim,2018-Q3,21,666,49
 Hoeseong Kim,2018-Q2,0,0,0
 Hoeseong Kim,2018-Q1,0,0,0
-Shahzad Lone,2021-Q4,0,0,0
-Shahzad Lone,2021-Q3,0,0,0
 Shahzad Lone,2021-Q2,0,0,0
 Shahzad Lone,2021-Q1,0,0,0
 Shahzad Lone,2020-Q4,0,0,0
@@ -26111,8 +22847,6 @@ Shahzad Lone,2018-Q4,1,2,0
 Shahzad Lone,2018-Q3,0,0,0
 Shahzad Lone,2018-Q2,0,0,0
 Shahzad Lone,2018-Q1,0,0,0
-Andrew Cotter,2021-Q4,0,0,0
-Andrew Cotter,2021-Q3,0,0,0
 Andrew Cotter,2021-Q2,0,0,0
 Andrew Cotter,2021-Q1,0,0,0
 Andrew Cotter,2020-Q4,0,0,0
@@ -26127,8 +22861,6 @@ Andrew Cotter,2018-Q4,0,0,0
 Andrew Cotter,2018-Q3,4,192,73
 Andrew Cotter,2018-Q2,16,2603,0
 Andrew Cotter,2018-Q1,0,0,0
-王振华 (WANG Zhenhua),2021-Q4,0,0,0
-王振华 (WANG Zhenhua),2021-Q3,0,0,0
 王振华 (WANG Zhenhua),2021-Q2,0,0,0
 王振华 (WANG Zhenhua),2021-Q1,0,0,0
 王振华 (WANG Zhenhua),2020-Q4,0,0,0
@@ -26143,8 +22875,6 @@ Andrew Cotter,2018-Q1,0,0,0
 王振华 (WANG Zhenhua),2018-Q3,0,0,0
 王振华 (WANG Zhenhua),2018-Q2,0,0,0
 王振华 (WANG Zhenhua),2018-Q1,0,0,0
-Supriya Rao,2021-Q4,0,0,0
-Supriya Rao,2021-Q3,0,0,0
 Supriya Rao,2021-Q2,0,0,0
 Supriya Rao,2021-Q1,0,0,0
 Supriya Rao,2020-Q4,0,0,0
@@ -26159,8 +22889,6 @@ Supriya Rao,2018-Q4,48,1771,680
 Supriya Rao,2018-Q3,0,0,0
 Supriya Rao,2018-Q2,0,0,0
 Supriya Rao,2018-Q1,0,0,0
-drpngx,2021-Q4,0,0,0
-drpngx,2021-Q3,0,0,0
 drpngx,2021-Q2,0,0,0
 drpngx,2021-Q1,0,0,0
 drpngx,2020-Q4,0,0,0
@@ -26175,8 +22903,6 @@ drpngx,2018-Q4,2,0,0
 drpngx,2018-Q3,3,2,4
 drpngx,2018-Q2,0,0,0
 drpngx,2018-Q1,0,0,0
-Vikram Tiwari,2021-Q4,0,0,0
-Vikram Tiwari,2021-Q3,0,0,0
 Vikram Tiwari,2021-Q2,0,0,0
 Vikram Tiwari,2021-Q1,0,0,0
 Vikram Tiwari,2020-Q4,0,0,0
@@ -26191,8 +22917,6 @@ Vikram Tiwari,2018-Q4,0,0,0
 Vikram Tiwari,2018-Q3,0,0,0
 Vikram Tiwari,2018-Q2,3,6,9
 Vikram Tiwari,2018-Q1,0,0,0
-Sherry Yang,2021-Q4,0,0,0
-Sherry Yang,2021-Q3,0,0,0
 Sherry Yang,2021-Q2,0,0,0
 Sherry Yang,2021-Q1,0,0,0
 Sherry Yang,2020-Q4,0,0,0
@@ -26207,8 +22931,6 @@ Sherry Yang,2018-Q4,10,296,93
 Sherry Yang,2018-Q3,0,0,0
 Sherry Yang,2018-Q2,0,0,0
 Sherry Yang,2018-Q1,0,0,0
-Joseph Friedman,2021-Q4,0,0,0
-Joseph Friedman,2021-Q3,0,0,0
 Joseph Friedman,2021-Q2,0,0,0
 Joseph Friedman,2021-Q1,0,0,0
 Joseph Friedman,2020-Q4,0,0,0
@@ -26223,8 +22945,6 @@ Joseph Friedman,2018-Q4,0,0,0
 Joseph Friedman,2018-Q3,0,0,0
 Joseph Friedman,2018-Q2,0,0,0
 Joseph Friedman,2018-Q1,0,0,0
-Roy Frostig,2021-Q4,0,0,0
-Roy Frostig,2021-Q3,0,0,0
 Roy Frostig,2021-Q2,0,0,0
 Roy Frostig,2021-Q1,0,0,0
 Roy Frostig,2020-Q4,0,0,0
@@ -26239,8 +22959,6 @@ Roy Frostig,2018-Q4,21,1066,372
 Roy Frostig,2018-Q3,0,0,0
 Roy Frostig,2018-Q2,9,138,64
 Roy Frostig,2018-Q1,14,479,154
-Michael Case,2021-Q4,0,0,0
-Michael Case,2021-Q3,0,0,0
 Michael Case,2021-Q2,0,0,0
 Michael Case,2021-Q1,0,0,0
 Michael Case,2020-Q4,0,0,0
@@ -26255,8 +22973,6 @@ Michael Case,2018-Q4,436,3365,113851
 Michael Case,2018-Q3,69,512,496
 Michael Case,2018-Q2,286,5495,2212
 Michael Case,2018-Q1,286,4647,1058
-Mr. metal,2021-Q4,0,0,0
-Mr. metal,2021-Q3,0,0,0
 Mr. metal,2021-Q2,0,0,0
 Mr. metal,2021-Q1,0,0,0
 Mr. metal,2020-Q4,0,0,0
@@ -26271,8 +22987,6 @@ Mr. metal,2018-Q4,0,0,0
 Mr. metal,2018-Q3,0,0,0
 Mr. metal,2018-Q2,0,0,0
 Mr. metal,2018-Q1,0,0,0
-dmitrievanthony,2021-Q4,0,0,0
-dmitrievanthony,2021-Q3,0,0,0
 dmitrievanthony,2021-Q2,0,0,0
 dmitrievanthony,2021-Q1,0,0,0
 dmitrievanthony,2020-Q4,0,0,0
@@ -26287,8 +23001,6 @@ dmitrievanthony,2018-Q4,1,0,3
 dmitrievanthony,2018-Q3,18,624,748
 dmitrievanthony,2018-Q2,0,0,0
 dmitrievanthony,2018-Q1,0,0,0
-Thomas Deegan,2021-Q4,0,0,0
-Thomas Deegan,2021-Q3,0,0,0
 Thomas Deegan,2021-Q2,0,0,0
 Thomas Deegan,2021-Q1,0,0,0
 Thomas Deegan,2020-Q4,0,0,0
@@ -26303,8 +23015,6 @@ Thomas Deegan,2018-Q4,1,2,2
 Thomas Deegan,2018-Q3,0,0,0
 Thomas Deegan,2018-Q2,0,0,0
 Thomas Deegan,2018-Q1,7,63,8
-I-Hong Jhuo,2021-Q4,0,0,0
-I-Hong Jhuo,2021-Q3,0,0,0
 I-Hong Jhuo,2021-Q2,0,0,0
 I-Hong Jhuo,2021-Q1,0,0,0
 I-Hong Jhuo,2020-Q4,0,0,0
@@ -26319,8 +23029,6 @@ I-Hong Jhuo,2018-Q4,0,0,0
 I-Hong Jhuo,2018-Q3,0,0,0
 I-Hong Jhuo,2018-Q2,0,0,0
 I-Hong Jhuo,2018-Q1,0,0,0
-ctiijima,2021-Q4,0,0,0
-ctiijima,2021-Q3,0,0,0
 ctiijima,2021-Q2,0,0,0
 ctiijima,2021-Q1,0,0,0
 ctiijima,2020-Q4,0,0,0
@@ -26335,8 +23043,6 @@ ctiijima,2018-Q4,0,0,0
 ctiijima,2018-Q3,0,0,0
 ctiijima,2018-Q2,5,27,36
 ctiijima,2018-Q1,0,0,0
-Gautam,2021-Q4,0,0,0
-Gautam,2021-Q3,0,0,0
 Gautam,2021-Q2,0,0,0
 Gautam,2021-Q1,0,0,0
 Gautam,2020-Q4,0,0,0
@@ -26351,8 +23057,6 @@ Gautam,2018-Q4,2,2,0
 Gautam,2018-Q3,0,0,0
 Gautam,2018-Q2,0,0,0
 Gautam,2018-Q1,0,0,0
-Mark Collier,2021-Q4,0,0,0
-Mark Collier,2021-Q3,0,0,0
 Mark Collier,2021-Q2,0,0,0
 Mark Collier,2021-Q1,0,0,0
 Mark Collier,2020-Q4,0,0,0
@@ -26367,8 +23071,6 @@ Mark Collier,2018-Q4,2,55,50
 Mark Collier,2018-Q3,4,432,129
 Mark Collier,2018-Q2,0,0,0
 Mark Collier,2018-Q1,0,0,0
-Felix Lemke,2021-Q4,0,0,0
-Felix Lemke,2021-Q3,0,0,0
 Felix Lemke,2021-Q2,0,0,0
 Felix Lemke,2021-Q1,0,0,0
 Felix Lemke,2020-Q4,0,0,0
@@ -26383,8 +23085,6 @@ Felix Lemke,2018-Q4,0,0,0
 Felix Lemke,2018-Q3,0,0,0
 Felix Lemke,2018-Q2,0,0,0
 Felix Lemke,2018-Q1,0,0,0
-Chao Liu,2021-Q4,0,0,0
-Chao Liu,2021-Q3,0,0,0
 Chao Liu,2021-Q2,0,0,0
 Chao Liu,2021-Q1,0,0,0
 Chao Liu,2020-Q4,0,0,0
@@ -26399,8 +23099,6 @@ Chao Liu,2018-Q4,0,0,0
 Chao Liu,2018-Q3,0,0,0
 Chao Liu,2018-Q2,0,0,0
 Chao Liu,2018-Q1,0,0,0
-Mike Holcomb,2021-Q4,0,0,0
-Mike Holcomb,2021-Q3,0,0,0
 Mike Holcomb,2021-Q2,0,0,0
 Mike Holcomb,2021-Q1,0,0,0
 Mike Holcomb,2020-Q4,0,0,0
@@ -26415,8 +23113,6 @@ Mike Holcomb,2018-Q4,0,0,0
 Mike Holcomb,2018-Q3,0,0,0
 Mike Holcomb,2018-Q2,0,0,0
 Mike Holcomb,2018-Q1,0,0,0
-MattConley,2021-Q4,0,0,0
-MattConley,2021-Q3,0,0,0
 MattConley,2021-Q2,0,0,0
 MattConley,2021-Q1,0,0,0
 MattConley,2020-Q4,0,0,0
@@ -26431,8 +23127,6 @@ MattConley,2018-Q4,0,0,0
 MattConley,2018-Q3,0,0,0
 MattConley,2018-Q2,0,0,0
 MattConley,2018-Q1,0,0,0
-Miguel Morin,2021-Q4,0,0,0
-Miguel Morin,2021-Q3,0,0,0
 Miguel Morin,2021-Q2,0,0,0
 Miguel Morin,2021-Q1,0,0,0
 Miguel Morin,2020-Q4,0,0,0
@@ -26447,8 +23141,6 @@ Miguel Morin,2018-Q4,0,0,0
 Miguel Morin,2018-Q3,0,0,0
 Miguel Morin,2018-Q2,0,0,0
 Miguel Morin,2018-Q1,0,0,0
-Dheeraj Rajaram Reddy,2021-Q4,0,0,0
-Dheeraj Rajaram Reddy,2021-Q3,0,0,0
 Dheeraj Rajaram Reddy,2021-Q2,0,0,0
 Dheeraj Rajaram Reddy,2021-Q1,0,0,0
 Dheeraj Rajaram Reddy,2020-Q4,0,0,0
@@ -26463,8 +23155,6 @@ Dheeraj Rajaram Reddy,2018-Q4,0,0,0
 Dheeraj Rajaram Reddy,2018-Q3,0,0,0
 Dheeraj Rajaram Reddy,2018-Q2,0,0,0
 Dheeraj Rajaram Reddy,2018-Q1,0,0,0
-tomguluson92,2021-Q4,0,0,0
-tomguluson92,2021-Q3,0,0,0
 tomguluson92,2021-Q2,0,0,0
 tomguluson92,2021-Q1,0,0,0
 tomguluson92,2020-Q4,0,0,0
@@ -26479,8 +23169,6 @@ tomguluson92,2018-Q4,2,0,0
 tomguluson92,2018-Q3,1,0,0
 tomguluson92,2018-Q2,0,0,0
 tomguluson92,2018-Q1,0,0,0
-Spencer Schaber,2021-Q4,0,0,0
-Spencer Schaber,2021-Q3,0,0,0
 Spencer Schaber,2021-Q2,0,0,0
 Spencer Schaber,2021-Q1,0,0,0
 Spencer Schaber,2020-Q4,0,0,0
@@ -26495,8 +23183,6 @@ Spencer Schaber,2018-Q4,2,6,5
 Spencer Schaber,2018-Q3,0,0,0
 Spencer Schaber,2018-Q2,0,0,0
 Spencer Schaber,2018-Q1,0,0,0
-Marek Drozdowski,2021-Q4,0,0,0
-Marek Drozdowski,2021-Q3,0,0,0
 Marek Drozdowski,2021-Q2,0,0,0
 Marek Drozdowski,2021-Q1,0,0,0
 Marek Drozdowski,2020-Q4,0,0,0
@@ -26511,8 +23197,6 @@ Marek Drozdowski,2018-Q4,31,671,225
 Marek Drozdowski,2018-Q3,0,0,0
 Marek Drozdowski,2018-Q2,0,0,0
 Marek Drozdowski,2018-Q1,0,0,0
-Jonas Rauber,2021-Q4,0,0,0
-Jonas Rauber,2021-Q3,0,0,0
 Jonas Rauber,2021-Q2,0,0,0
 Jonas Rauber,2021-Q1,0,0,0
 Jonas Rauber,2020-Q4,0,0,0
@@ -26527,8 +23211,6 @@ Jonas Rauber,2018-Q4,0,0,0
 Jonas Rauber,2018-Q3,0,0,0
 Jonas Rauber,2018-Q2,1,9,9
 Jonas Rauber,2018-Q1,0,0,0
-Dayananda V,2021-Q4,0,0,0
-Dayananda V,2021-Q3,0,0,0
 Dayananda V,2021-Q2,0,0,0
 Dayananda V,2021-Q1,0,0,0
 Dayananda V,2020-Q4,0,0,0
@@ -26543,8 +23225,6 @@ Dayananda V,2018-Q4,0,0,0
 Dayananda V,2018-Q3,0,0,0
 Dayananda V,2018-Q2,0,0,0
 Dayananda V,2018-Q1,0,0,0
-Asim Shankar,2021-Q4,0,0,0
-Asim Shankar,2021-Q3,0,0,0
 Asim Shankar,2021-Q2,0,0,0
 Asim Shankar,2021-Q1,0,0,0
 Asim Shankar,2020-Q4,0,0,0
@@ -26559,8 +23239,6 @@ Asim Shankar,2018-Q4,135,1038,4654
 Asim Shankar,2018-Q3,173,3627,3321
 Asim Shankar,2018-Q2,157,5019,2789
 Asim Shankar,2018-Q1,238,1882,2045
-Samantha Andow,2021-Q4,0,0,0
-Samantha Andow,2021-Q3,0,0,0
 Samantha Andow,2021-Q2,0,0,0
 Samantha Andow,2021-Q1,0,0,0
 Samantha Andow,2020-Q4,0,0,0
@@ -26575,8 +23253,6 @@ Samantha Andow,2018-Q4,2,10,10
 Samantha Andow,2018-Q3,0,0,0
 Samantha Andow,2018-Q2,0,0,0
 Samantha Andow,2018-Q1,0,0,0
-Saurabh Deoras,2021-Q4,0,0,0
-Saurabh Deoras,2021-Q3,0,0,0
 Saurabh Deoras,2021-Q2,0,0,0
 Saurabh Deoras,2021-Q1,0,0,0
 Saurabh Deoras,2020-Q4,0,0,0
@@ -26591,8 +23267,6 @@ Saurabh Deoras,2018-Q4,0,0,0
 Saurabh Deoras,2018-Q3,0,0,0
 Saurabh Deoras,2018-Q2,0,0,0
 Saurabh Deoras,2018-Q1,0,0,0
-Nutti,2021-Q4,0,0,0
-Nutti,2021-Q3,0,0,0
 Nutti,2021-Q2,0,0,0
 Nutti,2021-Q1,0,0,0
 Nutti,2020-Q4,0,0,0
@@ -26607,8 +23281,6 @@ Nutti,2018-Q4,3,14,14
 Nutti,2018-Q3,1,0,0
 Nutti,2018-Q2,0,0,0
 Nutti,2018-Q1,0,0,0
-Mark Heffernan,2021-Q4,0,0,0
-Mark Heffernan,2021-Q3,0,0,0
 Mark Heffernan,2021-Q2,0,0,0
 Mark Heffernan,2021-Q1,0,0,0
 Mark Heffernan,2020-Q4,0,0,0
@@ -26623,8 +23295,6 @@ Mark Heffernan,2018-Q4,490,5539,3122
 Mark Heffernan,2018-Q3,442,8450,4832
 Mark Heffernan,2018-Q2,165,2460,1107
 Mark Heffernan,2018-Q1,85,3589,2088
-Jia Qingtong,2021-Q4,0,0,0
-Jia Qingtong,2021-Q3,0,0,0
 Jia Qingtong,2021-Q2,0,0,0
 Jia Qingtong,2021-Q1,0,0,0
 Jia Qingtong,2020-Q4,0,0,0
@@ -26639,8 +23309,6 @@ Jia Qingtong,2018-Q4,0,0,0
 Jia Qingtong,2018-Q3,0,0,0
 Jia Qingtong,2018-Q2,0,0,0
 Jia Qingtong,2018-Q1,0,0,0
-Ilango R,2021-Q4,0,0,0
-Ilango R,2021-Q3,0,0,0
 Ilango R,2021-Q2,0,0,0
 Ilango R,2021-Q1,0,0,0
 Ilango R,2020-Q4,0,0,0
@@ -26655,8 +23323,6 @@ Ilango R,2018-Q4,0,0,0
 Ilango R,2018-Q3,0,0,0
 Ilango R,2018-Q2,0,0,0
 Ilango R,2018-Q1,0,0,0
-ktaebum,2021-Q4,0,0,0
-ktaebum,2021-Q3,0,0,0
 ktaebum,2021-Q2,0,0,0
 ktaebum,2021-Q1,0,0,0
 ktaebum,2020-Q4,0,0,0
@@ -26671,8 +23337,6 @@ ktaebum,2018-Q4,0,0,0
 ktaebum,2018-Q3,0,0,0
 ktaebum,2018-Q2,0,0,0
 ktaebum,2018-Q1,0,0,0
-Adam Weiss,2021-Q4,0,0,0
-Adam Weiss,2021-Q3,0,0,0
 Adam Weiss,2021-Q2,0,0,0
 Adam Weiss,2021-Q1,0,0,0
 Adam Weiss,2020-Q4,0,0,0
@@ -26687,8 +23351,6 @@ Adam Weiss,2018-Q4,1,11,10
 Adam Weiss,2018-Q3,0,0,0
 Adam Weiss,2018-Q2,0,0,0
 Adam Weiss,2018-Q1,0,0,0
-awesomealex1,2021-Q4,0,0,0
-awesomealex1,2021-Q3,0,0,0
 awesomealex1,2021-Q2,0,0,0
 awesomealex1,2021-Q1,0,0,0
 awesomealex1,2020-Q4,0,0,0
@@ -26703,8 +23365,6 @@ awesomealex1,2018-Q4,0,0,0
 awesomealex1,2018-Q3,0,0,0
 awesomealex1,2018-Q2,0,0,0
 awesomealex1,2018-Q1,0,0,0
-Laurent Le Brun,2021-Q4,0,0,0
-Laurent Le Brun,2021-Q3,0,0,0
 Laurent Le Brun,2021-Q2,0,0,0
 Laurent Le Brun,2021-Q1,0,0,0
 Laurent Le Brun,2020-Q4,0,0,0
@@ -26719,8 +23379,6 @@ Laurent Le Brun,2018-Q4,0,0,0
 Laurent Le Brun,2018-Q3,0,0,0
 Laurent Le Brun,2018-Q2,0,0,0
 Laurent Le Brun,2018-Q1,0,0,0
-manhyuk,2021-Q4,0,0,0
-manhyuk,2021-Q3,0,0,0
 manhyuk,2021-Q2,0,0,0
 manhyuk,2021-Q1,0,0,0
 manhyuk,2020-Q4,0,0,0
@@ -26735,8 +23393,6 @@ manhyuk,2018-Q4,13,9,9
 manhyuk,2018-Q3,0,0,0
 manhyuk,2018-Q2,13,7,7
 manhyuk,2018-Q1,0,0,0
-Mickaël Schoentgen,2021-Q4,0,0,0
-Mickaël Schoentgen,2021-Q3,0,0,0
 Mickaël Schoentgen,2021-Q2,0,0,0
 Mickaël Schoentgen,2021-Q1,0,0,0
 Mickaël Schoentgen,2020-Q4,0,0,0
@@ -26751,8 +23407,6 @@ Mickaël Schoentgen,2018-Q4,0,0,0
 Mickaël Schoentgen,2018-Q3,0,0,0
 Mickaël Schoentgen,2018-Q2,0,0,0
 Mickaël Schoentgen,2018-Q1,0,0,0
-Ben Zinberg,2021-Q4,0,0,0
-Ben Zinberg,2021-Q3,0,0,0
 Ben Zinberg,2021-Q2,0,0,0
 Ben Zinberg,2021-Q1,0,0,0
 Ben Zinberg,2020-Q4,0,0,0
@@ -26767,8 +23421,6 @@ Ben Zinberg,2018-Q4,2,5,5
 Ben Zinberg,2018-Q3,0,0,0
 Ben Zinberg,2018-Q2,0,0,0
 Ben Zinberg,2018-Q1,0,0,0
-Heungsub Lee,2021-Q4,0,0,0
-Heungsub Lee,2021-Q3,0,0,0
 Heungsub Lee,2021-Q2,0,0,0
 Heungsub Lee,2021-Q1,0,0,0
 Heungsub Lee,2020-Q4,0,0,0
@@ -26783,8 +23435,6 @@ Heungsub Lee,2018-Q4,0,0,0
 Heungsub Lee,2018-Q3,0,0,0
 Heungsub Lee,2018-Q2,0,0,0
 Heungsub Lee,2018-Q1,0,0,0
-Kay Zhu,2021-Q4,0,0,0
-Kay Zhu,2021-Q3,0,0,0
 Kay Zhu,2021-Q2,0,0,0
 Kay Zhu,2021-Q1,0,0,0
 Kay Zhu,2020-Q4,0,0,0
@@ -26799,8 +23449,6 @@ Kay Zhu,2018-Q4,40,1358,514
 Kay Zhu,2018-Q3,266,6689,6038
 Kay Zhu,2018-Q2,79,1626,1349
 Kay Zhu,2018-Q1,45,865,89
-Christoph Boeddeker,2021-Q4,0,0,0
-Christoph Boeddeker,2021-Q3,0,0,0
 Christoph Boeddeker,2021-Q2,0,0,0
 Christoph Boeddeker,2021-Q1,0,0,0
 Christoph Boeddeker,2020-Q4,0,0,0
@@ -26815,8 +23463,6 @@ Christoph Boeddeker,2018-Q4,0,0,0
 Christoph Boeddeker,2018-Q3,0,0,0
 Christoph Boeddeker,2018-Q2,1,3,0
 Christoph Boeddeker,2018-Q1,4,141,0
-Vishwak Srinivasan,2021-Q4,0,0,0
-Vishwak Srinivasan,2021-Q3,0,0,0
 Vishwak Srinivasan,2021-Q2,0,0,0
 Vishwak Srinivasan,2021-Q1,0,0,0
 Vishwak Srinivasan,2020-Q4,0,0,0
@@ -26831,8 +23477,6 @@ Vishwak Srinivasan,2018-Q4,1,0,0
 Vishwak Srinivasan,2018-Q3,0,0,0
 Vishwak Srinivasan,2018-Q2,0,0,0
 Vishwak Srinivasan,2018-Q1,0,0,0
-Jakub Lipinski,2021-Q4,0,0,0
-Jakub Lipinski,2021-Q3,0,0,0
 Jakub Lipinski,2021-Q2,0,0,0
 Jakub Lipinski,2021-Q1,0,0,0
 Jakub Lipinski,2020-Q4,0,0,0
@@ -26847,8 +23491,6 @@ Jakub Lipinski,2018-Q4,2,11,2
 Jakub Lipinski,2018-Q3,0,0,0
 Jakub Lipinski,2018-Q2,0,0,0
 Jakub Lipinski,2018-Q1,0,0,0
-Yves-Noel Weweler,2021-Q4,0,0,0
-Yves-Noel Weweler,2021-Q3,0,0,0
 Yves-Noel Weweler,2021-Q2,0,0,0
 Yves-Noel Weweler,2021-Q1,0,0,0
 Yves-Noel Weweler,2020-Q4,0,0,0
@@ -26863,8 +23505,6 @@ Yves-Noel Weweler,2018-Q4,12,225,70
 Yves-Noel Weweler,2018-Q3,0,0,0
 Yves-Noel Weweler,2018-Q2,0,0,0
 Yves-Noel Weweler,2018-Q1,0,0,0
-mars20,2021-Q4,0,0,0
-mars20,2021-Q3,0,0,0
 mars20,2021-Q2,0,0,0
 mars20,2021-Q1,0,0,0
 mars20,2020-Q4,0,0,0
@@ -26879,8 +23519,6 @@ mars20,2018-Q4,1,5,0
 mars20,2018-Q3,0,0,0
 mars20,2018-Q2,0,0,0
 mars20,2018-Q1,0,0,0
-vitor-alves,2021-Q4,0,0,0
-vitor-alves,2021-Q3,0,0,0
 vitor-alves,2021-Q2,0,0,0
 vitor-alves,2021-Q1,0,0,0
 vitor-alves,2020-Q4,0,0,0
@@ -26895,8 +23533,6 @@ vitor-alves,2018-Q4,1,0,0
 vitor-alves,2018-Q3,0,0,0
 vitor-alves,2018-Q2,0,0,0
 vitor-alves,2018-Q1,0,0,0
-Innovimax,2021-Q4,0,0,0
-Innovimax,2021-Q3,0,0,0
 Innovimax,2021-Q2,0,0,0
 Innovimax,2021-Q1,0,0,0
 Innovimax,2020-Q4,0,0,0
@@ -26911,8 +23547,6 @@ Innovimax,2018-Q4,1,0,0
 Innovimax,2018-Q3,0,0,0
 Innovimax,2018-Q2,0,0,0
 Innovimax,2018-Q1,0,0,0
-Ilya Biryukov,2021-Q4,0,0,0
-Ilya Biryukov,2021-Q3,0,0,0
 Ilya Biryukov,2021-Q2,0,0,0
 Ilya Biryukov,2021-Q1,0,0,0
 Ilya Biryukov,2020-Q4,0,0,0
@@ -26927,8 +23561,6 @@ Ilya Biryukov,2018-Q4,5,21,21
 Ilya Biryukov,2018-Q3,10,103,75
 Ilya Biryukov,2018-Q2,8,91,37
 Ilya Biryukov,2018-Q1,27,229,198
-WeberXie,2021-Q4,0,0,0
-WeberXie,2021-Q3,0,0,0
 WeberXie,2021-Q2,0,0,0
 WeberXie,2021-Q1,0,0,0
 WeberXie,2020-Q4,0,0,0
@@ -26943,8 +23575,6 @@ WeberXie,2018-Q4,1,2,2
 WeberXie,2018-Q3,1,6,4
 WeberXie,2018-Q2,0,0,0
 WeberXie,2018-Q1,0,0,0
-Taylor Thornton,2021-Q4,0,0,0
-Taylor Thornton,2021-Q3,0,0,0
 Taylor Thornton,2021-Q2,0,0,0
 Taylor Thornton,2021-Q1,0,0,0
 Taylor Thornton,2020-Q4,0,0,0
@@ -26959,8 +23589,6 @@ Taylor Thornton,2018-Q4,2,12,4
 Taylor Thornton,2018-Q3,0,0,0
 Taylor Thornton,2018-Q2,0,0,0
 Taylor Thornton,2018-Q1,0,0,0
-Ashwin Ramaswami,2021-Q4,0,0,0
-Ashwin Ramaswami,2021-Q3,0,0,0
 Ashwin Ramaswami,2021-Q2,0,0,0
 Ashwin Ramaswami,2021-Q1,0,0,0
 Ashwin Ramaswami,2020-Q4,0,0,0
@@ -26975,8 +23603,6 @@ Ashwin Ramaswami,2018-Q4,2,5,5
 Ashwin Ramaswami,2018-Q3,0,0,0
 Ashwin Ramaswami,2018-Q2,0,0,0
 Ashwin Ramaswami,2018-Q1,0,0,0
-jcf94,2021-Q4,0,0,0
-jcf94,2021-Q3,0,0,0
 jcf94,2021-Q2,0,0,0
 jcf94,2021-Q1,0,0,0
 jcf94,2020-Q4,0,0,0
@@ -26991,8 +23617,6 @@ jcf94,2018-Q4,11,50,48
 jcf94,2018-Q3,0,0,0
 jcf94,2018-Q2,0,0,0
 jcf94,2018-Q1,0,0,0
-Joe Quadrino,2021-Q4,0,0,0
-Joe Quadrino,2021-Q3,0,0,0
 Joe Quadrino,2021-Q2,0,0,0
 Joe Quadrino,2021-Q1,0,0,0
 Joe Quadrino,2020-Q4,0,0,0
@@ -27007,8 +23631,6 @@ Joe Quadrino,2018-Q4,1,3,0
 Joe Quadrino,2018-Q3,0,0,0
 Joe Quadrino,2018-Q2,0,0,0
 Joe Quadrino,2018-Q1,0,0,0
-Pavel Samolysov,2021-Q4,0,0,0
-Pavel Samolysov,2021-Q3,0,0,0
 Pavel Samolysov,2021-Q2,0,0,0
 Pavel Samolysov,2021-Q1,0,0,0
 Pavel Samolysov,2020-Q4,0,0,0
@@ -27023,8 +23645,6 @@ Pavel Samolysov,2018-Q4,2,5,0
 Pavel Samolysov,2018-Q3,0,0,0
 Pavel Samolysov,2018-Q2,0,0,0
 Pavel Samolysov,2018-Q1,0,0,0
-WeijieSun,2021-Q4,0,0,0
-WeijieSun,2021-Q3,0,0,0
 WeijieSun,2021-Q2,0,0,0
 WeijieSun,2021-Q1,0,0,0
 WeijieSun,2020-Q4,0,0,0
@@ -27039,8 +23659,6 @@ WeijieSun,2018-Q4,1,0,10
 WeijieSun,2018-Q3,0,0,0
 WeijieSun,2018-Q2,0,0,0
 WeijieSun,2018-Q1,0,0,0
-Keno Fischer,2021-Q4,0,0,0
-Keno Fischer,2021-Q3,0,0,0
 Keno Fischer,2021-Q2,0,0,0
 Keno Fischer,2021-Q1,0,0,0
 Keno Fischer,2020-Q4,0,0,0
@@ -27055,8 +23673,6 @@ Keno Fischer,2018-Q4,19,505,15
 Keno Fischer,2018-Q3,1,3,2
 Keno Fischer,2018-Q2,0,0,0
 Keno Fischer,2018-Q1,0,0,0
-Daniel Rasmussen,2021-Q4,0,0,0
-Daniel Rasmussen,2021-Q3,0,0,0
 Daniel Rasmussen,2021-Q2,0,0,0
 Daniel Rasmussen,2021-Q1,0,0,0
 Daniel Rasmussen,2020-Q4,0,0,0
@@ -27071,8 +23687,6 @@ Daniel Rasmussen,2018-Q4,2,39,5
 Daniel Rasmussen,2018-Q3,0,0,0
 Daniel Rasmussen,2018-Q2,0,0,0
 Daniel Rasmussen,2018-Q1,0,0,0
-Steve Lang,2021-Q4,0,0,0
-Steve Lang,2021-Q3,0,0,0
 Steve Lang,2021-Q2,0,0,0
 Steve Lang,2021-Q1,0,0,0
 Steve Lang,2020-Q4,0,0,0
@@ -27087,8 +23701,6 @@ Steve Lang,2018-Q4,1,0,0
 Steve Lang,2018-Q3,0,0,0
 Steve Lang,2018-Q2,0,0,0
 Steve Lang,2018-Q1,0,0,0
-Gautam Vasudevan,2021-Q4,0,0,0
-Gautam Vasudevan,2021-Q3,0,0,0
 Gautam Vasudevan,2021-Q2,0,0,0
 Gautam Vasudevan,2021-Q1,0,0,0
 Gautam Vasudevan,2020-Q4,0,0,0
@@ -27103,8 +23715,6 @@ Gautam Vasudevan,2018-Q4,2,0,293
 Gautam Vasudevan,2018-Q3,1,68,48
 Gautam Vasudevan,2018-Q2,0,0,0
 Gautam Vasudevan,2018-Q1,0,0,0
-Federico Martinez,2021-Q4,0,0,0
-Federico Martinez,2021-Q3,0,0,0
 Federico Martinez,2021-Q2,0,0,0
 Federico Martinez,2021-Q1,0,0,0
 Federico Martinez,2020-Q4,0,0,0
@@ -27119,8 +23729,6 @@ Federico Martinez,2018-Q4,1,0,2
 Federico Martinez,2018-Q3,0,0,0
 Federico Martinez,2018-Q2,0,0,0
 Federico Martinez,2018-Q1,0,0,0
-avijit-nervana,2021-Q4,0,0,0
-avijit-nervana,2021-Q3,0,0,0
 avijit-nervana,2021-Q2,0,0,0
 avijit-nervana,2021-Q1,0,0,0
 avijit-nervana,2020-Q4,0,0,0
@@ -27135,8 +23743,6 @@ avijit-nervana,2018-Q4,7,56,37
 avijit-nervana,2018-Q3,37,388,215
 avijit-nervana,2018-Q2,0,0,0
 avijit-nervana,2018-Q1,0,0,0
-Goldie Gadde,2021-Q4,0,0,0
-Goldie Gadde,2021-Q3,0,0,0
 Goldie Gadde,2021-Q2,0,0,0
 Goldie Gadde,2021-Q1,0,0,0
 Goldie Gadde,2020-Q4,0,0,0
@@ -27151,8 +23757,6 @@ Goldie Gadde,2018-Q4,23,89,54
 Goldie Gadde,2018-Q3,0,0,0
 Goldie Gadde,2018-Q2,0,0,0
 Goldie Gadde,2018-Q1,0,0,0
-Viacheslav Kovalevskyi,2021-Q4,0,0,0
-Viacheslav Kovalevskyi,2021-Q3,0,0,0
 Viacheslav Kovalevskyi,2021-Q2,0,0,0
 Viacheslav Kovalevskyi,2021-Q1,0,0,0
 Viacheslav Kovalevskyi,2020-Q4,0,0,0
@@ -27167,8 +23771,6 @@ Viacheslav Kovalevskyi,2018-Q4,5,57,0
 Viacheslav Kovalevskyi,2018-Q3,0,0,0
 Viacheslav Kovalevskyi,2018-Q2,0,0,0
 Viacheslav Kovalevskyi,2018-Q1,0,0,0
-hyunyoung,2021-Q4,0,0,0
-hyunyoung,2021-Q3,0,0,0
 hyunyoung,2021-Q2,0,0,0
 hyunyoung,2021-Q1,0,0,0
 hyunyoung,2020-Q4,0,0,0
@@ -27183,8 +23785,6 @@ hyunyoung,2018-Q4,1,0,0
 hyunyoung,2018-Q3,0,0,0
 hyunyoung,2018-Q2,0,0,0
 hyunyoung,2018-Q1,0,0,0
-Jacky Ko,2021-Q4,0,0,0
-Jacky Ko,2021-Q3,0,0,0
 Jacky Ko,2021-Q2,0,0,0
 Jacky Ko,2021-Q1,0,0,0
 Jacky Ko,2020-Q4,0,0,0
@@ -27199,8 +23799,6 @@ Jacky Ko,2018-Q4,20,44,91
 Jacky Ko,2018-Q3,0,0,0
 Jacky Ko,2018-Q2,10,116,19
 Jacky Ko,2018-Q1,3,2,4
-Jing Li,2021-Q4,0,0,0
-Jing Li,2021-Q3,0,0,0
 Jing Li,2021-Q2,0,0,0
 Jing Li,2021-Q1,0,0,0
 Jing Li,2020-Q4,0,0,0
@@ -27215,8 +23813,6 @@ Jing Li,2018-Q4,10,1191,10
 Jing Li,2018-Q3,0,0,0
 Jing Li,2018-Q2,0,0,0
 Jing Li,2018-Q1,0,0,0
-Luke Han,2021-Q4,0,0,0
-Luke Han,2021-Q3,0,0,0
 Luke Han,2021-Q2,0,0,0
 Luke Han,2021-Q1,0,0,0
 Luke Han,2020-Q4,0,0,0
@@ -27231,8 +23827,6 @@ Luke Han,2018-Q4,1,2,3
 Luke Han,2018-Q3,0,0,0
 Luke Han,2018-Q2,0,0,0
 Luke Han,2018-Q1,0,0,0
-Daniel Ingram,2021-Q4,0,0,0
-Daniel Ingram,2021-Q3,0,0,0
 Daniel Ingram,2021-Q2,0,0,0
 Daniel Ingram,2021-Q1,0,0,0
 Daniel Ingram,2020-Q4,0,0,0
@@ -27247,8 +23841,6 @@ Daniel Ingram,2018-Q4,1,3,3
 Daniel Ingram,2018-Q3,0,0,0
 Daniel Ingram,2018-Q2,0,0,0
 Daniel Ingram,2018-Q1,0,0,0
-neargye,2021-Q4,0,0,0
-neargye,2021-Q3,0,0,0
 neargye,2021-Q2,0,0,0
 neargye,2021-Q1,0,0,0
 neargye,2020-Q4,0,0,0
@@ -27263,8 +23855,6 @@ neargye,2018-Q4,5,5,15
 neargye,2018-Q3,0,0,0
 neargye,2018-Q2,0,0,0
 neargye,2018-Q1,0,0,0
-Dan Jarvis,2021-Q4,0,0,0
-Dan Jarvis,2021-Q3,0,0,0
 Dan Jarvis,2021-Q2,0,0,0
 Dan Jarvis,2021-Q1,0,0,0
 Dan Jarvis,2020-Q4,0,0,0
@@ -27279,8 +23869,6 @@ Dan Jarvis,2018-Q4,0,0,0
 Dan Jarvis,2018-Q3,0,0,0
 Dan Jarvis,2018-Q2,0,0,0
 Dan Jarvis,2018-Q1,0,0,0
-Andy Craze,2021-Q4,0,0,0
-Andy Craze,2021-Q3,0,0,0
 Andy Craze,2021-Q2,0,0,0
 Andy Craze,2021-Q1,0,0,0
 Andy Craze,2020-Q4,0,0,0
@@ -27295,8 +23883,6 @@ Andy Craze,2018-Q4,2,6,3
 Andy Craze,2018-Q3,1,4,0
 Andy Craze,2018-Q2,0,0,0
 Andy Craze,2018-Q1,0,0,0
-Steve Nesae,2021-Q4,0,0,0
-Steve Nesae,2021-Q3,0,0,0
 Steve Nesae,2021-Q2,0,0,0
 Steve Nesae,2021-Q1,0,0,0
 Steve Nesae,2020-Q4,0,0,0
@@ -27311,8 +23897,6 @@ Steve Nesae,2018-Q4,3535,191511,85826
 Steve Nesae,2018-Q3,0,0,0
 Steve Nesae,2018-Q2,0,0,0
 Steve Nesae,2018-Q1,0,0,0
-Dalmo Cirne,2021-Q4,0,0,0
-Dalmo Cirne,2021-Q3,0,0,0
 Dalmo Cirne,2021-Q2,0,0,0
 Dalmo Cirne,2021-Q1,0,0,0
 Dalmo Cirne,2020-Q4,0,0,0
@@ -27327,8 +23911,6 @@ Dalmo Cirne,2018-Q4,6,43,18
 Dalmo Cirne,2018-Q3,0,0,0
 Dalmo Cirne,2018-Q2,2,3,6
 Dalmo Cirne,2018-Q1,1,0,0
-Nayana-ibm,2021-Q4,0,0,0
-Nayana-ibm,2021-Q3,0,0,0
 Nayana-ibm,2021-Q2,0,0,0
 Nayana-ibm,2021-Q1,0,0,0
 Nayana-ibm,2020-Q4,0,0,0
@@ -27343,8 +23925,6 @@ Nayana-ibm,2018-Q4,1,2,0
 Nayana-ibm,2018-Q3,0,0,0
 Nayana-ibm,2018-Q2,0,0,0
 Nayana-ibm,2018-Q1,0,0,0
-卜居,2021-Q4,0,0,0
-卜居,2021-Q3,0,0,0
 卜居,2021-Q2,0,0,0
 卜居,2021-Q1,0,0,0
 卜居,2020-Q4,0,0,0
@@ -27359,8 +23939,6 @@ Nayana-ibm,2018-Q1,0,0,0
 卜居,2018-Q3,2,19,22
 卜居,2018-Q2,0,0,0
 卜居,2018-Q1,0,0,0
-lxl910915,2021-Q4,0,0,0
-lxl910915,2021-Q3,0,0,0
 lxl910915,2021-Q2,0,0,0
 lxl910915,2021-Q1,0,0,0
 lxl910915,2020-Q4,0,0,0
@@ -27375,8 +23953,6 @@ lxl910915,2018-Q4,1,3,0
 lxl910915,2018-Q3,0,0,0
 lxl910915,2018-Q2,0,0,0
 lxl910915,2018-Q1,0,0,0
-vanderliang,2021-Q4,0,0,0
-vanderliang,2021-Q3,0,0,0
 vanderliang,2021-Q2,0,0,0
 vanderliang,2021-Q1,0,0,0
 vanderliang,2020-Q4,0,0,0
@@ -27391,8 +23967,6 @@ vanderliang,2018-Q4,2,25,0
 vanderliang,2018-Q3,0,0,0
 vanderliang,2018-Q2,0,0,0
 vanderliang,2018-Q1,0,0,0
-Vidak Kazic,2021-Q4,0,0,0
-Vidak Kazic,2021-Q3,0,0,0
 Vidak Kazic,2021-Q2,0,0,0
 Vidak Kazic,2021-Q1,0,0,0
 Vidak Kazic,2020-Q4,0,0,0
@@ -27407,8 +23981,6 @@ Vidak Kazic,2018-Q4,2,62,0
 Vidak Kazic,2018-Q3,0,0,0
 Vidak Kazic,2018-Q2,0,0,0
 Vidak Kazic,2018-Q1,0,0,0
-Chris Antaki,2021-Q4,0,0,0
-Chris Antaki,2021-Q3,0,0,0
 Chris Antaki,2021-Q2,0,0,0
 Chris Antaki,2021-Q1,0,0,0
 Chris Antaki,2020-Q4,0,0,0
@@ -27423,8 +23995,6 @@ Chris Antaki,2018-Q4,2,0,2
 Chris Antaki,2018-Q3,0,0,0
 Chris Antaki,2018-Q2,0,0,0
 Chris Antaki,2018-Q1,0,0,0
-Serge Panev,2021-Q4,0,0,0
-Serge Panev,2021-Q3,0,0,0
 Serge Panev,2021-Q2,0,0,0
 Serge Panev,2021-Q1,0,0,0
 Serge Panev,2020-Q4,0,0,0
@@ -27439,8 +24009,6 @@ Serge Panev,2018-Q4,4,4,2
 Serge Panev,2018-Q3,0,0,0
 Serge Panev,2018-Q2,0,0,0
 Serge Panev,2018-Q1,0,0,0
-John Lin,2021-Q4,0,0,0
-John Lin,2021-Q3,0,0,0
 John Lin,2021-Q2,0,0,0
 John Lin,2021-Q1,0,0,0
 John Lin,2020-Q4,0,0,0
@@ -27455,8 +24023,6 @@ John Lin,2018-Q4,10,10,10
 John Lin,2018-Q3,0,0,0
 John Lin,2018-Q2,0,0,0
 John Lin,2018-Q1,0,0,0
-Neargye,2021-Q4,0,0,0
-Neargye,2021-Q3,0,0,0
 Neargye,2021-Q2,0,0,0
 Neargye,2021-Q1,0,0,0
 Neargye,2020-Q4,0,0,0
@@ -27471,8 +24037,6 @@ Neargye,2018-Q4,0,0,0
 Neargye,2018-Q3,0,0,0
 Neargye,2018-Q2,1,2,2
 Neargye,2018-Q1,0,0,0
-Younes Khoudli,2021-Q4,0,0,0
-Younes Khoudli,2021-Q3,0,0,0
 Younes Khoudli,2021-Q2,0,0,0
 Younes Khoudli,2021-Q1,0,0,0
 Younes Khoudli,2020-Q4,0,0,0
@@ -27487,8 +24051,6 @@ Younes Khoudli,2018-Q4,1,5,0
 Younes Khoudli,2018-Q3,0,0,0
 Younes Khoudli,2018-Q2,0,0,0
 Younes Khoudli,2018-Q1,0,0,0
-Leon Graser,2021-Q4,0,0,0
-Leon Graser,2021-Q3,0,0,0
 Leon Graser,2021-Q2,0,0,0
 Leon Graser,2021-Q1,0,0,0
 Leon Graser,2020-Q4,0,0,0
@@ -27503,8 +24065,6 @@ Leon Graser,2018-Q4,1,0,0
 Leon Graser,2018-Q3,0,0,0
 Leon Graser,2018-Q2,0,0,0
 Leon Graser,2018-Q1,0,0,0
-Wen yun,2021-Q4,0,0,0
-Wen yun,2021-Q3,0,0,0
 Wen yun,2021-Q2,0,0,0
 Wen yun,2021-Q1,0,0,0
 Wen yun,2020-Q4,0,0,0
@@ -27519,8 +24079,6 @@ Wen yun,2018-Q4,2,23,0
 Wen yun,2018-Q3,0,0,0
 Wen yun,2018-Q2,0,0,0
 Wen yun,2018-Q1,0,0,0
-Benjamin Tan Wei Hao,2021-Q4,0,0,0
-Benjamin Tan Wei Hao,2021-Q3,0,0,0
 Benjamin Tan Wei Hao,2021-Q2,0,0,0
 Benjamin Tan Wei Hao,2021-Q1,0,0,0
 Benjamin Tan Wei Hao,2020-Q4,0,0,0
@@ -27535,8 +24093,6 @@ Benjamin Tan Wei Hao,2018-Q4,1,0,0
 Benjamin Tan Wei Hao,2018-Q3,0,0,0
 Benjamin Tan Wei Hao,2018-Q2,0,0,0
 Benjamin Tan Wei Hao,2018-Q1,0,0,0
-qiezi,2021-Q4,0,0,0
-qiezi,2021-Q3,0,0,0
 qiezi,2021-Q2,0,0,0
 qiezi,2021-Q1,0,0,0
 qiezi,2020-Q4,0,0,0
@@ -27551,8 +24107,6 @@ qiezi,2018-Q4,1,12,0
 qiezi,2018-Q3,0,0,0
 qiezi,2018-Q2,0,0,0
 qiezi,2018-Q1,0,0,0
-Feiyang Chen,2021-Q4,0,0,0
-Feiyang Chen,2021-Q3,0,0,0
 Feiyang Chen,2021-Q2,0,0,0
 Feiyang Chen,2021-Q1,0,0,0
 Feiyang Chen,2020-Q4,0,0,0
@@ -27567,8 +24121,6 @@ Feiyang Chen,2018-Q4,1,0,0
 Feiyang Chen,2018-Q3,0,0,0
 Feiyang Chen,2018-Q2,0,0,0
 Feiyang Chen,2018-Q1,0,0,0
-Sandip Giri,2021-Q4,0,0,0
-Sandip Giri,2021-Q3,0,0,0
 Sandip Giri,2021-Q2,0,0,0
 Sandip Giri,2021-Q1,0,0,0
 Sandip Giri,2020-Q4,0,0,0
@@ -27583,8 +24135,6 @@ Sandip Giri,2018-Q4,1,0,0
 Sandip Giri,2018-Q3,0,0,0
 Sandip Giri,2018-Q2,2,5,4
 Sandip Giri,2018-Q1,0,0,0
-Rajagopal Ananthanarayanan,2021-Q4,0,0,0
-Rajagopal Ananthanarayanan,2021-Q3,0,0,0
 Rajagopal Ananthanarayanan,2021-Q2,0,0,0
 Rajagopal Ananthanarayanan,2021-Q1,0,0,0
 Rajagopal Ananthanarayanan,2020-Q4,0,0,0
@@ -27599,8 +24149,6 @@ Rajagopal Ananthanarayanan,2018-Q4,2,9,23
 Rajagopal Ananthanarayanan,2018-Q3,0,0,0
 Rajagopal Ananthanarayanan,2018-Q2,0,0,0
 Rajagopal Ananthanarayanan,2018-Q1,0,0,0
-Castiel,2021-Q4,0,0,0
-Castiel,2021-Q3,0,0,0
 Castiel,2021-Q2,0,0,0
 Castiel,2021-Q1,0,0,0
 Castiel,2020-Q4,0,0,0
@@ -27615,8 +24163,6 @@ Castiel,2018-Q4,1,2,0
 Castiel,2018-Q3,0,0,0
 Castiel,2018-Q2,0,0,0
 Castiel,2018-Q1,0,0,0
-Jonathan,2021-Q4,0,0,0
-Jonathan,2021-Q3,0,0,0
 Jonathan,2021-Q2,0,0,0
 Jonathan,2021-Q1,0,0,0
 Jonathan,2020-Q4,0,0,0
@@ -27631,8 +24177,6 @@ Jonathan,2018-Q4,1,5,5
 Jonathan,2018-Q3,2,14,8
 Jonathan,2018-Q2,0,0,0
 Jonathan,2018-Q1,0,0,0
-Cibifang,2021-Q4,0,0,0
-Cibifang,2021-Q3,0,0,0
 Cibifang,2021-Q2,0,0,0
 Cibifang,2021-Q1,0,0,0
 Cibifang,2020-Q4,0,0,0
@@ -27647,8 +24191,6 @@ Cibifang,2018-Q4,8,80,56
 Cibifang,2018-Q3,9,618,24
 Cibifang,2018-Q2,0,0,0
 Cibifang,2018-Q1,0,0,0
-akikaaa,2021-Q4,0,0,0
-akikaaa,2021-Q3,0,0,0
 akikaaa,2021-Q2,0,0,0
 akikaaa,2021-Q1,0,0,0
 akikaaa,2020-Q4,0,0,0
@@ -27663,8 +24205,6 @@ akikaaa,2018-Q4,1,0,0
 akikaaa,2018-Q3,0,0,0
 akikaaa,2018-Q2,0,0,0
 akikaaa,2018-Q1,0,0,0
-olicht,2021-Q4,0,0,0
-olicht,2021-Q3,0,0,0
 olicht,2021-Q2,0,0,0
 olicht,2021-Q1,0,0,0
 olicht,2020-Q4,0,0,0
@@ -27679,8 +24219,6 @@ olicht,2018-Q4,9,0,0
 olicht,2018-Q3,1,157,158
 olicht,2018-Q2,0,0,0
 olicht,2018-Q1,0,0,0
-zhaoyongke,2021-Q4,0,0,0
-zhaoyongke,2021-Q3,0,0,0
 zhaoyongke,2021-Q2,0,0,0
 zhaoyongke,2021-Q1,0,0,0
 zhaoyongke,2020-Q4,0,0,0
@@ -27695,8 +24233,6 @@ zhaoyongke,2018-Q4,4,238,5
 zhaoyongke,2018-Q3,1,2,0
 zhaoyongke,2018-Q2,0,0,0
 zhaoyongke,2018-Q1,0,0,0
-Ouwen Huang,2021-Q4,0,0,0
-Ouwen Huang,2021-Q3,0,0,0
 Ouwen Huang,2021-Q2,0,0,0
 Ouwen Huang,2021-Q1,0,0,0
 Ouwen Huang,2020-Q4,0,0,0
@@ -27711,8 +24247,6 @@ Ouwen Huang,2018-Q4,2,21,4
 Ouwen Huang,2018-Q3,0,0,0
 Ouwen Huang,2018-Q2,0,0,0
 Ouwen Huang,2018-Q1,0,0,0
-sahilbadyal,2021-Q4,0,0,0
-sahilbadyal,2021-Q3,0,0,0
 sahilbadyal,2021-Q2,0,0,0
 sahilbadyal,2021-Q1,0,0,0
 sahilbadyal,2020-Q4,0,0,0
@@ -27727,8 +24261,6 @@ sahilbadyal,2018-Q4,1,0,0
 sahilbadyal,2018-Q3,0,0,0
 sahilbadyal,2018-Q2,0,0,0
 sahilbadyal,2018-Q1,0,0,0
-Yash Gaurkar,2021-Q4,0,0,0
-Yash Gaurkar,2021-Q3,0,0,0
 Yash Gaurkar,2021-Q2,0,0,0
 Yash Gaurkar,2021-Q1,0,0,0
 Yash Gaurkar,2020-Q4,0,0,0
@@ -27743,8 +24275,6 @@ Yash Gaurkar,2018-Q4,1,4,4
 Yash Gaurkar,2018-Q3,0,0,0
 Yash Gaurkar,2018-Q2,0,0,0
 Yash Gaurkar,2018-Q1,0,0,0
-Vadim Borisov,2021-Q4,0,0,0
-Vadim Borisov,2021-Q3,0,0,0
 Vadim Borisov,2021-Q2,0,0,0
 Vadim Borisov,2021-Q1,0,0,0
 Vadim Borisov,2020-Q4,0,0,0
@@ -27759,8 +24289,6 @@ Vadim Borisov,2018-Q4,1,2,2
 Vadim Borisov,2018-Q3,0,0,0
 Vadim Borisov,2018-Q2,0,0,0
 Vadim Borisov,2018-Q1,0,0,0
-Anders Huss,2021-Q4,0,0,0
-Anders Huss,2021-Q3,0,0,0
 Anders Huss,2021-Q2,0,0,0
 Anders Huss,2021-Q1,0,0,0
 Anders Huss,2020-Q4,0,0,0
@@ -27775,8 +24303,6 @@ Anders Huss,2018-Q4,3,132,17
 Anders Huss,2018-Q3,0,0,0
 Anders Huss,2018-Q2,0,0,0
 Anders Huss,2018-Q1,0,0,0
-Peng Yu,2021-Q4,0,0,0
-Peng Yu,2021-Q3,0,0,0
 Peng Yu,2021-Q2,0,0,0
 Peng Yu,2021-Q1,0,0,0
 Peng Yu,2020-Q4,0,0,0
@@ -27791,8 +24317,6 @@ Peng Yu,2018-Q4,0,0,0
 Peng Yu,2018-Q3,22,761,2
 Peng Yu,2018-Q2,7,73,25
 Peng Yu,2018-Q1,2,19,12
-NEWPLAN,2021-Q4,0,0,0
-NEWPLAN,2021-Q3,0,0,0
 NEWPLAN,2021-Q2,0,0,0
 NEWPLAN,2021-Q1,0,0,0
 NEWPLAN,2020-Q4,0,0,0
@@ -27807,8 +24331,6 @@ NEWPLAN,2018-Q4,1,0,0
 NEWPLAN,2018-Q3,0,0,0
 NEWPLAN,2018-Q2,0,0,0
 NEWPLAN,2018-Q1,0,0,0
-Dustin Tran,2021-Q4,0,0,0
-Dustin Tran,2021-Q3,0,0,0
 Dustin Tran,2021-Q2,0,0,0
 Dustin Tran,2021-Q1,0,0,0
 Dustin Tran,2020-Q4,0,0,0
@@ -27823,8 +24345,6 @@ Dustin Tran,2018-Q4,2,2,2
 Dustin Tran,2018-Q3,7,70,46
 Dustin Tran,2018-Q2,50,157,82
 Dustin Tran,2018-Q1,87,5227,3574
-Daniel Hunter,2021-Q4,0,0,0
-Daniel Hunter,2021-Q3,0,0,0
 Daniel Hunter,2021-Q2,0,0,0
 Daniel Hunter,2021-Q1,0,0,0
 Daniel Hunter,2020-Q4,0,0,0
@@ -27839,8 +24359,6 @@ Daniel Hunter,2018-Q4,1,0,0
 Daniel Hunter,2018-Q3,0,0,0
 Daniel Hunter,2018-Q2,0,0,0
 Daniel Hunter,2018-Q1,0,0,0
-Ubuntu,2021-Q4,0,0,0
-Ubuntu,2021-Q3,0,0,0
 Ubuntu,2021-Q2,0,0,0
 Ubuntu,2021-Q1,0,0,0
 Ubuntu,2020-Q4,0,0,0
@@ -27855,8 +24373,6 @@ Ubuntu,2018-Q4,7,278,190
 Ubuntu,2018-Q3,0,0,0
 Ubuntu,2018-Q2,0,0,0
 Ubuntu,2018-Q1,0,0,0
-Anton Dmitriev,2021-Q4,0,0,0
-Anton Dmitriev,2021-Q3,0,0,0
 Anton Dmitriev,2021-Q2,0,0,0
 Anton Dmitriev,2021-Q1,0,0,0
 Anton Dmitriev,2020-Q4,0,0,0
@@ -27871,8 +24387,6 @@ Anton Dmitriev,2018-Q4,109,1141,909
 Anton Dmitriev,2018-Q3,91,5661,822
 Anton Dmitriev,2018-Q2,0,0,0
 Anton Dmitriev,2018-Q1,0,0,0
-zldrobit,2021-Q4,0,0,0
-zldrobit,2021-Q3,0,0,0
 zldrobit,2021-Q2,0,0,0
 zldrobit,2021-Q1,0,0,0
 zldrobit,2020-Q4,0,0,0
@@ -27887,8 +24401,6 @@ zldrobit,2018-Q4,6,67,54
 zldrobit,2018-Q3,0,0,0
 zldrobit,2018-Q2,0,0,0
 zldrobit,2018-Q1,0,0,0
-fcole,2021-Q4,0,0,0
-fcole,2021-Q3,0,0,0
 fcole,2021-Q2,0,0,0
 fcole,2021-Q1,0,0,0
 fcole,2020-Q4,0,0,0
@@ -27903,8 +24415,6 @@ fcole,2018-Q4,1,4,0
 fcole,2018-Q3,0,0,0
 fcole,2018-Q2,0,0,0
 fcole,2018-Q1,0,0,0
-dianlujitao,2021-Q4,0,0,0
-dianlujitao,2021-Q3,0,0,0
 dianlujitao,2021-Q2,0,0,0
 dianlujitao,2021-Q1,0,0,0
 dianlujitao,2020-Q4,0,0,0
@@ -27919,8 +24429,6 @@ dianlujitao,2018-Q4,3,14,9
 dianlujitao,2018-Q3,0,0,0
 dianlujitao,2018-Q2,0,0,0
 dianlujitao,2018-Q1,0,0,0
-joaak,2021-Q4,0,0,0
-joaak,2021-Q3,0,0,0
 joaak,2021-Q2,0,0,0
 joaak,2021-Q1,0,0,0
 joaak,2020-Q4,0,0,0
@@ -27935,8 +24443,6 @@ joaak,2018-Q4,2,1158,1168
 joaak,2018-Q3,0,0,0
 joaak,2018-Q2,0,0,0
 joaak,2018-Q1,0,0,0
-Grzegorz George Pawelczak,2021-Q4,0,0,0
-Grzegorz George Pawelczak,2021-Q3,0,0,0
 Grzegorz George Pawelczak,2021-Q2,0,0,0
 Grzegorz George Pawelczak,2021-Q1,0,0,0
 Grzegorz George Pawelczak,2020-Q4,0,0,0
@@ -27951,8 +24457,6 @@ Grzegorz George Pawelczak,2018-Q4,1,0,4
 Grzegorz George Pawelczak,2018-Q3,0,0,0
 Grzegorz George Pawelczak,2018-Q2,0,0,0
 Grzegorz George Pawelczak,2018-Q1,0,0,0
-Mateusz Chudyk,2021-Q4,0,0,0
-Mateusz Chudyk,2021-Q3,0,0,0
 Mateusz Chudyk,2021-Q2,0,0,0
 Mateusz Chudyk,2021-Q1,0,0,0
 Mateusz Chudyk,2020-Q4,0,0,0
@@ -27967,8 +24471,6 @@ Mateusz Chudyk,2018-Q4,4,5,5
 Mateusz Chudyk,2018-Q3,0,0,0
 Mateusz Chudyk,2018-Q2,0,0,0
 Mateusz Chudyk,2018-Q1,0,0,0
-Thor Johnsen,2021-Q4,0,0,0
-Thor Johnsen,2021-Q3,0,0,0
 Thor Johnsen,2021-Q2,0,0,0
 Thor Johnsen,2021-Q1,0,0,0
 Thor Johnsen,2020-Q4,0,0,0
@@ -27983,8 +24485,6 @@ Thor Johnsen,2018-Q4,3,2749,2727
 Thor Johnsen,2018-Q3,18,6224,436
 Thor Johnsen,2018-Q2,0,0,0
 Thor Johnsen,2018-Q1,0,0,0
-Artem Malykh,2021-Q4,0,0,0
-Artem Malykh,2021-Q3,0,0,0
 Artem Malykh,2021-Q2,0,0,0
 Artem Malykh,2021-Q1,0,0,0
 Artem Malykh,2020-Q4,0,0,0
@@ -27999,8 +24499,6 @@ Artem Malykh,2018-Q4,0,0,0
 Artem Malykh,2018-Q3,11,1211,0
 Artem Malykh,2018-Q2,0,0,0
 Artem Malykh,2018-Q1,0,0,0
-Michael,2021-Q4,0,0,0
-Michael,2021-Q3,0,0,0
 Michael,2021-Q2,0,0,0
 Michael,2021-Q1,0,0,0
 Michael,2020-Q4,0,0,0
@@ -28015,8 +24513,6 @@ Michael,2018-Q4,1,4,4
 Michael,2018-Q3,4,71,41
 Michael,2018-Q2,0,0,0
 Michael,2018-Q1,0,0,0
-Todd Wang,2021-Q4,0,0,0
-Todd Wang,2021-Q3,0,0,0
 Todd Wang,2021-Q2,0,0,0
 Todd Wang,2021-Q1,0,0,0
 Todd Wang,2020-Q4,0,0,0
@@ -28031,8 +24527,6 @@ Todd Wang,2018-Q4,187,2712,1310
 Todd Wang,2018-Q3,42,972,423
 Todd Wang,2018-Q2,0,0,0
 Todd Wang,2018-Q1,6,338,762
-HuiyangFei,2021-Q4,0,0,0
-HuiyangFei,2021-Q3,0,0,0
 HuiyangFei,2021-Q2,0,0,0
 HuiyangFei,2021-Q1,0,0,0
 HuiyangFei,2020-Q4,0,0,0
@@ -28047,8 +24541,6 @@ HuiyangFei,2018-Q4,2,0,433
 HuiyangFei,2018-Q3,2,18,16
 HuiyangFei,2018-Q2,0,0,0
 HuiyangFei,2018-Q1,0,0,0
-Javier Luraschi,2021-Q4,0,0,0
-Javier Luraschi,2021-Q3,0,0,0
 Javier Luraschi,2021-Q2,0,0,0
 Javier Luraschi,2021-Q1,0,0,0
 Javier Luraschi,2020-Q4,0,0,0
@@ -28063,8 +24555,6 @@ Javier Luraschi,2018-Q4,4,11,10
 Javier Luraschi,2018-Q3,0,0,0
 Javier Luraschi,2018-Q2,0,0,0
 Javier Luraschi,2018-Q1,0,0,0
-Pedro Monreal,2021-Q4,0,0,0
-Pedro Monreal,2021-Q3,0,0,0
 Pedro Monreal,2021-Q2,0,0,0
 Pedro Monreal,2021-Q1,0,0,0
 Pedro Monreal,2020-Q4,0,0,0
@@ -28079,8 +24569,6 @@ Pedro Monreal,2018-Q4,18,25,25
 Pedro Monreal,2018-Q3,0,0,0
 Pedro Monreal,2018-Q2,0,0,0
 Pedro Monreal,2018-Q1,0,0,0
-Daniel Visentin,2021-Q4,0,0,0
-Daniel Visentin,2021-Q3,0,0,0
 Daniel Visentin,2021-Q2,0,0,0
 Daniel Visentin,2021-Q1,0,0,0
 Daniel Visentin,2020-Q4,0,0,0
@@ -28095,8 +24583,6 @@ Daniel Visentin,2018-Q4,2,7,5
 Daniel Visentin,2018-Q3,0,0,0
 Daniel Visentin,2018-Q2,0,0,0
 Daniel Visentin,2018-Q1,0,0,0
-BY Shen,2021-Q4,0,0,0
-BY Shen,2021-Q3,0,0,0
 BY Shen,2021-Q2,0,0,0
 BY Shen,2021-Q1,0,0,0
 BY Shen,2020-Q4,0,0,0
@@ -28111,8 +24597,6 @@ BY Shen,2018-Q4,1,0,0
 BY Shen,2018-Q3,1,0,0
 BY Shen,2018-Q2,0,0,0
 BY Shen,2018-Q1,0,0,0
-margaretmz,2021-Q4,0,0,0
-margaretmz,2021-Q3,0,0,0
 margaretmz,2021-Q2,0,0,0
 margaretmz,2021-Q1,0,0,0
 margaretmz,2020-Q4,0,0,0
@@ -28127,8 +24611,6 @@ margaretmz,2018-Q4,10,2048,1064
 margaretmz,2018-Q3,2,0,694
 margaretmz,2018-Q2,0,0,0
 margaretmz,2018-Q1,0,0,0
-Rholais Lii,2021-Q4,0,0,0
-Rholais Lii,2021-Q3,0,0,0
 Rholais Lii,2021-Q2,0,0,0
 Rholais Lii,2021-Q1,0,0,0
 Rholais Lii,2020-Q4,0,0,0
@@ -28143,8 +24625,6 @@ Rholais Lii,2018-Q4,1,3,2
 Rholais Lii,2018-Q3,0,0,0
 Rholais Lii,2018-Q2,3,29,27
 Rholais Lii,2018-Q1,1,0,0
-Anna Revinskaya,2021-Q4,0,0,0
-Anna Revinskaya,2021-Q3,0,0,0
 Anna Revinskaya,2021-Q2,0,0,0
 Anna Revinskaya,2021-Q1,0,0,0
 Anna Revinskaya,2020-Q4,0,0,0
@@ -28159,8 +24639,6 @@ Anna Revinskaya,2018-Q4,4,0,31
 Anna Revinskaya,2018-Q3,0,0,0
 Anna Revinskaya,2018-Q2,0,0,0
 Anna Revinskaya,2018-Q1,0,0,0
-Jonathan J Hunt,2021-Q4,0,0,0
-Jonathan J Hunt,2021-Q3,0,0,0
 Jonathan J Hunt,2021-Q2,0,0,0
 Jonathan J Hunt,2021-Q1,0,0,0
 Jonathan J Hunt,2020-Q4,0,0,0
@@ -28175,8 +24653,6 @@ Jonathan J Hunt,2018-Q4,5,241,34
 Jonathan J Hunt,2018-Q3,5,39,15
 Jonathan J Hunt,2018-Q2,0,0,0
 Jonathan J Hunt,2018-Q1,0,0,0
-Yaniv Blumenfeld,2021-Q4,0,0,0
-Yaniv Blumenfeld,2021-Q3,0,0,0
 Yaniv Blumenfeld,2021-Q2,0,0,0
 Yaniv Blumenfeld,2021-Q1,0,0,0
 Yaniv Blumenfeld,2020-Q4,0,0,0
@@ -28191,8 +24667,6 @@ Yaniv Blumenfeld,2018-Q4,8,35,33
 Yaniv Blumenfeld,2018-Q3,0,0,0
 Yaniv Blumenfeld,2018-Q2,0,0,0
 Yaniv Blumenfeld,2018-Q1,0,0,0
-Jonathan Wyatt Hoech,2021-Q4,0,0,0
-Jonathan Wyatt Hoech,2021-Q3,0,0,0
 Jonathan Wyatt Hoech,2021-Q2,0,0,0
 Jonathan Wyatt Hoech,2021-Q1,0,0,0
 Jonathan Wyatt Hoech,2020-Q4,0,0,0
@@ -28207,8 +24681,6 @@ Jonathan Wyatt Hoech,2018-Q4,6,14,6
 Jonathan Wyatt Hoech,2018-Q3,14,429,47
 Jonathan Wyatt Hoech,2018-Q2,0,0,0
 Jonathan Wyatt Hoech,2018-Q1,0,0,0
-Palmer Lao,2021-Q4,0,0,0
-Palmer Lao,2021-Q3,0,0,0
 Palmer Lao,2021-Q2,0,0,0
 Palmer Lao,2021-Q1,0,0,0
 Palmer Lao,2020-Q4,0,0,0
@@ -28223,8 +24695,6 @@ Palmer Lao,2018-Q4,1,0,0
 Palmer Lao,2018-Q3,0,0,0
 Palmer Lao,2018-Q2,0,0,0
 Palmer Lao,2018-Q1,0,0,0
-Josh Gordon,2021-Q4,0,0,0
-Josh Gordon,2021-Q3,0,0,0
 Josh Gordon,2021-Q2,0,0,0
 Josh Gordon,2021-Q1,0,0,0
 Josh Gordon,2020-Q4,0,0,0
@@ -28239,8 +24709,6 @@ Josh Gordon,2018-Q4,2,926,1031
 Josh Gordon,2018-Q3,3,30,12
 Josh Gordon,2018-Q2,0,0,0
 Josh Gordon,2018-Q1,0,0,0
-Gitea,2021-Q4,0,0,0
-Gitea,2021-Q3,0,0,0
 Gitea,2021-Q2,0,0,0
 Gitea,2021-Q1,0,0,0
 Gitea,2020-Q4,0,0,0
@@ -28255,8 +24723,6 @@ Gitea,2018-Q4,6,12,12
 Gitea,2018-Q3,0,0,0
 Gitea,2018-Q2,0,0,0
 Gitea,2018-Q1,0,0,0
-Brendan Finan,2021-Q4,0,0,0
-Brendan Finan,2021-Q3,0,0,0
 Brendan Finan,2021-Q2,0,0,0
 Brendan Finan,2021-Q1,0,0,0
 Brendan Finan,2020-Q4,0,0,0
@@ -28271,8 +24737,6 @@ Brendan Finan,2018-Q4,1,0,0
 Brendan Finan,2018-Q3,0,0,0
 Brendan Finan,2018-Q2,0,0,0
 Brendan Finan,2018-Q1,0,0,0
-Cong Xu,2021-Q4,0,0,0
-Cong Xu,2021-Q3,0,0,0
 Cong Xu,2021-Q2,0,0,0
 Cong Xu,2021-Q1,0,0,0
 Cong Xu,2020-Q4,0,0,0
@@ -28287,8 +24751,6 @@ Cong Xu,2018-Q4,6,616,5
 Cong Xu,2018-Q3,0,0,0
 Cong Xu,2018-Q2,0,0,0
 Cong Xu,2018-Q1,0,0,0
-Roger Iyengar,2021-Q4,0,0,0
-Roger Iyengar,2021-Q3,0,0,0
 Roger Iyengar,2021-Q2,0,0,0
 Roger Iyengar,2021-Q1,0,0,0
 Roger Iyengar,2020-Q4,0,0,0
@@ -28303,8 +24765,6 @@ Roger Iyengar,2018-Q4,1,8,15
 Roger Iyengar,2018-Q3,1,0,2
 Roger Iyengar,2018-Q2,0,0,0
 Roger Iyengar,2018-Q1,0,0,0
-steven,2021-Q4,0,0,0
-steven,2021-Q3,0,0,0
 steven,2021-Q2,0,0,0
 steven,2021-Q1,0,0,0
 steven,2020-Q4,0,0,0
@@ -28319,8 +24779,6 @@ steven,2018-Q4,2,22,85
 steven,2018-Q3,8,413,2
 steven,2018-Q2,0,0,0
 steven,2018-Q1,0,0,0
-Brian Nemsick,2021-Q4,0,0,0
-Brian Nemsick,2021-Q3,0,0,0
 Brian Nemsick,2021-Q2,0,0,0
 Brian Nemsick,2021-Q1,0,0,0
 Brian Nemsick,2020-Q4,0,0,0
@@ -28335,8 +24793,6 @@ Brian Nemsick,2018-Q4,1,0,0
 Brian Nemsick,2018-Q3,0,0,0
 Brian Nemsick,2018-Q2,1,0,0
 Brian Nemsick,2018-Q1,0,0,0
-Deepak B,2021-Q4,0,0,0
-Deepak B,2021-Q3,0,0,0
 Deepak B,2021-Q2,0,0,0
 Deepak B,2021-Q1,0,0,0
 Deepak B,2020-Q4,0,0,0
@@ -28351,8 +24807,6 @@ Deepak B,2018-Q4,19,285,164
 Deepak B,2018-Q3,0,0,0
 Deepak B,2018-Q2,0,0,0
 Deepak B,2018-Q1,0,0,0
-Seunghoon Park,2021-Q4,0,0,0
-Seunghoon Park,2021-Q3,0,0,0
 Seunghoon Park,2021-Q2,0,0,0
 Seunghoon Park,2021-Q1,0,0,0
 Seunghoon Park,2020-Q4,0,0,0
@@ -28367,8 +24821,6 @@ Seunghoon Park,2018-Q4,2,24,0
 Seunghoon Park,2018-Q3,0,0,0
 Seunghoon Park,2018-Q2,0,0,0
 Seunghoon Park,2018-Q1,0,0,0
-Raghuraman Krishnamoorthi,2021-Q4,0,0,0
-Raghuraman Krishnamoorthi,2021-Q3,0,0,0
 Raghuraman Krishnamoorthi,2021-Q2,0,0,0
 Raghuraman Krishnamoorthi,2021-Q1,0,0,0
 Raghuraman Krishnamoorthi,2020-Q4,0,0,0
@@ -28383,8 +24835,6 @@ Raghuraman Krishnamoorthi,2018-Q4,6,750,186
 Raghuraman Krishnamoorthi,2018-Q3,22,940,226
 Raghuraman Krishnamoorthi,2018-Q2,4,209,68
 Raghuraman Krishnamoorthi,2018-Q1,116,3272,895
-wateryzephyr,2021-Q4,0,0,0
-wateryzephyr,2021-Q3,0,0,0
 wateryzephyr,2021-Q2,0,0,0
 wateryzephyr,2021-Q1,0,0,0
 wateryzephyr,2020-Q4,0,0,0
@@ -28399,8 +24849,6 @@ wateryzephyr,2018-Q4,1,21,12
 wateryzephyr,2018-Q3,0,0,0
 wateryzephyr,2018-Q2,0,0,0
 wateryzephyr,2018-Q1,0,0,0
-Shimin Guo,2021-Q4,0,0,0
-Shimin Guo,2021-Q3,0,0,0
 Shimin Guo,2021-Q2,0,0,0
 Shimin Guo,2021-Q1,0,0,0
 Shimin Guo,2020-Q4,0,0,0
@@ -28415,8 +24863,6 @@ Shimin Guo,2018-Q4,6,11,2
 Shimin Guo,2018-Q3,2,2,0
 Shimin Guo,2018-Q2,0,0,0
 Shimin Guo,2018-Q1,0,0,0
-Shafi Dayatar,2021-Q4,0,0,0
-Shafi Dayatar,2021-Q3,0,0,0
 Shafi Dayatar,2021-Q2,0,0,0
 Shafi Dayatar,2021-Q1,0,0,0
 Shafi Dayatar,2020-Q4,0,0,0
@@ -28431,8 +24877,6 @@ Shafi Dayatar,2018-Q4,1,13,2
 Shafi Dayatar,2018-Q3,0,0,0
 Shafi Dayatar,2018-Q2,0,0,0
 Shafi Dayatar,2018-Q1,0,0,0
-himkt,2021-Q4,0,0,0
-himkt,2021-Q3,0,0,0
 himkt,2021-Q2,0,0,0
 himkt,2021-Q1,0,0,0
 himkt,2020-Q4,0,0,0
@@ -28447,8 +24891,6 @@ himkt,2018-Q4,1,5,5
 himkt,2018-Q3,0,0,0
 himkt,2018-Q2,0,0,0
 himkt,2018-Q1,0,0,0
-knight,2021-Q4,0,0,0
-knight,2021-Q3,0,0,0
 knight,2021-Q2,0,0,0
 knight,2021-Q1,0,0,0
 knight,2020-Q4,0,0,0
@@ -28463,8 +24905,6 @@ knight,2018-Q4,3,20,21
 knight,2018-Q3,0,0,0
 knight,2018-Q2,0,0,0
 knight,2018-Q1,0,0,0
-Richard Wei,2021-Q4,0,0,0
-Richard Wei,2021-Q3,0,0,0
 Richard Wei,2021-Q2,0,0,0
 Richard Wei,2021-Q1,0,0,0
 Richard Wei,2020-Q4,0,0,0
@@ -28479,8 +24919,6 @@ Richard Wei,2018-Q4,1,0,0
 Richard Wei,2018-Q3,2,18,0
 Richard Wei,2018-Q2,4,38,84
 Richard Wei,2018-Q1,3,4,0
-Alexis Louis,2021-Q4,0,0,0
-Alexis Louis,2021-Q3,0,0,0
 Alexis Louis,2021-Q2,0,0,0
 Alexis Louis,2021-Q1,0,0,0
 Alexis Louis,2020-Q4,0,0,0
@@ -28495,8 +24933,6 @@ Alexis Louis,2018-Q4,1,3,3
 Alexis Louis,2018-Q3,0,0,0
 Alexis Louis,2018-Q2,0,0,0
 Alexis Louis,2018-Q1,0,0,0
-rachellj218,2021-Q4,0,0,0
-rachellj218,2021-Q3,0,0,0
 rachellj218,2021-Q2,0,0,0
 rachellj218,2021-Q1,0,0,0
 rachellj218,2020-Q4,0,0,0
@@ -28511,8 +24947,6 @@ rachellj218,2018-Q4,1,7,0
 rachellj218,2018-Q3,0,0,0
 rachellj218,2018-Q2,0,0,0
 rachellj218,2018-Q1,0,0,0
-Jason Furmanek,2021-Q4,0,0,0
-Jason Furmanek,2021-Q3,0,0,0
 Jason Furmanek,2021-Q2,0,0,0
 Jason Furmanek,2021-Q1,0,0,0
 Jason Furmanek,2020-Q4,0,0,0
@@ -28527,8 +24961,6 @@ Jason Furmanek,2018-Q4,1,10,0
 Jason Furmanek,2018-Q3,6,116,49
 Jason Furmanek,2018-Q2,0,0,0
 Jason Furmanek,2018-Q1,0,0,0
-Muhammad Wildan,2021-Q4,0,0,0
-Muhammad Wildan,2021-Q3,0,0,0
 Muhammad Wildan,2021-Q2,0,0,0
 Muhammad Wildan,2021-Q1,0,0,0
 Muhammad Wildan,2020-Q4,0,0,0
@@ -28543,8 +24975,6 @@ Muhammad Wildan,2018-Q4,4,13,2
 Muhammad Wildan,2018-Q3,0,0,0
 Muhammad Wildan,2018-Q2,0,0,0
 Muhammad Wildan,2018-Q1,0,0,0
-Scott Leishman,2021-Q4,0,0,0
-Scott Leishman,2021-Q3,0,0,0
 Scott Leishman,2021-Q2,0,0,0
 Scott Leishman,2021-Q1,0,0,0
 Scott Leishman,2020-Q4,0,0,0
@@ -28559,8 +24989,6 @@ Scott Leishman,2018-Q4,2,6,2
 Scott Leishman,2018-Q3,0,0,0
 Scott Leishman,2018-Q2,0,0,0
 Scott Leishman,2018-Q1,0,0,0
-Pavel Sountsov,2021-Q4,0,0,0
-Pavel Sountsov,2021-Q3,0,0,0
 Pavel Sountsov,2021-Q2,0,0,0
 Pavel Sountsov,2021-Q1,0,0,0
 Pavel Sountsov,2020-Q4,0,0,0
@@ -28575,8 +25003,6 @@ Pavel Sountsov,2018-Q4,2,85,78
 Pavel Sountsov,2018-Q3,0,0,0
 Pavel Sountsov,2018-Q2,0,0,0
 Pavel Sountsov,2018-Q1,0,0,0
-Makoto Uchida,2021-Q4,0,0,0
-Makoto Uchida,2021-Q3,0,0,0
 Makoto Uchida,2021-Q2,0,0,0
 Makoto Uchida,2021-Q1,0,0,0
 Makoto Uchida,2020-Q4,0,0,0
@@ -28591,8 +25017,6 @@ Makoto Uchida,2018-Q4,1,0,0
 Makoto Uchida,2018-Q3,0,0,0
 Makoto Uchida,2018-Q2,0,0,0
 Makoto Uchida,2018-Q1,3,17,7
-Marcela Morales Quispe,2021-Q4,0,0,0
-Marcela Morales Quispe,2021-Q3,0,0,0
 Marcela Morales Quispe,2021-Q2,0,0,0
 Marcela Morales Quispe,2021-Q1,0,0,0
 Marcela Morales Quispe,2020-Q4,0,0,0
@@ -28607,8 +25031,6 @@ Marcela Morales Quispe,2018-Q4,2,12,9
 Marcela Morales Quispe,2018-Q3,0,0,0
 Marcela Morales Quispe,2018-Q2,0,0,0
 Marcela Morales Quispe,2018-Q1,0,0,0
-jackonan,2021-Q4,0,0,0
-jackonan,2021-Q3,0,0,0
 jackonan,2021-Q2,0,0,0
 jackonan,2021-Q1,0,0,0
 jackonan,2020-Q4,0,0,0
@@ -28623,8 +25045,6 @@ jackonan,2018-Q4,2,2,2
 jackonan,2018-Q3,2,6,2
 jackonan,2018-Q2,0,0,0
 jackonan,2018-Q1,0,0,0
-Nehal J Wani,2021-Q4,0,0,0
-Nehal J Wani,2021-Q3,0,0,0
 Nehal J Wani,2021-Q2,0,0,0
 Nehal J Wani,2021-Q1,0,0,0
 Nehal J Wani,2020-Q4,0,0,0
@@ -28639,8 +25059,6 @@ Nehal J Wani,2018-Q4,1,2,0
 Nehal J Wani,2018-Q3,1,2,2
 Nehal J Wani,2018-Q2,2,0,0
 Nehal J Wani,2018-Q1,0,0,0
-Yicheng Fan,2021-Q4,0,0,0
-Yicheng Fan,2021-Q3,0,0,0
 Yicheng Fan,2021-Q2,0,0,0
 Yicheng Fan,2021-Q1,0,0,0
 Yicheng Fan,2020-Q4,0,0,0
@@ -28655,8 +25073,6 @@ Yicheng Fan,2018-Q4,2,0,4
 Yicheng Fan,2018-Q3,8,102,121
 Yicheng Fan,2018-Q2,0,0,0
 Yicheng Fan,2018-Q1,0,0,0
-shengfuintel,2021-Q4,0,0,0
-shengfuintel,2021-Q3,0,0,0
 shengfuintel,2021-Q2,0,0,0
 shengfuintel,2021-Q1,0,0,0
 shengfuintel,2020-Q4,0,0,0
@@ -28671,8 +25087,6 @@ shengfuintel,2018-Q4,2,0,4041
 shengfuintel,2018-Q3,0,0,0
 shengfuintel,2018-Q2,1,16,19
 shengfuintel,2018-Q1,1,25,27
-Andreas Madsen,2021-Q4,0,0,0
-Andreas Madsen,2021-Q3,0,0,0
 Andreas Madsen,2021-Q2,0,0,0
 Andreas Madsen,2021-Q1,0,0,0
 Andreas Madsen,2020-Q4,0,0,0
@@ -28687,8 +25101,6 @@ Andreas Madsen,2018-Q4,0,0,0
 Andreas Madsen,2018-Q3,4,178,11
 Andreas Madsen,2018-Q2,0,0,0
 Andreas Madsen,2018-Q1,0,0,0
-Tingbo Lu,2021-Q4,0,0,0
-Tingbo Lu,2021-Q3,0,0,0
 Tingbo Lu,2021-Q2,0,0,0
 Tingbo Lu,2021-Q1,0,0,0
 Tingbo Lu,2020-Q4,0,0,0
@@ -28703,8 +25115,6 @@ Tingbo Lu,2018-Q4,1,0,0
 Tingbo Lu,2018-Q3,0,0,0
 Tingbo Lu,2018-Q2,0,0,0
 Tingbo Lu,2018-Q1,0,0,0
-Andrew Banchich,2021-Q4,0,0,0
-Andrew Banchich,2021-Q3,0,0,0
 Andrew Banchich,2021-Q2,0,0,0
 Andrew Banchich,2021-Q1,0,0,0
 Andrew Banchich,2020-Q4,0,0,0
@@ -28719,8 +25129,6 @@ Andrew Banchich,2018-Q4,1,0,0
 Andrew Banchich,2018-Q3,0,0,0
 Andrew Banchich,2018-Q2,0,0,0
 Andrew Banchich,2018-Q1,0,0,0
-YongJoon Lee,2021-Q4,0,0,0
-YongJoon Lee,2021-Q3,0,0,0
 YongJoon Lee,2021-Q2,0,0,0
 YongJoon Lee,2021-Q1,0,0,0
 YongJoon Lee,2020-Q4,0,0,0
@@ -28735,8 +25143,6 @@ YongJoon Lee,2018-Q4,3,5,5
 YongJoon Lee,2018-Q3,0,0,0
 YongJoon Lee,2018-Q2,0,0,0
 YongJoon Lee,2018-Q1,0,0,0
-Christopher Olston,2021-Q4,0,0,0
-Christopher Olston,2021-Q3,0,0,0
 Christopher Olston,2021-Q2,0,0,0
 Christopher Olston,2021-Q1,0,0,0
 Christopher Olston,2020-Q4,0,0,0
@@ -28751,8 +25157,6 @@ Christopher Olston,2018-Q4,11,0,266
 Christopher Olston,2018-Q3,3,67,8
 Christopher Olston,2018-Q2,0,0,0
 Christopher Olston,2018-Q1,0,0,0
-joe yearsley,2021-Q4,0,0,0
-joe yearsley,2021-Q3,0,0,0
 joe yearsley,2021-Q2,0,0,0
 joe yearsley,2021-Q1,0,0,0
 joe yearsley,2020-Q4,0,0,0
@@ -28767,8 +25171,6 @@ joe yearsley,2018-Q4,3,5,5
 joe yearsley,2018-Q3,0,0,0
 joe yearsley,2018-Q2,0,0,0
 joe yearsley,2018-Q1,0,0,0
-Joe Yearsley,2021-Q4,0,0,0
-Joe Yearsley,2021-Q3,0,0,0
 Joe Yearsley,2021-Q2,0,0,0
 Joe Yearsley,2021-Q1,0,0,0
 Joe Yearsley,2020-Q4,0,0,0
@@ -28783,8 +25185,6 @@ Joe Yearsley,2018-Q4,0,0,0
 Joe Yearsley,2018-Q3,4,8,4
 Joe Yearsley,2018-Q2,2,0,0
 Joe Yearsley,2018-Q1,4,15,3
-josephyearsley,2021-Q4,0,0,0
-josephyearsley,2021-Q3,0,0,0
 josephyearsley,2021-Q2,0,0,0
 josephyearsley,2021-Q1,0,0,0
 josephyearsley,2020-Q4,0,0,0
@@ -28799,8 +25199,6 @@ josephyearsley,2018-Q4,0,0,0
 josephyearsley,2018-Q3,3,2,6
 josephyearsley,2018-Q2,1,4,2
 josephyearsley,2018-Q1,5,41,6
-lanhin,2021-Q4,0,0,0
-lanhin,2021-Q3,0,0,0
 lanhin,2021-Q2,0,0,0
 lanhin,2021-Q1,0,0,0
 lanhin,2020-Q4,0,0,0
@@ -28815,8 +25213,6 @@ lanhin,2018-Q4,0,0,0
 lanhin,2018-Q3,1,0,0
 lanhin,2018-Q2,0,0,0
 lanhin,2018-Q1,0,0,0
-knightXun,2021-Q4,0,0,0
-knightXun,2021-Q3,0,0,0
 knightXun,2021-Q2,0,0,0
 knightXun,2021-Q1,0,0,0
 knightXun,2020-Q4,0,0,0
@@ -28831,8 +25227,6 @@ knightXun,2018-Q4,0,0,0
 knightXun,2018-Q3,1,3,0
 knightXun,2018-Q2,0,0,0
 knightXun,2018-Q1,0,0,0
-Piotr Padlewski,2021-Q4,0,0,0
-Piotr Padlewski,2021-Q3,0,0,0
 Piotr Padlewski,2021-Q2,0,0,0
 Piotr Padlewski,2021-Q1,0,0,0
 Piotr Padlewski,2020-Q4,0,0,0
@@ -28847,8 +25241,6 @@ Piotr Padlewski,2018-Q4,0,0,0
 Piotr Padlewski,2018-Q3,149,6166,1608
 Piotr Padlewski,2018-Q2,0,0,0
 Piotr Padlewski,2018-Q1,0,0,0
-franklin5,2021-Q4,0,0,0
-franklin5,2021-Q3,0,0,0
 franklin5,2021-Q2,0,0,0
 franklin5,2021-Q1,0,0,0
 franklin5,2020-Q4,0,0,0
@@ -28863,8 +25255,6 @@ franklin5,2018-Q4,0,0,0
 franklin5,2018-Q3,2,4,4
 franklin5,2018-Q2,0,0,0
 franklin5,2018-Q1,0,0,0
-Rin Arakaki,2021-Q4,0,0,0
-Rin Arakaki,2021-Q3,0,0,0
 Rin Arakaki,2021-Q2,0,0,0
 Rin Arakaki,2021-Q1,0,0,0
 Rin Arakaki,2020-Q4,0,0,0
@@ -28879,8 +25269,6 @@ Rin Arakaki,2018-Q4,0,0,0
 Rin Arakaki,2018-Q3,3,4,4
 Rin Arakaki,2018-Q2,0,0,0
 Rin Arakaki,2018-Q1,0,0,0
-IMBurbank,2021-Q4,0,0,0
-IMBurbank,2021-Q3,0,0,0
 IMBurbank,2021-Q2,0,0,0
 IMBurbank,2021-Q1,0,0,0
 IMBurbank,2020-Q4,0,0,0
@@ -28895,8 +25283,6 @@ IMBurbank,2018-Q4,0,0,0
 IMBurbank,2018-Q3,39,346,95
 IMBurbank,2018-Q2,0,0,0
 IMBurbank,2018-Q1,0,0,0
-Dave Airlie,2021-Q4,0,0,0
-Dave Airlie,2021-Q3,0,0,0
 Dave Airlie,2021-Q2,0,0,0
 Dave Airlie,2021-Q1,0,0,0
 Dave Airlie,2020-Q4,0,0,0
@@ -28911,8 +25297,6 @@ Dave Airlie,2018-Q4,0,0,0
 Dave Airlie,2018-Q3,3,3,0
 Dave Airlie,2018-Q2,0,0,0
 Dave Airlie,2018-Q1,0,0,0
-William Irons,2021-Q4,0,0,0
-William Irons,2021-Q3,0,0,0
 William Irons,2021-Q2,0,0,0
 William Irons,2021-Q1,0,0,0
 William Irons,2020-Q4,0,0,0
@@ -28927,8 +25311,6 @@ William Irons,2018-Q4,0,0,0
 William Irons,2018-Q3,1,2,0
 William Irons,2018-Q2,0,0,0
 William Irons,2018-Q1,0,0,0
-Isaac Burbank,2021-Q4,0,0,0
-Isaac Burbank,2021-Q3,0,0,0
 Isaac Burbank,2021-Q2,0,0,0
 Isaac Burbank,2021-Q1,0,0,0
 Isaac Burbank,2020-Q4,0,0,0
@@ -28943,8 +25325,6 @@ Isaac Burbank,2018-Q4,0,0,0
 Isaac Burbank,2018-Q3,2,0,78
 Isaac Burbank,2018-Q2,0,0,0
 Isaac Burbank,2018-Q1,0,0,0
-Richard Yu,2021-Q4,0,0,0
-Richard Yu,2021-Q3,0,0,0
 Richard Yu,2021-Q2,0,0,0
 Richard Yu,2021-Q1,0,0,0
 Richard Yu,2020-Q4,0,0,0
@@ -28959,8 +25339,6 @@ Richard Yu,2018-Q4,0,0,0
 Richard Yu,2018-Q3,4,9,9
 Richard Yu,2018-Q2,0,0,0
 Richard Yu,2018-Q1,0,0,0
-Debidatta Dwibedi,2021-Q4,0,0,0
-Debidatta Dwibedi,2021-Q3,0,0,0
 Debidatta Dwibedi,2021-Q2,0,0,0
 Debidatta Dwibedi,2021-Q1,0,0,0
 Debidatta Dwibedi,2020-Q4,0,0,0
@@ -28975,8 +25353,6 @@ Debidatta Dwibedi,2018-Q4,0,0,0
 Debidatta Dwibedi,2018-Q3,3,39,5
 Debidatta Dwibedi,2018-Q2,0,0,0
 Debidatta Dwibedi,2018-Q1,0,0,0
-Steven,2021-Q4,0,0,0
-Steven,2021-Q3,0,0,0
 Steven,2021-Q2,0,0,0
 Steven,2021-Q1,0,0,0
 Steven,2020-Q4,0,0,0
@@ -28991,8 +25367,6 @@ Steven,2018-Q4,0,0,0
 Steven,2018-Q3,10,500,26
 Steven,2018-Q2,0,0,0
 Steven,2018-Q1,0,0,0
-Yutaka Leon,2021-Q4,0,0,0
-Yutaka Leon,2021-Q3,0,0,0
 Yutaka Leon,2021-Q2,0,0,0
 Yutaka Leon,2021-Q1,0,0,0
 Yutaka Leon,2020-Q4,0,0,0
@@ -29007,8 +25381,6 @@ Yutaka Leon,2018-Q4,0,0,0
 Yutaka Leon,2018-Q3,2,72,38
 Yutaka Leon,2018-Q2,0,0,0
 Yutaka Leon,2018-Q1,1,13,0
-Dougal J. Sutherland,2021-Q4,0,0,0
-Dougal J. Sutherland,2021-Q3,0,0,0
 Dougal J. Sutherland,2021-Q2,0,0,0
 Dougal J. Sutherland,2021-Q1,0,0,0
 Dougal J. Sutherland,2020-Q4,0,0,0
@@ -29023,8 +25395,6 @@ Dougal J. Sutherland,2018-Q4,0,0,0
 Dougal J. Sutherland,2018-Q3,3,476,3
 Dougal J. Sutherland,2018-Q2,0,0,0
 Dougal J. Sutherland,2018-Q1,0,0,0
-Roland Fernandez,2021-Q4,0,0,0
-Roland Fernandez,2021-Q3,0,0,0
 Roland Fernandez,2021-Q2,0,0,0
 Roland Fernandez,2021-Q1,0,0,0
 Roland Fernandez,2020-Q4,0,0,0
@@ -29039,8 +25409,6 @@ Roland Fernandez,2018-Q4,0,0,0
 Roland Fernandez,2018-Q3,1,0,0
 Roland Fernandez,2018-Q2,0,0,0
 Roland Fernandez,2018-Q1,0,0,0
-Elms,2021-Q4,0,0,0
-Elms,2021-Q3,0,0,0
 Elms,2021-Q2,0,0,0
 Elms,2021-Q1,0,0,0
 Elms,2020-Q4,0,0,0
@@ -29055,8 +25423,6 @@ Elms,2018-Q4,0,0,0
 Elms,2018-Q3,1,0,0
 Elms,2018-Q2,0,0,0
 Elms,2018-Q1,0,0,0
-Yanbo Liang,2021-Q4,0,0,0
-Yanbo Liang,2021-Q3,0,0,0
 Yanbo Liang,2021-Q2,0,0,0
 Yanbo Liang,2021-Q1,0,0,0
 Yanbo Liang,2020-Q4,0,0,0
@@ -29071,8 +25437,6 @@ Yanbo Liang,2018-Q4,0,0,0
 Yanbo Liang,2018-Q3,16,166,53
 Yanbo Liang,2018-Q2,1,2,2
 Yanbo Liang,2018-Q1,0,0,0
-manipopopo,2021-Q4,0,0,0
-manipopopo,2021-Q3,0,0,0
 manipopopo,2021-Q2,0,0,0
 manipopopo,2021-Q1,0,0,0
 manipopopo,2020-Q4,0,0,0
@@ -29087,8 +25451,6 @@ manipopopo,2018-Q4,0,0,0
 manipopopo,2018-Q3,0,0,0
 manipopopo,2018-Q2,4,84,41
 manipopopo,2018-Q1,0,0,0
-Shujian2015,2021-Q4,0,0,0
-Shujian2015,2021-Q3,0,0,0
 Shujian2015,2021-Q2,0,0,0
 Shujian2015,2021-Q1,0,0,0
 Shujian2015,2020-Q4,0,0,0
@@ -29103,8 +25465,6 @@ Shujian2015,2018-Q4,0,0,0
 Shujian2015,2018-Q3,1,3,4
 Shujian2015,2018-Q2,0,0,0
 Shujian2015,2018-Q1,0,0,0
-Moritz Kröger,2021-Q4,0,0,0
-Moritz Kröger,2021-Q3,0,0,0
 Moritz Kröger,2021-Q2,0,0,0
 Moritz Kröger,2021-Q1,0,0,0
 Moritz Kröger,2020-Q4,0,0,0
@@ -29119,8 +25479,6 @@ Moritz Kröger,2018-Q4,0,0,0
 Moritz Kröger,2018-Q3,1,5,4
 Moritz Kröger,2018-Q2,0,0,0
 Moritz Kröger,2018-Q1,0,0,0
-David G. Andersen,2021-Q4,0,0,0
-David G. Andersen,2021-Q3,0,0,0
 David G. Andersen,2021-Q2,0,0,0
 David G. Andersen,2021-Q1,0,0,0
 David G. Andersen,2020-Q4,0,0,0
@@ -29135,8 +25493,6 @@ David G. Andersen,2018-Q4,0,0,0
 David G. Andersen,2018-Q3,2,47,0
 David G. Andersen,2018-Q2,3,38,0
 David G. Andersen,2018-Q1,5,64,12
-Max Pumperla,2021-Q4,0,0,0
-Max Pumperla,2021-Q3,0,0,0
 Max Pumperla,2021-Q2,0,0,0
 Max Pumperla,2021-Q1,0,0,0
 Max Pumperla,2020-Q4,0,0,0
@@ -29151,8 +25507,6 @@ Max Pumperla,2018-Q4,0,0,0
 Max Pumperla,2018-Q3,1,38,38
 Max Pumperla,2018-Q2,0,0,0
 Max Pumperla,2018-Q1,0,0,0
-Akshay Agrawal,2021-Q4,0,0,0
-Akshay Agrawal,2021-Q3,0,0,0
 Akshay Agrawal,2021-Q2,0,0,0
 Akshay Agrawal,2021-Q1,0,0,0
 Akshay Agrawal,2020-Q4,0,0,0
@@ -29167,8 +25521,6 @@ Akshay Agrawal,2018-Q4,0,0,0
 Akshay Agrawal,2018-Q3,98,2858,3258
 Akshay Agrawal,2018-Q2,54,1709,518
 Akshay Agrawal,2018-Q1,80,1747,564
-Samuel Matzek,2021-Q4,0,0,0
-Samuel Matzek,2021-Q3,0,0,0
 Samuel Matzek,2021-Q2,0,0,0
 Samuel Matzek,2021-Q1,0,0,0
 Samuel Matzek,2020-Q4,0,0,0
@@ -29183,8 +25535,6 @@ Samuel Matzek,2018-Q4,0,0,0
 Samuel Matzek,2018-Q3,6,85,33
 Samuel Matzek,2018-Q2,0,0,0
 Samuel Matzek,2018-Q1,0,0,0
-Jenny Sahng,2021-Q4,0,0,0
-Jenny Sahng,2021-Q3,0,0,0
 Jenny Sahng,2021-Q2,0,0,0
 Jenny Sahng,2021-Q1,0,0,0
 Jenny Sahng,2020-Q4,0,0,0
@@ -29199,8 +25549,6 @@ Jenny Sahng,2018-Q4,0,0,0
 Jenny Sahng,2018-Q3,2,2,2
 Jenny Sahng,2018-Q2,0,0,0
 Jenny Sahng,2018-Q1,0,0,0
-leondgarse,2021-Q4,0,0,0
-leondgarse,2021-Q3,0,0,0
 leondgarse,2021-Q2,0,0,0
 leondgarse,2021-Q1,0,0,0
 leondgarse,2020-Q4,0,0,0
@@ -29215,8 +25563,6 @@ leondgarse,2018-Q4,0,0,0
 leondgarse,2018-Q3,3,2,9
 leondgarse,2018-Q2,0,0,0
 leondgarse,2018-Q1,0,0,0
-(David) Siu-Kei Muk,2021-Q4,0,0,0
-(David) Siu-Kei Muk,2021-Q3,0,0,0
 (David) Siu-Kei Muk,2021-Q2,0,0,0
 (David) Siu-Kei Muk,2021-Q1,0,0,0
 (David) Siu-Kei Muk,2020-Q4,0,0,0
@@ -29231,8 +25577,6 @@ leondgarse,2018-Q1,0,0,0
 (David) Siu-Kei Muk,2018-Q3,1,2,0
 (David) Siu-Kei Muk,2018-Q2,4,10,4
 (David) Siu-Kei Muk,2018-Q1,6,101,94
-Rasmi Elasmar,2021-Q4,0,0,0
-Rasmi Elasmar,2021-Q3,0,0,0
 Rasmi Elasmar,2021-Q2,0,0,0
 Rasmi Elasmar,2021-Q1,0,0,0
 Rasmi Elasmar,2020-Q4,0,0,0
@@ -29247,8 +25591,6 @@ Rasmi Elasmar,2018-Q4,0,0,0
 Rasmi Elasmar,2018-Q3,4,10,0
 Rasmi Elasmar,2018-Q2,0,0,0
 Rasmi Elasmar,2018-Q1,0,0,0
-Joppe Geluykens,2021-Q4,0,0,0
-Joppe Geluykens,2021-Q3,0,0,0
 Joppe Geluykens,2021-Q2,0,0,0
 Joppe Geluykens,2021-Q1,0,0,0
 Joppe Geluykens,2020-Q4,0,0,0
@@ -29263,8 +25605,6 @@ Joppe Geluykens,2018-Q4,0,0,0
 Joppe Geluykens,2018-Q3,2,4,3
 Joppe Geluykens,2018-Q2,0,0,0
 Joppe Geluykens,2018-Q1,0,0,0
-hellcom,2021-Q4,0,0,0
-hellcom,2021-Q3,0,0,0
 hellcom,2021-Q2,0,0,0
 hellcom,2021-Q1,0,0,0
 hellcom,2020-Q4,0,0,0
@@ -29279,8 +25619,6 @@ hellcom,2018-Q4,0,0,0
 hellcom,2018-Q3,1,0,0
 hellcom,2018-Q2,0,0,0
 hellcom,2018-Q1,0,0,0
-Johannes Bannhofer,2021-Q4,0,0,0
-Johannes Bannhofer,2021-Q3,0,0,0
 Johannes Bannhofer,2021-Q2,0,0,0
 Johannes Bannhofer,2021-Q1,0,0,0
 Johannes Bannhofer,2020-Q4,0,0,0
@@ -29295,8 +25633,6 @@ Johannes Bannhofer,2018-Q4,0,0,0
 Johannes Bannhofer,2018-Q3,1,0,0
 Johannes Bannhofer,2018-Q2,0,0,0
 Johannes Bannhofer,2018-Q1,0,0,0
-Olivia Nordquist,2021-Q4,0,0,0
-Olivia Nordquist,2021-Q3,0,0,0
 Olivia Nordquist,2021-Q2,0,0,0
 Olivia Nordquist,2021-Q1,0,0,0
 Olivia Nordquist,2020-Q4,0,0,0
@@ -29311,8 +25647,6 @@ Olivia Nordquist,2018-Q4,0,0,0
 Olivia Nordquist,2018-Q3,15,137,122
 Olivia Nordquist,2018-Q2,5,7,7
 Olivia Nordquist,2018-Q1,21,160,28
-Smokrow,2021-Q4,0,0,0
-Smokrow,2021-Q3,0,0,0
 Smokrow,2021-Q2,0,0,0
 Smokrow,2021-Q1,0,0,0
 Smokrow,2020-Q4,0,0,0
@@ -29327,8 +25661,6 @@ Smokrow,2018-Q4,0,0,0
 Smokrow,2018-Q3,3,20,5
 Smokrow,2018-Q2,0,0,0
 Smokrow,2018-Q1,0,0,0
-pengwa,2021-Q4,0,0,0
-pengwa,2021-Q3,0,0,0
 pengwa,2021-Q2,0,0,0
 pengwa,2021-Q1,0,0,0
 pengwa,2020-Q4,0,0,0
@@ -29343,8 +25675,6 @@ pengwa,2018-Q4,0,0,0
 pengwa,2018-Q3,16,25,46
 pengwa,2018-Q2,0,0,0
 pengwa,2018-Q1,0,0,0
-Edvard Fagerholm,2021-Q4,0,0,0
-Edvard Fagerholm,2021-Q3,0,0,0
 Edvard Fagerholm,2021-Q2,0,0,0
 Edvard Fagerholm,2021-Q1,0,0,0
 Edvard Fagerholm,2020-Q4,0,0,0
@@ -29359,8 +25689,6 @@ Edvard Fagerholm,2018-Q4,0,0,0
 Edvard Fagerholm,2018-Q3,1,7,2
 Edvard Fagerholm,2018-Q2,0,0,0
 Edvard Fagerholm,2018-Q1,0,0,0
-Jonathan Homer,2021-Q4,0,0,0
-Jonathan Homer,2021-Q3,0,0,0
 Jonathan Homer,2021-Q2,0,0,0
 Jonathan Homer,2021-Q1,0,0,0
 Jonathan Homer,2020-Q4,0,0,0
@@ -29375,8 +25703,6 @@ Jonathan Homer,2018-Q4,0,0,0
 Jonathan Homer,2018-Q3,1,3,3
 Jonathan Homer,2018-Q2,0,0,0
 Jonathan Homer,2018-Q1,0,0,0
-在原佐为,2021-Q4,0,0,0
-在原佐为,2021-Q3,0,0,0
 在原佐为,2021-Q2,0,0,0
 在原佐为,2021-Q1,0,0,0
 在原佐为,2020-Q4,0,0,0
@@ -29391,8 +25717,6 @@ Jonathan Homer,2018-Q1,0,0,0
 在原佐为,2018-Q3,4,3,3
 在原佐为,2018-Q2,0,0,0
 在原佐为,2018-Q1,0,0,0
-Vinícius Camargo,2021-Q4,0,0,0
-Vinícius Camargo,2021-Q3,0,0,0
 Vinícius Camargo,2021-Q2,0,0,0
 Vinícius Camargo,2021-Q1,0,0,0
 Vinícius Camargo,2020-Q4,0,0,0
@@ -29407,8 +25731,6 @@ Vinícius Camargo,2018-Q4,0,0,0
 Vinícius Camargo,2018-Q3,1,3,3
 Vinícius Camargo,2018-Q2,0,0,0
 Vinícius Camargo,2018-Q1,0,0,0
-Roger Xin,2021-Q4,0,0,0
-Roger Xin,2021-Q3,0,0,0
 Roger Xin,2021-Q2,0,0,0
 Roger Xin,2021-Q1,0,0,0
 Roger Xin,2020-Q4,0,0,0
@@ -29423,8 +25745,6 @@ Roger Xin,2018-Q4,0,0,0
 Roger Xin,2018-Q3,1,2,2
 Roger Xin,2018-Q2,0,0,0
 Roger Xin,2018-Q1,0,0,0
-Sangjung Woo,2021-Q4,0,0,0
-Sangjung Woo,2021-Q3,0,0,0
 Sangjung Woo,2021-Q2,0,0,0
 Sangjung Woo,2021-Q1,0,0,0
 Sangjung Woo,2020-Q4,0,0,0
@@ -29439,8 +25759,6 @@ Sangjung Woo,2018-Q4,0,0,0
 Sangjung Woo,2018-Q3,1,0,0
 Sangjung Woo,2018-Q2,0,0,0
 Sangjung Woo,2018-Q1,0,0,0
-coder3101,2021-Q4,0,0,0
-coder3101,2021-Q3,0,0,0
 coder3101,2021-Q2,0,0,0
 coder3101,2021-Q1,0,0,0
 coder3101,2020-Q4,0,0,0
@@ -29455,8 +25773,6 @@ coder3101,2018-Q4,0,0,0
 coder3101,2018-Q3,2,8,8
 coder3101,2018-Q2,0,0,0
 coder3101,2018-Q1,0,0,0
-Patrik Sundberg,2021-Q4,0,0,0
-Patrik Sundberg,2021-Q3,0,0,0
 Patrik Sundberg,2021-Q2,0,0,0
 Patrik Sundberg,2021-Q1,0,0,0
 Patrik Sundberg,2020-Q4,0,0,0
@@ -29471,8 +25787,6 @@ Patrik Sundberg,2018-Q4,0,0,0
 Patrik Sundberg,2018-Q3,15,2507,589
 Patrik Sundberg,2018-Q2,0,0,0
 Patrik Sundberg,2018-Q1,0,0,0
-Naurril,2021-Q4,0,0,0
-Naurril,2021-Q3,0,0,0
 Naurril,2021-Q2,0,0,0
 Naurril,2021-Q1,0,0,0
 Naurril,2020-Q4,0,0,0
@@ -29487,8 +25801,6 @@ Naurril,2018-Q4,0,0,0
 Naurril,2018-Q3,1,0,0
 Naurril,2018-Q2,0,0,0
 Naurril,2018-Q1,0,0,0
-Ming Li,2021-Q4,0,0,0
-Ming Li,2021-Q3,0,0,0
 Ming Li,2021-Q2,0,0,0
 Ming Li,2021-Q1,0,0,0
 Ming Li,2020-Q4,0,0,0
@@ -29503,8 +25815,6 @@ Ming Li,2018-Q4,0,0,0
 Ming Li,2018-Q3,1,0,0
 Ming Li,2018-Q2,0,0,0
 Ming Li,2018-Q1,1,0,0
-naurril,2021-Q4,0,0,0
-naurril,2021-Q3,0,0,0
 naurril,2021-Q2,0,0,0
 naurril,2021-Q1,0,0,0
 naurril,2020-Q4,0,0,0
@@ -29519,8 +25829,6 @@ naurril,2018-Q4,0,0,0
 naurril,2018-Q3,7,63,46
 naurril,2018-Q2,0,0,0
 naurril,2018-Q1,0,0,0
-Yao Zhang,2021-Q4,0,0,0
-Yao Zhang,2021-Q3,0,0,0
 Yao Zhang,2021-Q2,0,0,0
 Yao Zhang,2021-Q1,0,0,0
 Yao Zhang,2020-Q4,0,0,0
@@ -29535,8 +25843,6 @@ Yao Zhang,2018-Q4,0,0,0
 Yao Zhang,2018-Q3,25,5546,0
 Yao Zhang,2018-Q2,16,301,149
 Yao Zhang,2018-Q1,58,1497,489
-weidankong,2021-Q4,0,0,0
-weidankong,2021-Q3,0,0,0
 weidankong,2021-Q2,0,0,0
 weidankong,2021-Q1,0,0,0
 weidankong,2020-Q4,0,0,0
@@ -29551,8 +25857,6 @@ weidankong,2018-Q4,0,0,0
 weidankong,2018-Q3,20,735,182
 weidankong,2018-Q2,0,0,0
 weidankong,2018-Q1,0,0,0
-Misha Brukman,2021-Q4,0,0,0
-Misha Brukman,2021-Q3,0,0,0
 Misha Brukman,2021-Q2,0,0,0
 Misha Brukman,2021-Q1,0,0,0
 Misha Brukman,2020-Q4,0,0,0
@@ -29567,8 +25871,6 @@ Misha Brukman,2018-Q4,0,0,0
 Misha Brukman,2018-Q3,14,64,56
 Misha Brukman,2018-Q2,0,0,0
 Misha Brukman,2018-Q1,0,0,0
-Keishi Hattori,2021-Q4,0,0,0
-Keishi Hattori,2021-Q3,0,0,0
 Keishi Hattori,2021-Q2,0,0,0
 Keishi Hattori,2021-Q1,0,0,0
 Keishi Hattori,2020-Q4,0,0,0
@@ -29583,8 +25885,6 @@ Keishi Hattori,2018-Q4,0,0,0
 Keishi Hattori,2018-Q3,1,4,3
 Keishi Hattori,2018-Q2,0,0,0
 Keishi Hattori,2018-Q1,0,0,0
-Stefan Dyulgerov,2021-Q4,0,0,0
-Stefan Dyulgerov,2021-Q3,0,0,0
 Stefan Dyulgerov,2021-Q2,0,0,0
 Stefan Dyulgerov,2021-Q1,0,0,0
 Stefan Dyulgerov,2020-Q4,0,0,0
@@ -29599,8 +25899,6 @@ Stefan Dyulgerov,2018-Q4,0,0,0
 Stefan Dyulgerov,2018-Q3,6,110,29
 Stefan Dyulgerov,2018-Q2,0,0,0
 Stefan Dyulgerov,2018-Q1,0,0,0
-Santosh Kumar,2021-Q4,0,0,0
-Santosh Kumar,2021-Q3,0,0,0
 Santosh Kumar,2021-Q2,0,0,0
 Santosh Kumar,2021-Q1,0,0,0
 Santosh Kumar,2020-Q4,0,0,0
@@ -29615,8 +25913,6 @@ Santosh Kumar,2018-Q4,0,0,0
 Santosh Kumar,2018-Q3,1,2,2
 Santosh Kumar,2018-Q2,0,0,0
 Santosh Kumar,2018-Q1,0,0,0
-Dao Zhang,2021-Q4,0,0,0
-Dao Zhang,2021-Q3,0,0,0
 Dao Zhang,2021-Q2,0,0,0
 Dao Zhang,2021-Q1,0,0,0
 Dao Zhang,2020-Q4,0,0,0
@@ -29631,8 +25927,6 @@ Dao Zhang,2018-Q4,0,0,0
 Dao Zhang,2018-Q3,1,3,3
 Dao Zhang,2018-Q2,0,0,0
 Dao Zhang,2018-Q1,0,0,0
-Avijit,2021-Q4,0,0,0
-Avijit,2021-Q3,0,0,0
 Avijit,2021-Q2,0,0,0
 Avijit,2021-Q1,0,0,0
 Avijit,2020-Q4,0,0,0
@@ -29647,8 +25941,6 @@ Avijit,2018-Q4,0,0,0
 Avijit,2018-Q3,28,3153,2474
 Avijit,2018-Q2,0,0,0
 Avijit,2018-Q1,0,0,0
-Zafarali Ahmed,2021-Q4,0,0,0
-Zafarali Ahmed,2021-Q3,0,0,0
 Zafarali Ahmed,2021-Q2,0,0,0
 Zafarali Ahmed,2021-Q1,0,0,0
 Zafarali Ahmed,2020-Q4,0,0,0
@@ -29663,8 +25955,6 @@ Zafarali Ahmed,2018-Q4,0,0,0
 Zafarali Ahmed,2018-Q3,3,86,0
 Zafarali Ahmed,2018-Q2,0,0,0
 Zafarali Ahmed,2018-Q1,0,0,0
-Vikram Tankasali,2021-Q4,0,0,0
-Vikram Tankasali,2021-Q3,0,0,0
 Vikram Tankasali,2021-Q2,0,0,0
 Vikram Tankasali,2021-Q1,0,0,0
 Vikram Tankasali,2020-Q4,0,0,0
@@ -29679,8 +25969,6 @@ Vikram Tankasali,2018-Q4,0,0,0
 Vikram Tankasali,2018-Q3,98,0,28870
 Vikram Tankasali,2018-Q2,2,11,0
 Vikram Tankasali,2018-Q1,0,0,0
-gracehoney,2021-Q4,0,0,0
-gracehoney,2021-Q3,0,0,0
 gracehoney,2021-Q2,0,0,0
 gracehoney,2021-Q1,0,0,0
 gracehoney,2020-Q4,0,0,0
@@ -29695,8 +25983,6 @@ gracehoney,2018-Q4,0,0,0
 gracehoney,2018-Q3,157,3852,2843
 gracehoney,2018-Q2,134,2097,1954
 gracehoney,2018-Q1,109,1375,1467
-Soila Kavulya,2021-Q4,0,0,0
-Soila Kavulya,2021-Q3,0,0,0
 Soila Kavulya,2021-Q2,0,0,0
 Soila Kavulya,2021-Q1,0,0,0
 Soila Kavulya,2020-Q4,0,0,0
@@ -29711,8 +25997,6 @@ Soila Kavulya,2018-Q4,0,0,0
 Soila Kavulya,2018-Q3,4,10,10
 Soila Kavulya,2018-Q2,26,447,341
 Soila Kavulya,2018-Q1,0,0,0
-Kate Hodesdon,2021-Q4,0,0,0
-Kate Hodesdon,2021-Q3,0,0,0
 Kate Hodesdon,2021-Q2,0,0,0
 Kate Hodesdon,2021-Q1,0,0,0
 Kate Hodesdon,2020-Q4,0,0,0
@@ -29727,8 +26011,6 @@ Kate Hodesdon,2018-Q4,0,0,0
 Kate Hodesdon,2018-Q3,2,0,0
 Kate Hodesdon,2018-Q2,0,0,0
 Kate Hodesdon,2018-Q1,0,0,0
-Aapeli,2021-Q4,0,0,0
-Aapeli,2021-Q3,0,0,0
 Aapeli,2021-Q2,0,0,0
 Aapeli,2021-Q1,0,0,0
 Aapeli,2020-Q4,0,0,0
@@ -29743,8 +26025,6 @@ Aapeli,2018-Q4,0,0,0
 Aapeli,2018-Q3,1,0,2
 Aapeli,2018-Q2,0,0,0
 Aapeli,2018-Q1,0,0,0
-Artem Sobolev,2021-Q4,0,0,0
-Artem Sobolev,2021-Q3,0,0,0
 Artem Sobolev,2021-Q2,0,0,0
 Artem Sobolev,2021-Q1,0,0,0
 Artem Sobolev,2020-Q4,0,0,0
@@ -29759,8 +26039,6 @@ Artem Sobolev,2018-Q4,0,0,0
 Artem Sobolev,2018-Q3,2,0,2
 Artem Sobolev,2018-Q2,0,0,0
 Artem Sobolev,2018-Q1,0,0,0
-Mehdi Sharifzadeh,2021-Q4,0,0,0
-Mehdi Sharifzadeh,2021-Q3,0,0,0
 Mehdi Sharifzadeh,2021-Q2,0,0,0
 Mehdi Sharifzadeh,2021-Q1,0,0,0
 Mehdi Sharifzadeh,2020-Q4,0,0,0
@@ -29775,8 +26053,6 @@ Mehdi Sharifzadeh,2018-Q4,0,0,0
 Mehdi Sharifzadeh,2018-Q3,6,514,514
 Mehdi Sharifzadeh,2018-Q2,0,0,0
 Mehdi Sharifzadeh,2018-Q1,0,0,0
-Vitaly Lavrukhin,2021-Q4,0,0,0
-Vitaly Lavrukhin,2021-Q3,0,0,0
 Vitaly Lavrukhin,2021-Q2,0,0,0
 Vitaly Lavrukhin,2021-Q1,0,0,0
 Vitaly Lavrukhin,2020-Q4,0,0,0
@@ -29791,8 +26067,6 @@ Vitaly Lavrukhin,2018-Q4,0,0,0
 Vitaly Lavrukhin,2018-Q3,4,28,16
 Vitaly Lavrukhin,2018-Q2,0,0,0
 Vitaly Lavrukhin,2018-Q1,0,0,0
-feiquan,2021-Q4,0,0,0
-feiquan,2021-Q3,0,0,0
 feiquan,2021-Q2,0,0,0
 feiquan,2021-Q1,0,0,0
 feiquan,2020-Q4,0,0,0
@@ -29807,8 +26081,6 @@ feiquan,2018-Q4,0,0,0
 feiquan,2018-Q3,3,20,0
 feiquan,2018-Q2,0,0,0
 feiquan,2018-Q1,0,0,0
-kouml,2021-Q4,0,0,0
-kouml,2021-Q3,0,0,0
 kouml,2021-Q2,0,0,0
 kouml,2021-Q1,0,0,0
 kouml,2020-Q4,0,0,0
@@ -29823,8 +26095,6 @@ kouml,2018-Q4,0,0,0
 kouml,2018-Q3,2,2,2
 kouml,2018-Q2,0,0,0
 kouml,2018-Q1,0,0,0
-bstriner,2021-Q4,0,0,0
-bstriner,2021-Q3,0,0,0
 bstriner,2021-Q2,0,0,0
 bstriner,2021-Q1,0,0,0
 bstriner,2020-Q4,0,0,0
@@ -29839,8 +26109,6 @@ bstriner,2018-Q4,0,0,0
 bstriner,2018-Q3,6,38,40
 bstriner,2018-Q2,0,0,0
 bstriner,2018-Q1,0,0,0
-formath,2021-Q4,0,0,0
-formath,2021-Q3,0,0,0
 formath,2021-Q2,0,0,0
 formath,2021-Q1,0,0,0
 formath,2020-Q4,0,0,0
@@ -29855,8 +26123,6 @@ formath,2018-Q4,0,0,0
 formath,2018-Q3,5,5,18
 formath,2018-Q2,6,126,71
 formath,2018-Q1,0,0,0
-Ruizhi,2021-Q4,0,0,0
-Ruizhi,2021-Q3,0,0,0
 Ruizhi,2021-Q2,0,0,0
 Ruizhi,2021-Q1,0,0,0
 Ruizhi,2020-Q4,0,0,0
@@ -29871,8 +26137,6 @@ Ruizhi,2018-Q4,0,0,0
 Ruizhi,2018-Q3,4,2,2
 Ruizhi,2018-Q2,0,0,0
 Ruizhi,2018-Q1,0,0,0
-Wesley Qian,2021-Q4,0,0,0
-Wesley Qian,2021-Q3,0,0,0
 Wesley Qian,2021-Q2,0,0,0
 Wesley Qian,2021-Q1,0,0,0
 Wesley Qian,2020-Q4,0,0,0
@@ -29887,8 +26151,6 @@ Wesley Qian,2018-Q4,0,0,0
 Wesley Qian,2018-Q3,15,970,99
 Wesley Qian,2018-Q2,0,0,0
 Wesley Qian,2018-Q1,0,0,0
-Patrick Nguyen,2021-Q4,0,0,0
-Patrick Nguyen,2021-Q3,0,0,0
 Patrick Nguyen,2021-Q2,0,0,0
 Patrick Nguyen,2021-Q1,0,0,0
 Patrick Nguyen,2020-Q4,0,0,0
@@ -29903,8 +26165,6 @@ Patrick Nguyen,2018-Q4,0,0,0
 Patrick Nguyen,2018-Q3,4,186,74
 Patrick Nguyen,2018-Q2,168,5268,895
 Patrick Nguyen,2018-Q1,11,418,4
-Seb Bro,2021-Q4,0,0,0
-Seb Bro,2021-Q3,0,0,0
 Seb Bro,2021-Q2,0,0,0
 Seb Bro,2021-Q1,0,0,0
 Seb Bro,2020-Q4,0,0,0
@@ -29919,8 +26179,6 @@ Seb Bro,2018-Q4,0,0,0
 Seb Bro,2018-Q3,5,8,9
 Seb Bro,2018-Q2,0,0,0
 Seb Bro,2018-Q1,0,0,0
-npow,2021-Q4,0,0,0
-npow,2021-Q3,0,0,0
 npow,2021-Q2,0,0,0
 npow,2021-Q1,0,0,0
 npow,2020-Q4,0,0,0
@@ -29935,8 +26193,6 @@ npow,2018-Q4,0,0,0
 npow,2018-Q3,2,17,12
 npow,2018-Q2,0,0,0
 npow,2018-Q1,0,0,0
-Jiawei Zhang,2021-Q4,0,0,0
-Jiawei Zhang,2021-Q3,0,0,0
 Jiawei Zhang,2021-Q2,0,0,0
 Jiawei Zhang,2021-Q1,0,0,0
 Jiawei Zhang,2020-Q4,0,0,0
@@ -29951,8 +26207,6 @@ Jiawei Zhang,2018-Q4,0,0,0
 Jiawei Zhang,2018-Q3,1,2,2
 Jiawei Zhang,2018-Q2,0,0,0
 Jiawei Zhang,2018-Q1,0,0,0
-Robin Richtsfeld,2021-Q4,0,0,0
-Robin Richtsfeld,2021-Q3,0,0,0
 Robin Richtsfeld,2021-Q2,0,0,0
 Robin Richtsfeld,2021-Q1,0,0,0
 Robin Richtsfeld,2020-Q4,0,0,0
@@ -29967,8 +26221,6 @@ Robin Richtsfeld,2018-Q4,0,0,0
 Robin Richtsfeld,2018-Q3,3,17,9
 Robin Richtsfeld,2018-Q2,14,94,10
 Robin Richtsfeld,2018-Q1,10,166,30
-rasmi,2021-Q4,0,0,0
-rasmi,2021-Q3,0,0,0
 rasmi,2021-Q2,0,0,0
 rasmi,2021-Q1,0,0,0
 rasmi,2020-Q4,0,0,0
@@ -29983,8 +26235,6 @@ rasmi,2018-Q4,0,0,0
 rasmi,2018-Q3,3,2,0
 rasmi,2018-Q2,0,0,0
 rasmi,2018-Q1,0,0,0
-Reeze Xia,2021-Q4,0,0,0
-Reeze Xia,2021-Q3,0,0,0
 Reeze Xia,2021-Q2,0,0,0
 Reeze Xia,2021-Q1,0,0,0
 Reeze Xia,2020-Q4,0,0,0
@@ -29999,8 +26249,6 @@ Reeze Xia,2018-Q4,0,0,0
 Reeze Xia,2018-Q3,1,0,0
 Reeze Xia,2018-Q2,1,2,2
 Reeze Xia,2018-Q1,0,0,0
-melvinljy96,2021-Q4,0,0,0
-melvinljy96,2021-Q3,0,0,0
 melvinljy96,2021-Q2,0,0,0
 melvinljy96,2021-Q1,0,0,0
 melvinljy96,2020-Q4,0,0,0
@@ -30015,8 +26263,6 @@ melvinljy96,2018-Q4,0,0,0
 melvinljy96,2018-Q3,2,10,6
 melvinljy96,2018-Q2,0,0,0
 melvinljy96,2018-Q1,0,0,0
-Xuechen Li,2021-Q4,0,0,0
-Xuechen Li,2021-Q3,0,0,0
 Xuechen Li,2021-Q2,0,0,0
 Xuechen Li,2021-Q1,0,0,0
 Xuechen Li,2020-Q4,0,0,0
@@ -30031,8 +26277,6 @@ Xuechen Li,2018-Q4,0,0,0
 Xuechen Li,2018-Q3,62,4131,1714
 Xuechen Li,2018-Q2,42,3142,1732
 Xuechen Li,2018-Q1,0,0,0
-Niall Moran,2021-Q4,0,0,0
-Niall Moran,2021-Q3,0,0,0
 Niall Moran,2021-Q2,0,0,0
 Niall Moran,2021-Q1,0,0,0
 Niall Moran,2020-Q4,0,0,0
@@ -30047,8 +26291,6 @@ Niall Moran,2018-Q4,0,0,0
 Niall Moran,2018-Q3,2,10,7
 Niall Moran,2018-Q2,0,0,0
 Niall Moran,2018-Q1,0,0,0
-weidan.kong,2021-Q4,0,0,0
-weidan.kong,2021-Q3,0,0,0
 weidan.kong,2021-Q2,0,0,0
 weidan.kong,2021-Q1,0,0,0
 weidan.kong,2020-Q4,0,0,0
@@ -30063,8 +26305,6 @@ weidan.kong,2018-Q4,0,0,0
 weidan.kong,2018-Q3,2,246,44
 weidan.kong,2018-Q2,0,0,0
 weidan.kong,2018-Q1,0,0,0
-Monica Dinculescu,2021-Q4,0,0,0
-Monica Dinculescu,2021-Q3,0,0,0
 Monica Dinculescu,2021-Q2,0,0,0
 Monica Dinculescu,2021-Q1,0,0,0
 Monica Dinculescu,2020-Q4,0,0,0
@@ -30079,8 +26319,6 @@ Monica Dinculescu,2018-Q4,0,0,0
 Monica Dinculescu,2018-Q3,1,3,3
 Monica Dinculescu,2018-Q2,0,0,0
 Monica Dinculescu,2018-Q1,0,0,0
-Vicente Reyes,2021-Q4,0,0,0
-Vicente Reyes,2021-Q3,0,0,0
 Vicente Reyes,2021-Q2,0,0,0
 Vicente Reyes,2021-Q1,0,0,0
 Vicente Reyes,2020-Q4,0,0,0
@@ -30095,8 +26333,6 @@ Vicente Reyes,2018-Q4,0,0,0
 Vicente Reyes,2018-Q3,1,0,0
 Vicente Reyes,2018-Q2,0,0,0
 Vicente Reyes,2018-Q1,0,0,0
-silent567,2021-Q4,0,0,0
-silent567,2021-Q3,0,0,0
 silent567,2021-Q2,0,0,0
 silent567,2021-Q1,0,0,0
 silent567,2020-Q4,0,0,0
@@ -30111,8 +26347,6 @@ silent567,2018-Q4,0,0,0
 silent567,2018-Q3,1,2,2
 silent567,2018-Q2,0,0,0
 silent567,2018-Q1,0,0,0
-Justin Shenk,2021-Q4,0,0,0
-Justin Shenk,2021-Q3,0,0,0
 Justin Shenk,2021-Q2,0,0,0
 Justin Shenk,2021-Q1,0,0,0
 Justin Shenk,2020-Q4,0,0,0
@@ -30127,8 +26361,6 @@ Justin Shenk,2018-Q4,0,0,0
 Justin Shenk,2018-Q3,3,2,2
 Justin Shenk,2018-Q2,0,0,0
 Justin Shenk,2018-Q1,0,0,0
-Andrew Gibiansky,2021-Q4,0,0,0
-Andrew Gibiansky,2021-Q3,0,0,0
 Andrew Gibiansky,2021-Q2,0,0,0
 Andrew Gibiansky,2021-Q1,0,0,0
 Andrew Gibiansky,2020-Q4,0,0,0
@@ -30143,8 +26375,6 @@ Andrew Gibiansky,2018-Q4,0,0,0
 Andrew Gibiansky,2018-Q3,2,2,0
 Andrew Gibiansky,2018-Q2,0,0,0
 Andrew Gibiansky,2018-Q1,0,0,0
-Pei Zhang,2021-Q4,0,0,0
-Pei Zhang,2021-Q3,0,0,0
 Pei Zhang,2021-Q2,0,0,0
 Pei Zhang,2021-Q1,0,0,0
 Pei Zhang,2020-Q4,0,0,0
@@ -30159,8 +26389,6 @@ Pei Zhang,2018-Q4,0,0,0
 Pei Zhang,2018-Q3,1,3,3
 Pei Zhang,2018-Q2,0,0,0
 Pei Zhang,2018-Q1,0,0,0
-ThisIsPIRI,2021-Q4,0,0,0
-ThisIsPIRI,2021-Q3,0,0,0
 ThisIsPIRI,2021-Q2,0,0,0
 ThisIsPIRI,2021-Q1,0,0,0
 ThisIsPIRI,2020-Q4,0,0,0
@@ -30175,8 +26403,6 @@ ThisIsPIRI,2018-Q4,0,0,0
 ThisIsPIRI,2018-Q3,2,7,4
 ThisIsPIRI,2018-Q2,0,0,0
 ThisIsPIRI,2018-Q1,0,0,0
-cbockman,2021-Q4,0,0,0
-cbockman,2021-Q3,0,0,0
 cbockman,2021-Q2,0,0,0
 cbockman,2021-Q1,0,0,0
 cbockman,2020-Q4,0,0,0
@@ -30191,8 +26417,6 @@ cbockman,2018-Q4,0,0,0
 cbockman,2018-Q3,2,5,2
 cbockman,2018-Q2,0,0,0
 cbockman,2018-Q1,1,0,0
-Max Galkin,2021-Q4,0,0,0
-Max Galkin,2021-Q3,0,0,0
 Max Galkin,2021-Q2,0,0,0
 Max Galkin,2021-Q1,0,0,0
 Max Galkin,2020-Q4,0,0,0
@@ -30207,8 +26431,6 @@ Max Galkin,2018-Q4,0,0,0
 Max Galkin,2018-Q3,2,85,78
 Max Galkin,2018-Q2,7,66,47
 Max Galkin,2018-Q1,17,431,293
-Raymond Yuan,2021-Q4,0,0,0
-Raymond Yuan,2021-Q3,0,0,0
 Raymond Yuan,2021-Q2,0,0,0
 Raymond Yuan,2021-Q1,0,0,0
 Raymond Yuan,2020-Q4,0,0,0
@@ -30223,8 +26445,6 @@ Raymond Yuan,2018-Q4,0,0,0
 Raymond Yuan,2018-Q3,8,402,13
 Raymond Yuan,2018-Q2,0,0,0
 Raymond Yuan,2018-Q1,0,0,0
-Daniel Zheng,2021-Q4,0,0,0
-Daniel Zheng,2021-Q3,0,0,0
 Daniel Zheng,2021-Q2,0,0,0
 Daniel Zheng,2021-Q1,0,0,0
 Daniel Zheng,2020-Q4,0,0,0
@@ -30239,8 +26459,6 @@ Daniel Zheng,2018-Q4,0,0,0
 Daniel Zheng,2018-Q3,1,0,0
 Daniel Zheng,2018-Q2,2,11,12
 Daniel Zheng,2018-Q1,0,0,0
-sfujiwara,2021-Q4,0,0,0
-sfujiwara,2021-Q3,0,0,0
 sfujiwara,2021-Q2,0,0,0
 sfujiwara,2021-Q1,0,0,0
 sfujiwara,2020-Q4,0,0,0
@@ -30255,8 +26473,6 @@ sfujiwara,2018-Q4,0,0,0
 sfujiwara,2018-Q3,1,2,2
 sfujiwara,2018-Q2,0,0,0
 sfujiwara,2018-Q1,0,0,0
-Johannes Schmitz,2021-Q4,0,0,0
-Johannes Schmitz,2021-Q3,0,0,0
 Johannes Schmitz,2021-Q2,0,0,0
 Johannes Schmitz,2021-Q1,0,0,0
 Johannes Schmitz,2020-Q4,0,0,0
@@ -30271,8 +26487,6 @@ Johannes Schmitz,2018-Q4,0,0,0
 Johannes Schmitz,2018-Q3,1,2,2
 Johannes Schmitz,2018-Q2,0,0,0
 Johannes Schmitz,2018-Q1,0,0,0
-David,2021-Q4,0,0,0
-David,2021-Q3,0,0,0
 David,2021-Q2,0,0,0
 David,2021-Q1,0,0,0
 David,2020-Q4,0,0,0
@@ -30287,8 +26501,6 @@ David,2018-Q4,0,0,0
 David,2018-Q3,1,0,0
 David,2018-Q2,0,0,0
 David,2018-Q1,0,0,0
-Áron Ricardo Perez-Lopez,2021-Q4,0,0,0
-Áron Ricardo Perez-Lopez,2021-Q3,0,0,0
 Áron Ricardo Perez-Lopez,2021-Q2,0,0,0
 Áron Ricardo Perez-Lopez,2021-Q1,0,0,0
 Áron Ricardo Perez-Lopez,2020-Q4,0,0,0
@@ -30303,8 +26515,6 @@ David,2018-Q1,0,0,0
 Áron Ricardo Perez-Lopez,2018-Q3,1,0,0
 Áron Ricardo Perez-Lopez,2018-Q2,0,0,0
 Áron Ricardo Perez-Lopez,2018-Q1,0,0,0
-Rakesh Chada,2021-Q4,0,0,0
-Rakesh Chada,2021-Q3,0,0,0
 Rakesh Chada,2021-Q2,0,0,0
 Rakesh Chada,2021-Q1,0,0,0
 Rakesh Chada,2020-Q4,0,0,0
@@ -30319,8 +26529,6 @@ Rakesh Chada,2018-Q4,0,0,0
 Rakesh Chada,2018-Q3,3,15,12
 Rakesh Chada,2018-Q2,0,0,0
 Rakesh Chada,2018-Q1,0,0,0
-CUI Wei,2021-Q4,0,0,0
-CUI Wei,2021-Q3,0,0,0
 CUI Wei,2021-Q2,0,0,0
 CUI Wei,2021-Q1,0,0,0
 CUI Wei,2020-Q4,0,0,0
@@ -30335,8 +26543,6 @@ CUI Wei,2018-Q4,0,0,0
 CUI Wei,2018-Q3,1,0,0
 CUI Wei,2018-Q2,0,0,0
 CUI Wei,2018-Q1,0,0,0
-Matt Dodge,2021-Q4,0,0,0
-Matt Dodge,2021-Q3,0,0,0
 Matt Dodge,2021-Q2,0,0,0
 Matt Dodge,2021-Q1,0,0,0
 Matt Dodge,2020-Q4,0,0,0
@@ -30351,8 +26557,6 @@ Matt Dodge,2018-Q4,0,0,0
 Matt Dodge,2018-Q3,1,2,2
 Matt Dodge,2018-Q2,0,0,0
 Matt Dodge,2018-Q1,0,0,0
-Rui Zhao,2021-Q4,0,0,0
-Rui Zhao,2021-Q3,0,0,0
 Rui Zhao,2021-Q2,0,0,0
 Rui Zhao,2021-Q1,0,0,0
 Rui Zhao,2020-Q4,0,0,0
@@ -30367,8 +26571,6 @@ Rui Zhao,2018-Q4,0,0,0
 Rui Zhao,2018-Q3,4,68,5
 Rui Zhao,2018-Q2,2,24,0
 Rui Zhao,2018-Q1,9,141,40
-hehongliang,2021-Q4,0,0,0
-hehongliang,2021-Q3,0,0,0
 hehongliang,2021-Q2,0,0,0
 hehongliang,2021-Q1,0,0,0
 hehongliang,2020-Q4,0,0,0
@@ -30383,8 +26585,6 @@ hehongliang,2018-Q4,0,0,0
 hehongliang,2018-Q3,6,250,107
 hehongliang,2018-Q2,0,0,0
 hehongliang,2018-Q1,0,0,0
-cosine0,2021-Q4,0,0,0
-cosine0,2021-Q3,0,0,0
 cosine0,2021-Q2,0,0,0
 cosine0,2021-Q1,0,0,0
 cosine0,2020-Q4,0,0,0
@@ -30399,8 +26599,6 @@ cosine0,2018-Q4,0,0,0
 cosine0,2018-Q3,1,0,0
 cosine0,2018-Q2,0,0,0
 cosine0,2018-Q1,0,0,0
-shaohua,2021-Q4,0,0,0
-shaohua,2021-Q3,0,0,0
 shaohua,2021-Q2,0,0,0
 shaohua,2021-Q1,0,0,0
 shaohua,2020-Q4,0,0,0
@@ -30415,8 +26613,6 @@ shaohua,2018-Q4,0,0,0
 shaohua,2018-Q3,1,2,2
 shaohua,2018-Q2,0,0,0
 shaohua,2018-Q1,0,0,0
-Guoliang Hua,2021-Q4,0,0,0
-Guoliang Hua,2021-Q3,0,0,0
 Guoliang Hua,2021-Q2,0,0,0
 Guoliang Hua,2021-Q1,0,0,0
 Guoliang Hua,2020-Q4,0,0,0
@@ -30431,8 +26627,6 @@ Guoliang Hua,2018-Q4,0,0,0
 Guoliang Hua,2018-Q3,1,2,0
 Guoliang Hua,2018-Q2,0,0,0
 Guoliang Hua,2018-Q1,0,0,0
-Yoshihiro Yamazaki,2021-Q4,0,0,0
-Yoshihiro Yamazaki,2021-Q3,0,0,0
 Yoshihiro Yamazaki,2021-Q2,0,0,0
 Yoshihiro Yamazaki,2021-Q1,0,0,0
 Yoshihiro Yamazaki,2020-Q4,0,0,0
@@ -30447,8 +26641,6 @@ Yoshihiro Yamazaki,2018-Q4,0,0,0
 Yoshihiro Yamazaki,2018-Q3,6,5,0
 Yoshihiro Yamazaki,2018-Q2,1,11,3
 Yoshihiro Yamazaki,2018-Q1,0,0,0
-Herman Zvonimir Došilović,2021-Q4,0,0,0
-Herman Zvonimir Došilović,2021-Q3,0,0,0
 Herman Zvonimir Došilović,2021-Q2,0,0,0
 Herman Zvonimir Došilović,2021-Q1,0,0,0
 Herman Zvonimir Došilović,2020-Q4,0,0,0
@@ -30463,8 +26655,6 @@ Herman Zvonimir Došilović,2018-Q4,0,0,0
 Herman Zvonimir Došilović,2018-Q3,1,0,2
 Herman Zvonimir Došilović,2018-Q2,1,0,2
 Herman Zvonimir Došilović,2018-Q1,0,0,0
-Jie,2021-Q4,0,0,0
-Jie,2021-Q3,0,0,0
 Jie,2021-Q2,0,0,0
 Jie,2021-Q1,0,0,0
 Jie,2020-Q4,0,0,0
@@ -30479,8 +26669,6 @@ Jie,2018-Q4,0,0,0
 Jie,2018-Q3,98,2476,2426
 Jie,2018-Q2,84,3914,640
 Jie,2018-Q1,81,1263,1085
-Shaba Abhiram,2021-Q4,0,0,0
-Shaba Abhiram,2021-Q3,0,0,0
 Shaba Abhiram,2021-Q2,0,0,0
 Shaba Abhiram,2021-Q1,0,0,0
 Shaba Abhiram,2020-Q4,0,0,0
@@ -30495,8 +26683,6 @@ Shaba Abhiram,2018-Q4,0,0,0
 Shaba Abhiram,2018-Q3,6,104,67
 Shaba Abhiram,2018-Q2,0,0,0
 Shaba Abhiram,2018-Q1,0,0,0
-adoda,2021-Q4,0,0,0
-adoda,2021-Q3,0,0,0
 adoda,2021-Q2,0,0,0
 adoda,2021-Q1,0,0,0
 adoda,2020-Q4,0,0,0
@@ -30511,8 +26697,6 @@ adoda,2018-Q4,0,0,0
 adoda,2018-Q3,1,0,0
 adoda,2018-Q2,0,0,0
 adoda,2018-Q1,0,0,0
-Eliel Hojman,2021-Q4,0,0,0
-Eliel Hojman,2021-Q3,0,0,0
 Eliel Hojman,2021-Q2,0,0,0
 Eliel Hojman,2021-Q1,0,0,0
 Eliel Hojman,2020-Q4,0,0,0
@@ -30527,8 +26711,6 @@ Eliel Hojman,2018-Q4,0,0,0
 Eliel Hojman,2018-Q3,2,2,2
 Eliel Hojman,2018-Q2,0,0,0
 Eliel Hojman,2018-Q1,0,0,0
-Anirudh Koul,2021-Q4,0,0,0
-Anirudh Koul,2021-Q3,0,0,0
 Anirudh Koul,2021-Q2,0,0,0
 Anirudh Koul,2021-Q1,0,0,0
 Anirudh Koul,2020-Q4,0,0,0
@@ -30543,8 +26725,6 @@ Anirudh Koul,2018-Q4,0,0,0
 Anirudh Koul,2018-Q3,1,0,0
 Anirudh Koul,2018-Q2,0,0,0
 Anirudh Koul,2018-Q1,0,0,0
-Miguel Mota,2021-Q4,0,0,0
-Miguel Mota,2021-Q3,0,0,0
 Miguel Mota,2021-Q2,0,0,0
 Miguel Mota,2021-Q1,0,0,0
 Miguel Mota,2020-Q4,0,0,0
@@ -30559,8 +26739,6 @@ Miguel Mota,2018-Q4,0,0,0
 Miguel Mota,2018-Q3,1,0,0
 Miguel Mota,2018-Q2,0,0,0
 Miguel Mota,2018-Q1,0,0,0
-KB Sriram,2021-Q4,0,0,0
-KB Sriram,2021-Q3,0,0,0
 KB Sriram,2021-Q2,0,0,0
 KB Sriram,2021-Q1,0,0,0
 KB Sriram,2020-Q4,0,0,0
@@ -30575,8 +26753,6 @@ KB Sriram,2018-Q4,0,0,0
 KB Sriram,2018-Q3,6,288,0
 KB Sriram,2018-Q2,2,59,0
 KB Sriram,2018-Q1,7,282,21
-XFeiF,2021-Q4,0,0,0
-XFeiF,2021-Q3,0,0,0
 XFeiF,2021-Q2,0,0,0
 XFeiF,2021-Q1,0,0,0
 XFeiF,2020-Q4,0,0,0
@@ -30591,8 +26767,6 @@ XFeiF,2018-Q4,0,0,0
 XFeiF,2018-Q3,1,15,10
 XFeiF,2018-Q2,0,0,0
 XFeiF,2018-Q1,0,0,0
-Ray Kim,2021-Q4,0,0,0
-Ray Kim,2021-Q3,0,0,0
 Ray Kim,2021-Q2,0,0,0
 Ray Kim,2021-Q1,0,0,0
 Ray Kim,2020-Q4,0,0,0
@@ -30607,8 +26781,6 @@ Ray Kim,2018-Q4,0,0,0
 Ray Kim,2018-Q3,1,0,0
 Ray Kim,2018-Q2,0,0,0
 Ray Kim,2018-Q1,0,0,0
-qwertWZ,2021-Q4,0,0,0
-qwertWZ,2021-Q3,0,0,0
 qwertWZ,2021-Q2,0,0,0
 qwertWZ,2021-Q1,0,0,0
 qwertWZ,2020-Q4,0,0,0
@@ -30623,8 +26795,6 @@ qwertWZ,2018-Q4,0,0,0
 qwertWZ,2018-Q3,1,0,0
 qwertWZ,2018-Q2,0,0,0
 qwertWZ,2018-Q1,0,0,0
-Nick Desaulniers,2021-Q4,0,0,0
-Nick Desaulniers,2021-Q3,0,0,0
 Nick Desaulniers,2021-Q2,0,0,0
 Nick Desaulniers,2021-Q1,0,0,0
 Nick Desaulniers,2020-Q4,0,0,0
@@ -30639,8 +26809,6 @@ Nick Desaulniers,2018-Q4,0,0,0
 Nick Desaulniers,2018-Q3,25,197,0
 Nick Desaulniers,2018-Q2,39,405,137
 Nick Desaulniers,2018-Q1,49,711,287
-Sunitha Kambhampati,2021-Q4,0,0,0
-Sunitha Kambhampati,2021-Q3,0,0,0
 Sunitha Kambhampati,2021-Q2,0,0,0
 Sunitha Kambhampati,2021-Q1,0,0,0
 Sunitha Kambhampati,2020-Q4,0,0,0
@@ -30655,8 +26823,6 @@ Sunitha Kambhampati,2018-Q4,0,0,0
 Sunitha Kambhampati,2018-Q3,3,20,2
 Sunitha Kambhampati,2018-Q2,4,64,8
 Sunitha Kambhampati,2018-Q1,3,11,11
-Peng Wang (SIMPENG),2021-Q4,0,0,0
-Peng Wang (SIMPENG),2021-Q3,0,0,0
 Peng Wang (SIMPENG),2021-Q2,0,0,0
 Peng Wang (SIMPENG),2021-Q1,0,0,0
 Peng Wang (SIMPENG),2020-Q4,0,0,0
@@ -30671,8 +26837,6 @@ Peng Wang (SIMPENG),2018-Q4,0,0,0
 Peng Wang (SIMPENG),2018-Q3,2,0,0
 Peng Wang (SIMPENG),2018-Q2,0,0,0
 Peng Wang (SIMPENG),2018-Q1,0,0,0
-Jacker,2021-Q4,0,0,0
-Jacker,2021-Q3,0,0,0
 Jacker,2021-Q2,0,0,0
 Jacker,2021-Q1,0,0,0
 Jacker,2020-Q4,0,0,0
@@ -30687,8 +26851,6 @@ Jacker,2018-Q4,0,0,0
 Jacker,2018-Q3,1,4,7
 Jacker,2018-Q2,0,0,0
 Jacker,2018-Q1,0,0,0
-vilmar-hillow,2021-Q4,0,0,0
-vilmar-hillow,2021-Q3,0,0,0
 vilmar-hillow,2021-Q2,0,0,0
 vilmar-hillow,2021-Q1,0,0,0
 vilmar-hillow,2020-Q4,0,0,0
@@ -30703,8 +26865,6 @@ vilmar-hillow,2018-Q4,0,0,0
 vilmar-hillow,2018-Q3,1,0,0
 vilmar-hillow,2018-Q2,0,0,0
 vilmar-hillow,2018-Q1,0,0,0
-cheerss,2021-Q4,0,0,0
-cheerss,2021-Q3,0,0,0
 cheerss,2021-Q2,0,0,0
 cheerss,2021-Q1,0,0,0
 cheerss,2020-Q4,0,0,0
@@ -30719,8 +26879,6 @@ cheerss,2018-Q4,0,0,0
 cheerss,2018-Q3,1,2,2
 cheerss,2018-Q2,0,0,0
 cheerss,2018-Q1,0,0,0
-wim glenn,2021-Q4,0,0,0
-wim glenn,2021-Q3,0,0,0
 wim glenn,2021-Q2,0,0,0
 wim glenn,2021-Q1,0,0,0
 wim glenn,2020-Q4,0,0,0
@@ -30735,8 +26893,6 @@ wim glenn,2018-Q4,0,0,0
 wim glenn,2018-Q3,1,8,8
 wim glenn,2018-Q2,0,0,0
 wim glenn,2018-Q1,0,0,0
-Kenneth Blomqvist,2021-Q4,0,0,0
-Kenneth Blomqvist,2021-Q3,0,0,0
 Kenneth Blomqvist,2021-Q2,0,0,0
 Kenneth Blomqvist,2021-Q1,0,0,0
 Kenneth Blomqvist,2020-Q4,0,0,0
@@ -30751,8 +26907,6 @@ Kenneth Blomqvist,2018-Q4,0,0,0
 Kenneth Blomqvist,2018-Q3,1,0,0
 Kenneth Blomqvist,2018-Q2,0,0,0
 Kenneth Blomqvist,2018-Q1,0,0,0
-Jongmin Park,2021-Q4,0,0,0
-Jongmin Park,2021-Q3,0,0,0
 Jongmin Park,2021-Q2,0,0,0
 Jongmin Park,2021-Q1,0,0,0
 Jongmin Park,2020-Q4,0,0,0
@@ -30767,8 +26921,6 @@ Jongmin Park,2018-Q4,0,0,0
 Jongmin Park,2018-Q3,1,0,0
 Jongmin Park,2018-Q2,0,0,0
 Jongmin Park,2018-Q1,0,0,0
-Paul Woitaschek,2021-Q4,0,0,0
-Paul Woitaschek,2021-Q3,0,0,0
 Paul Woitaschek,2021-Q2,0,0,0
 Paul Woitaschek,2021-Q1,0,0,0
 Paul Woitaschek,2020-Q4,0,0,0
@@ -30783,8 +26935,6 @@ Paul Woitaschek,2018-Q4,0,0,0
 Paul Woitaschek,2018-Q3,4,9,5
 Paul Woitaschek,2018-Q2,0,0,0
 Paul Woitaschek,2018-Q1,0,0,0
-Pratik Kalshetti,2021-Q4,0,0,0
-Pratik Kalshetti,2021-Q3,0,0,0
 Pratik Kalshetti,2021-Q2,0,0,0
 Pratik Kalshetti,2021-Q1,0,0,0
 Pratik Kalshetti,2020-Q4,0,0,0
@@ -30799,8 +26949,6 @@ Pratik Kalshetti,2018-Q4,0,0,0
 Pratik Kalshetti,2018-Q3,1,0,0
 Pratik Kalshetti,2018-Q2,0,0,0
 Pratik Kalshetti,2018-Q1,0,0,0
-Amogh Mannekote,2021-Q4,0,0,0
-Amogh Mannekote,2021-Q3,0,0,0
 Amogh Mannekote,2021-Q2,0,0,0
 Amogh Mannekote,2021-Q1,0,0,0
 Amogh Mannekote,2020-Q4,0,0,0
@@ -30815,8 +26963,6 @@ Amogh Mannekote,2018-Q4,0,0,0
 Amogh Mannekote,2018-Q3,0,0,0
 Amogh Mannekote,2018-Q2,3,37,49
 Amogh Mannekote,2018-Q1,0,0,0
-Jan Horst Hünnemeyer,2021-Q4,0,0,0
-Jan Horst Hünnemeyer,2021-Q3,0,0,0
 Jan Horst Hünnemeyer,2021-Q2,0,0,0
 Jan Horst Hünnemeyer,2021-Q1,0,0,0
 Jan Horst Hünnemeyer,2020-Q4,0,0,0
@@ -30831,8 +26977,6 @@ Jan Horst Hünnemeyer,2018-Q4,0,0,0
 Jan Horst Hünnemeyer,2018-Q3,2,2,2
 Jan Horst Hünnemeyer,2018-Q2,7,14,14
 Jan Horst Hünnemeyer,2018-Q1,0,0,0
-Jon Perl,2021-Q4,0,0,0
-Jon Perl,2021-Q3,0,0,0
 Jon Perl,2021-Q2,0,0,0
 Jon Perl,2021-Q1,0,0,0
 Jon Perl,2020-Q4,0,0,0
@@ -30847,8 +26991,6 @@ Jon Perl,2018-Q4,0,0,0
 Jon Perl,2018-Q3,3,2,0
 Jon Perl,2018-Q2,0,0,0
 Jon Perl,2018-Q1,0,0,0
-Shashi,2021-Q4,0,0,0
-Shashi,2021-Q3,0,0,0
 Shashi,2021-Q2,0,0,0
 Shashi,2021-Q1,0,0,0
 Shashi,2020-Q4,0,0,0
@@ -30863,8 +27005,6 @@ Shashi,2018-Q4,0,0,0
 Shashi,2018-Q3,2,4,2
 Shashi,2018-Q2,0,0,0
 Shashi,2018-Q1,0,0,0
-wangershi,2021-Q4,0,0,0
-wangershi,2021-Q3,0,0,0
 wangershi,2021-Q2,0,0,0
 wangershi,2021-Q1,0,0,0
 wangershi,2020-Q4,0,0,0
@@ -30879,8 +27019,6 @@ wangershi,2018-Q4,0,0,0
 wangershi,2018-Q3,1,4,2
 wangershi,2018-Q2,0,0,0
 wangershi,2018-Q1,0,0,0
-Nafis Sadat,2021-Q4,0,0,0
-Nafis Sadat,2021-Q3,0,0,0
 Nafis Sadat,2021-Q2,0,0,0
 Nafis Sadat,2021-Q1,0,0,0
 Nafis Sadat,2020-Q4,0,0,0
@@ -30895,8 +27033,6 @@ Nafis Sadat,2018-Q4,0,0,0
 Nafis Sadat,2018-Q3,1,201,0
 Nafis Sadat,2018-Q2,0,0,0
 Nafis Sadat,2018-Q1,0,0,0
-tianyapiaozi,2021-Q4,0,0,0
-tianyapiaozi,2021-Q3,0,0,0
 tianyapiaozi,2021-Q2,0,0,0
 tianyapiaozi,2021-Q1,0,0,0
 tianyapiaozi,2020-Q4,0,0,0
@@ -30911,8 +27047,6 @@ tianyapiaozi,2018-Q4,0,0,0
 tianyapiaozi,2018-Q3,1,4,4
 tianyapiaozi,2018-Q2,0,0,0
 tianyapiaozi,2018-Q1,0,0,0
-Rodrigo Silveira,2021-Q4,0,0,0
-Rodrigo Silveira,2021-Q3,0,0,0
 Rodrigo Silveira,2021-Q2,0,0,0
 Rodrigo Silveira,2021-Q1,0,0,0
 Rodrigo Silveira,2020-Q4,0,0,0
@@ -30927,8 +27061,6 @@ Rodrigo Silveira,2018-Q4,0,0,0
 Rodrigo Silveira,2018-Q3,1,0,0
 Rodrigo Silveira,2018-Q2,0,0,0
 Rodrigo Silveira,2018-Q1,0,0,0
-Li Liangbin,2021-Q4,0,0,0
-Li Liangbin,2021-Q3,0,0,0
 Li Liangbin,2021-Q2,0,0,0
 Li Liangbin,2021-Q1,0,0,0
 Li Liangbin,2020-Q4,0,0,0
@@ -30943,8 +27075,6 @@ Li Liangbin,2018-Q4,0,0,0
 Li Liangbin,2018-Q3,7,41,12
 Li Liangbin,2018-Q2,0,0,0
 Li Liangbin,2018-Q1,0,0,0
-Dmitry Klimenkov,2021-Q4,0,0,0
-Dmitry Klimenkov,2021-Q3,0,0,0
 Dmitry Klimenkov,2021-Q2,0,0,0
 Dmitry Klimenkov,2021-Q1,0,0,0
 Dmitry Klimenkov,2020-Q4,0,0,0
@@ -30959,8 +27089,6 @@ Dmitry Klimenkov,2018-Q4,0,0,0
 Dmitry Klimenkov,2018-Q3,4,16,16
 Dmitry Klimenkov,2018-Q2,0,0,0
 Dmitry Klimenkov,2018-Q1,0,0,0
-Pradeep Banavara,2021-Q4,0,0,0
-Pradeep Banavara,2021-Q3,0,0,0
 Pradeep Banavara,2021-Q2,0,0,0
 Pradeep Banavara,2021-Q1,0,0,0
 Pradeep Banavara,2020-Q4,0,0,0
@@ -30975,8 +27103,6 @@ Pradeep Banavara,2018-Q4,0,0,0
 Pradeep Banavara,2018-Q3,2,109,14
 Pradeep Banavara,2018-Q2,0,0,0
 Pradeep Banavara,2018-Q1,0,0,0
-kjopek,2021-Q4,0,0,0
-kjopek,2021-Q3,0,0,0
 kjopek,2021-Q2,0,0,0
 kjopek,2021-Q1,0,0,0
 kjopek,2020-Q4,0,0,0
@@ -30991,8 +27117,6 @@ kjopek,2018-Q4,0,0,0
 kjopek,2018-Q3,1,0,0
 kjopek,2018-Q2,0,0,0
 kjopek,2018-Q1,0,0,0
-SneakyFish5,2021-Q4,0,0,0
-SneakyFish5,2021-Q3,0,0,0
 SneakyFish5,2021-Q2,0,0,0
 SneakyFish5,2021-Q1,0,0,0
 SneakyFish5,2020-Q4,0,0,0
@@ -31007,8 +27131,6 @@ SneakyFish5,2018-Q4,0,0,0
 SneakyFish5,2018-Q3,2,3,3
 SneakyFish5,2018-Q2,0,0,0
 SneakyFish5,2018-Q1,0,0,0
-mktozk,2021-Q4,0,0,0
-mktozk,2021-Q3,0,0,0
 mktozk,2021-Q2,0,0,0
 mktozk,2021-Q1,0,0,0
 mktozk,2020-Q4,0,0,0
@@ -31023,8 +27145,6 @@ mktozk,2018-Q4,0,0,0
 mktozk,2018-Q3,5,22,33
 mktozk,2018-Q2,5,374,0
 mktozk,2018-Q1,4,9,4
-TShapinsky,2021-Q4,0,0,0
-TShapinsky,2021-Q3,0,0,0
 TShapinsky,2021-Q2,0,0,0
 TShapinsky,2021-Q1,0,0,0
 TShapinsky,2020-Q4,0,0,0
@@ -31039,8 +27159,6 @@ TShapinsky,2018-Q4,0,0,0
 TShapinsky,2018-Q3,1,0,0
 TShapinsky,2018-Q2,0,0,0
 TShapinsky,2018-Q1,0,0,0
-Alex Wiltschko,2021-Q4,0,0,0
-Alex Wiltschko,2021-Q3,0,0,0
 Alex Wiltschko,2021-Q2,0,0,0
 Alex Wiltschko,2021-Q1,0,0,0
 Alex Wiltschko,2020-Q4,0,0,0
@@ -31055,8 +27173,6 @@ Alex Wiltschko,2018-Q4,0,0,0
 Alex Wiltschko,2018-Q3,1,0,0
 Alex Wiltschko,2018-Q2,0,0,0
 Alex Wiltschko,2018-Q1,1,63,114
-Nitish,2021-Q4,0,0,0
-Nitish,2021-Q3,0,0,0
 Nitish,2021-Q2,0,0,0
 Nitish,2021-Q1,0,0,0
 Nitish,2020-Q4,0,0,0
@@ -31071,8 +27187,6 @@ Nitish,2018-Q4,0,0,0
 Nitish,2018-Q3,1,0,0
 Nitish,2018-Q2,0,0,0
 Nitish,2018-Q1,0,0,0
-Bjørn Moholt,2021-Q4,0,0,0
-Bjørn Moholt,2021-Q3,0,0,0
 Bjørn Moholt,2021-Q2,0,0,0
 Bjørn Moholt,2021-Q1,0,0,0
 Bjørn Moholt,2020-Q4,0,0,0
@@ -31087,8 +27201,6 @@ Bjørn Moholt,2018-Q4,0,0,0
 Bjørn Moholt,2018-Q3,1,0,0
 Bjørn Moholt,2018-Q2,0,0,0
 Bjørn Moholt,2018-Q1,0,0,0
-Andrew Ginns,2021-Q4,0,0,0
-Andrew Ginns,2021-Q3,0,0,0
 Andrew Ginns,2021-Q2,0,0,0
 Andrew Ginns,2021-Q1,0,0,0
 Andrew Ginns,2020-Q4,0,0,0
@@ -31103,8 +27215,6 @@ Andrew Ginns,2018-Q4,0,0,0
 Andrew Ginns,2018-Q3,1,0,0
 Andrew Ginns,2018-Q2,0,0,0
 Andrew Ginns,2018-Q1,0,0,0
-Tristan Rice,2021-Q4,0,0,0
-Tristan Rice,2021-Q3,0,0,0
 Tristan Rice,2021-Q2,0,0,0
 Tristan Rice,2021-Q1,0,0,0
 Tristan Rice,2020-Q4,0,0,0
@@ -31119,8 +27229,6 @@ Tristan Rice,2018-Q4,0,0,0
 Tristan Rice,2018-Q3,0,0,0
 Tristan Rice,2018-Q2,13,642,28
 Tristan Rice,2018-Q1,0,0,0
-张晓飞,2021-Q4,0,0,0
-张晓飞,2021-Q3,0,0,0
 张晓飞,2021-Q2,0,0,0
 张晓飞,2021-Q1,0,0,0
 张晓飞,2020-Q4,0,0,0
@@ -31135,8 +27243,6 @@ Tristan Rice,2018-Q1,0,0,0
 张晓飞,2018-Q3,1,0,0
 张晓飞,2018-Q2,0,0,0
 张晓飞,2018-Q1,0,0,0
-Mahmoud Aslan,2021-Q4,0,0,0
-Mahmoud Aslan,2021-Q3,0,0,0
 Mahmoud Aslan,2021-Q2,0,0,0
 Mahmoud Aslan,2021-Q1,0,0,0
 Mahmoud Aslan,2020-Q4,0,0,0
@@ -31151,8 +27257,6 @@ Mahmoud Aslan,2018-Q4,0,0,0
 Mahmoud Aslan,2018-Q3,1,0,0
 Mahmoud Aslan,2018-Q2,0,0,0
 Mahmoud Aslan,2018-Q1,0,0,0
-nrstott,2021-Q4,0,0,0
-nrstott,2021-Q3,0,0,0
 nrstott,2021-Q2,0,0,0
 nrstott,2021-Q1,0,0,0
 nrstott,2020-Q4,0,0,0
@@ -31167,8 +27271,6 @@ nrstott,2018-Q4,0,0,0
 nrstott,2018-Q3,2,9,9
 nrstott,2018-Q2,14,115,11
 nrstott,2018-Q1,0,0,0
-张天启,2021-Q4,0,0,0
-张天启,2021-Q3,0,0,0
 张天启,2021-Q2,0,0,0
 张天启,2021-Q1,0,0,0
 张天启,2020-Q4,0,0,0
@@ -31183,8 +27285,6 @@ nrstott,2018-Q1,0,0,0
 张天启,2018-Q3,1,0,0
 张天启,2018-Q2,0,0,0
 张天启,2018-Q1,0,0,0
-Dan J,2021-Q4,0,0,0
-Dan J,2021-Q3,0,0,0
 Dan J,2021-Q2,0,0,0
 Dan J,2021-Q1,0,0,0
 Dan J,2020-Q4,0,0,0
@@ -31199,8 +27299,6 @@ Dan J,2018-Q4,0,0,0
 Dan J,2018-Q3,0,0,0
 Dan J,2018-Q2,3,49,19
 Dan J,2018-Q1,0,0,0
-Terry Koo,2021-Q4,0,0,0
-Terry Koo,2021-Q3,0,0,0
 Terry Koo,2021-Q2,0,0,0
 Terry Koo,2021-Q1,0,0,0
 Terry Koo,2020-Q4,0,0,0
@@ -31215,8 +27313,6 @@ Terry Koo,2018-Q4,0,0,0
 Terry Koo,2018-Q3,0,0,0
 Terry Koo,2018-Q2,2,43,6
 Terry Koo,2018-Q1,3,22,8
-PENGWA,2021-Q4,0,0,0
-PENGWA,2021-Q3,0,0,0
 PENGWA,2021-Q2,0,0,0
 PENGWA,2021-Q1,0,0,0
 PENGWA,2020-Q4,0,0,0
@@ -31231,8 +27327,6 @@ PENGWA,2018-Q4,0,0,0
 PENGWA,2018-Q3,0,0,0
 PENGWA,2018-Q2,7,39,23
 PENGWA,2018-Q1,0,0,0
-Tony Wang,2021-Q4,0,0,0
-Tony Wang,2021-Q3,0,0,0
 Tony Wang,2021-Q2,0,0,0
 Tony Wang,2021-Q1,0,0,0
 Tony Wang,2020-Q4,0,0,0
@@ -31247,8 +27341,6 @@ Tony Wang,2018-Q4,0,0,0
 Tony Wang,2018-Q3,0,0,0
 Tony Wang,2018-Q2,49,1308,494
 Tony Wang,2018-Q1,0,0,0
-Jon Triebenbach,2021-Q4,0,0,0
-Jon Triebenbach,2021-Q3,0,0,0
 Jon Triebenbach,2021-Q2,0,0,0
 Jon Triebenbach,2021-Q1,0,0,0
 Jon Triebenbach,2020-Q4,0,0,0
@@ -31263,8 +27355,6 @@ Jon Triebenbach,2018-Q4,0,0,0
 Jon Triebenbach,2018-Q3,0,0,0
 Jon Triebenbach,2018-Q2,5,37,2
 Jon Triebenbach,2018-Q1,0,0,0
-Parag Jain,2021-Q4,0,0,0
-Parag Jain,2021-Q3,0,0,0
 Parag Jain,2021-Q2,0,0,0
 Parag Jain,2021-Q1,0,0,0
 Parag Jain,2020-Q4,0,0,0
@@ -31279,8 +27369,6 @@ Parag Jain,2018-Q4,0,0,0
 Parag Jain,2018-Q3,0,0,0
 Parag Jain,2018-Q2,1,0,0
 Parag Jain,2018-Q1,0,0,0
-Nicolas Lopez,2021-Q4,0,0,0
-Nicolas Lopez,2021-Q3,0,0,0
 Nicolas Lopez,2021-Q2,0,0,0
 Nicolas Lopez,2021-Q1,0,0,0
 Nicolas Lopez,2020-Q4,0,0,0
@@ -31295,8 +27383,6 @@ Nicolas Lopez,2018-Q4,0,0,0
 Nicolas Lopez,2018-Q3,0,0,0
 Nicolas Lopez,2018-Q2,2,24,2
 Nicolas Lopez,2018-Q1,0,0,0
-Dan Dascalescu,2021-Q4,0,0,0
-Dan Dascalescu,2021-Q3,0,0,0
 Dan Dascalescu,2021-Q2,0,0,0
 Dan Dascalescu,2021-Q1,0,0,0
 Dan Dascalescu,2020-Q4,0,0,0
@@ -31311,8 +27397,6 @@ Dan Dascalescu,2018-Q4,0,0,0
 Dan Dascalescu,2018-Q3,0,0,0
 Dan Dascalescu,2018-Q2,1,0,0
 Dan Dascalescu,2018-Q1,0,0,0
-Yu YI,2021-Q4,0,0,0
-Yu YI,2021-Q3,0,0,0
 Yu YI,2021-Q2,0,0,0
 Yu YI,2021-Q1,0,0,0
 Yu YI,2020-Q4,0,0,0
@@ -31327,8 +27411,6 @@ Yu YI,2018-Q4,0,0,0
 Yu YI,2018-Q3,0,0,0
 Yu YI,2018-Q2,1,4,4
 Yu YI,2018-Q1,0,0,0
-freedom" Koan-Sin Tan,2021-Q4,0,0,0
-freedom" Koan-Sin Tan,2021-Q3,0,0,0
 freedom" Koan-Sin Tan,2021-Q2,0,0,0
 freedom" Koan-Sin Tan,2021-Q1,0,0,0
 freedom" Koan-Sin Tan,2020-Q4,0,0,0
@@ -31343,8 +27425,6 @@ freedom" Koan-Sin Tan,2018-Q4,0,0,0
 freedom" Koan-Sin Tan,2018-Q3,0,0,0
 freedom" Koan-Sin Tan,2018-Q2,12,133,4
 freedom" Koan-Sin Tan,2018-Q1,21,950,30
-Zé Vinícius,2021-Q4,0,0,0
-Zé Vinícius,2021-Q3,0,0,0
 Zé Vinícius,2021-Q2,0,0,0
 Zé Vinícius,2021-Q1,0,0,0
 Zé Vinícius,2020-Q4,0,0,0
@@ -31359,8 +27439,6 @@ Zé Vinícius,2018-Q4,0,0,0
 Zé Vinícius,2018-Q3,0,0,0
 Zé Vinícius,2018-Q2,1,0,0
 Zé Vinícius,2018-Q1,0,0,0
-xxxx001,2021-Q4,0,0,0
-xxxx001,2021-Q3,0,0,0
 xxxx001,2021-Q2,0,0,0
 xxxx001,2021-Q1,0,0,0
 xxxx001,2020-Q4,0,0,0
@@ -31375,8 +27453,6 @@ xxxx001,2018-Q4,0,0,0
 xxxx001,2018-Q3,0,0,0
 xxxx001,2018-Q2,15,147,147
 xxxx001,2018-Q1,0,0,0
-Christian Ertler,2021-Q4,0,0,0
-Christian Ertler,2021-Q3,0,0,0
 Christian Ertler,2021-Q2,0,0,0
 Christian Ertler,2021-Q1,0,0,0
 Christian Ertler,2020-Q4,0,0,0
@@ -31391,8 +27467,6 @@ Christian Ertler,2018-Q4,0,0,0
 Christian Ertler,2018-Q3,0,0,0
 Christian Ertler,2018-Q2,8,527,40
 Christian Ertler,2018-Q1,0,0,0
-Peng Wang(SIMPENG),2021-Q4,0,0,0
-Peng Wang(SIMPENG),2021-Q3,0,0,0
 Peng Wang(SIMPENG),2021-Q2,0,0,0
 Peng Wang(SIMPENG),2021-Q1,0,0,0
 Peng Wang(SIMPENG),2020-Q4,0,0,0
@@ -31407,8 +27481,6 @@ Peng Wang(SIMPENG),2018-Q4,0,0,0
 Peng Wang(SIMPENG),2018-Q3,0,0,0
 Peng Wang(SIMPENG),2018-Q2,2,11,0
 Peng Wang(SIMPENG),2018-Q1,0,0,0
-Jayaram Bobba,2021-Q4,0,0,0
-Jayaram Bobba,2021-Q3,0,0,0
 Jayaram Bobba,2021-Q2,0,0,0
 Jayaram Bobba,2021-Q1,0,0,0
 Jayaram Bobba,2020-Q4,0,0,0
@@ -31423,8 +27495,6 @@ Jayaram Bobba,2018-Q4,0,0,0
 Jayaram Bobba,2018-Q3,0,0,0
 Jayaram Bobba,2018-Q2,10,157,21
 Jayaram Bobba,2018-Q1,1,0,0
-Andrei Nigmatulin,2021-Q4,0,0,0
-Andrei Nigmatulin,2021-Q3,0,0,0
 Andrei Nigmatulin,2021-Q2,0,0,0
 Andrei Nigmatulin,2021-Q1,0,0,0
 Andrei Nigmatulin,2020-Q4,0,0,0
@@ -31439,8 +27509,6 @@ Andrei Nigmatulin,2018-Q4,0,0,0
 Andrei Nigmatulin,2018-Q3,0,0,0
 Andrei Nigmatulin,2018-Q2,1,2,2
 Andrei Nigmatulin,2018-Q1,0,0,0
-Yu Yi,2021-Q4,0,0,0
-Yu Yi,2021-Q3,0,0,0
 Yu Yi,2021-Q2,0,0,0
 Yu Yi,2021-Q1,0,0,0
 Yu Yi,2020-Q4,0,0,0
@@ -31455,8 +27523,6 @@ Yu Yi,2018-Q4,0,0,0
 Yu Yi,2018-Q3,0,0,0
 Yu Yi,2018-Q2,2,231,245
 Yu Yi,2018-Q1,0,0,0
-Naman Bhalla,2021-Q4,0,0,0
-Naman Bhalla,2021-Q3,0,0,0
 Naman Bhalla,2021-Q2,0,0,0
 Naman Bhalla,2021-Q1,0,0,0
 Naman Bhalla,2020-Q4,0,0,0
@@ -31471,8 +27537,6 @@ Naman Bhalla,2018-Q4,0,0,0
 Naman Bhalla,2018-Q3,0,0,0
 Naman Bhalla,2018-Q2,1,0,0
 Naman Bhalla,2018-Q1,1,0,0
-Vikram,2021-Q4,0,0,0
-Vikram,2021-Q3,0,0,0
 Vikram,2021-Q2,0,0,0
 Vikram,2021-Q1,0,0,0
 Vikram,2020-Q4,0,0,0
@@ -31487,8 +27551,6 @@ Vikram,2018-Q4,0,0,0
 Vikram,2018-Q3,0,0,0
 Vikram,2018-Q2,1,4,4
 Vikram,2018-Q1,0,0,0
-Rafal Wojdyla,2021-Q4,0,0,0
-Rafal Wojdyla,2021-Q3,0,0,0
 Rafal Wojdyla,2021-Q2,0,0,0
 Rafal Wojdyla,2021-Q1,0,0,0
 Rafal Wojdyla,2020-Q4,0,0,0
@@ -31503,8 +27565,6 @@ Rafal Wojdyla,2018-Q4,0,0,0
 Rafal Wojdyla,2018-Q3,0,0,0
 Rafal Wojdyla,2018-Q2,2,29,0
 Rafal Wojdyla,2018-Q1,0,0,0
-Jongmin Baek,2021-Q4,0,0,0
-Jongmin Baek,2021-Q3,0,0,0
 Jongmin Baek,2021-Q2,0,0,0
 Jongmin Baek,2021-Q1,0,0,0
 Jongmin Baek,2020-Q4,0,0,0
@@ -31519,8 +27579,6 @@ Jongmin Baek,2018-Q4,0,0,0
 Jongmin Baek,2018-Q3,0,0,0
 Jongmin Baek,2018-Q2,1,0,0
 Jongmin Baek,2018-Q1,0,0,0
-Martin Patz,2021-Q4,0,0,0
-Martin Patz,2021-Q3,0,0,0
 Martin Patz,2021-Q2,0,0,0
 Martin Patz,2021-Q1,0,0,0
 Martin Patz,2020-Q4,0,0,0
@@ -31535,8 +27593,6 @@ Martin Patz,2018-Q4,0,0,0
 Martin Patz,2018-Q3,0,0,0
 Martin Patz,2018-Q2,1,0,0
 Martin Patz,2018-Q1,0,0,0
-Dan Osipov,2021-Q4,0,0,0
-Dan Osipov,2021-Q3,0,0,0
 Dan Osipov,2021-Q2,0,0,0
 Dan Osipov,2021-Q1,0,0,0
 Dan Osipov,2020-Q4,0,0,0
@@ -31551,8 +27607,6 @@ Dan Osipov,2018-Q4,0,0,0
 Dan Osipov,2018-Q3,0,0,0
 Dan Osipov,2018-Q2,15,58,128
 Dan Osipov,2018-Q1,1,0,0
-ManHyuk,2021-Q4,0,0,0
-ManHyuk,2021-Q3,0,0,0
 ManHyuk,2021-Q2,0,0,0
 ManHyuk,2021-Q1,0,0,0
 ManHyuk,2020-Q4,0,0,0
@@ -31567,8 +27621,6 @@ ManHyuk,2018-Q4,0,0,0
 ManHyuk,2018-Q3,0,0,0
 ManHyuk,2018-Q2,22,22,22
 ManHyuk,2018-Q1,62,68,68
-chinmay Das,2021-Q4,0,0,0
-chinmay Das,2021-Q3,0,0,0
 chinmay Das,2021-Q2,0,0,0
 chinmay Das,2021-Q1,0,0,0
 chinmay Das,2020-Q4,0,0,0
@@ -31583,8 +27635,6 @@ chinmay Das,2018-Q4,0,0,0
 chinmay Das,2018-Q3,0,0,0
 chinmay Das,2018-Q2,1,0,0
 chinmay Das,2018-Q1,0,0,0
-Younghee Kwon,2021-Q4,0,0,0
-Younghee Kwon,2021-Q3,0,0,0
 Younghee Kwon,2021-Q2,0,0,0
 Younghee Kwon,2021-Q1,0,0,0
 Younghee Kwon,2020-Q4,0,0,0
@@ -31599,8 +27649,6 @@ Younghee Kwon,2018-Q4,0,0,0
 Younghee Kwon,2018-Q3,0,0,0
 Younghee Kwon,2018-Q2,50,1334,753
 Younghee Kwon,2018-Q1,52,7952,23
-Jiandong Ruan,2021-Q4,0,0,0
-Jiandong Ruan,2021-Q3,0,0,0
 Jiandong Ruan,2021-Q2,0,0,0
 Jiandong Ruan,2021-Q1,0,0,0
 Jiandong Ruan,2020-Q4,0,0,0
@@ -31615,8 +27663,6 @@ Jiandong Ruan,2018-Q4,0,0,0
 Jiandong Ruan,2018-Q3,0,0,0
 Jiandong Ruan,2018-Q2,1,2,2
 Jiandong Ruan,2018-Q1,0,0,0
-Mohammad Ashraf Bhuiyan,2021-Q4,0,0,0
-Mohammad Ashraf Bhuiyan,2021-Q3,0,0,0
 Mohammad Ashraf Bhuiyan,2021-Q2,0,0,0
 Mohammad Ashraf Bhuiyan,2021-Q1,0,0,0
 Mohammad Ashraf Bhuiyan,2020-Q4,0,0,0
@@ -31631,8 +27677,6 @@ Mohammad Ashraf Bhuiyan,2018-Q4,0,0,0
 Mohammad Ashraf Bhuiyan,2018-Q3,0,0,0
 Mohammad Ashraf Bhuiyan,2018-Q2,1,4,4
 Mohammad Ashraf Bhuiyan,2018-Q1,5,229,2
-ruanjiandong,2021-Q4,0,0,0
-ruanjiandong,2021-Q3,0,0,0
 ruanjiandong,2021-Q2,0,0,0
 ruanjiandong,2021-Q1,0,0,0
 ruanjiandong,2020-Q4,0,0,0
@@ -31647,8 +27691,6 @@ ruanjiandong,2018-Q4,0,0,0
 ruanjiandong,2018-Q3,0,0,0
 ruanjiandong,2018-Q2,2,21,0
 ruanjiandong,2018-Q1,0,0,0
-Steven Schmatz,2021-Q4,0,0,0
-Steven Schmatz,2021-Q3,0,0,0
 Steven Schmatz,2021-Q2,0,0,0
 Steven Schmatz,2021-Q1,0,0,0
 Steven Schmatz,2020-Q4,0,0,0
@@ -31663,8 +27705,6 @@ Steven Schmatz,2018-Q4,0,0,0
 Steven Schmatz,2018-Q3,0,0,0
 Steven Schmatz,2018-Q2,1,2,2
 Steven Schmatz,2018-Q1,0,0,0
-Taras Sereda,2021-Q4,0,0,0
-Taras Sereda,2021-Q3,0,0,0
 Taras Sereda,2021-Q2,0,0,0
 Taras Sereda,2021-Q1,0,0,0
 Taras Sereda,2020-Q4,0,0,0
@@ -31679,8 +27719,6 @@ Taras Sereda,2018-Q4,0,0,0
 Taras Sereda,2018-Q3,0,0,0
 Taras Sereda,2018-Q2,1,0,0
 Taras Sereda,2018-Q1,0,0,0
-Jason Taylor,2021-Q4,0,0,0
-Jason Taylor,2021-Q3,0,0,0
 Jason Taylor,2021-Q2,0,0,0
 Jason Taylor,2021-Q1,0,0,0
 Jason Taylor,2020-Q4,0,0,0
@@ -31695,8 +27733,6 @@ Jason Taylor,2018-Q4,0,0,0
 Jason Taylor,2018-Q3,0,0,0
 Jason Taylor,2018-Q2,1,0,0
 Jason Taylor,2018-Q1,0,0,0
-Surry Shome,2021-Q4,0,0,0
-Surry Shome,2021-Q3,0,0,0
 Surry Shome,2021-Q2,0,0,0
 Surry Shome,2021-Q1,0,0,0
 Surry Shome,2020-Q4,0,0,0
@@ -31711,8 +27747,6 @@ Surry Shome,2018-Q4,0,0,0
 Surry Shome,2018-Q3,0,0,0
 Surry Shome,2018-Q2,1,0,3
 Surry Shome,2018-Q1,0,0,0
-maxpumperla,2021-Q4,0,0,0
-maxpumperla,2021-Q3,0,0,0
 maxpumperla,2021-Q2,0,0,0
 maxpumperla,2021-Q1,0,0,0
 maxpumperla,2020-Q4,0,0,0
@@ -31727,8 +27761,6 @@ maxpumperla,2018-Q4,0,0,0
 maxpumperla,2018-Q3,0,0,0
 maxpumperla,2018-Q2,1,39,21
 maxpumperla,2018-Q1,0,0,0
-Emanuele Ballarin,2021-Q4,0,0,0
-Emanuele Ballarin,2021-Q3,0,0,0
 Emanuele Ballarin,2021-Q2,0,0,0
 Emanuele Ballarin,2021-Q1,0,0,0
 Emanuele Ballarin,2020-Q4,0,0,0
@@ -31743,8 +27775,6 @@ Emanuele Ballarin,2018-Q4,0,0,0
 Emanuele Ballarin,2018-Q3,0,0,0
 Emanuele Ballarin,2018-Q2,2,11,0
 Emanuele Ballarin,2018-Q1,0,0,0
-jiefangxuanyan,2021-Q4,0,0,0
-jiefangxuanyan,2021-Q3,0,0,0
 jiefangxuanyan,2021-Q2,0,0,0
 jiefangxuanyan,2021-Q1,0,0,0
 jiefangxuanyan,2020-Q4,0,0,0
@@ -31759,8 +27789,6 @@ jiefangxuanyan,2018-Q4,0,0,0
 jiefangxuanyan,2018-Q3,0,0,0
 jiefangxuanyan,2018-Q2,1,0,0
 jiefangxuanyan,2018-Q1,0,0,0
-hsm207,2021-Q4,0,0,0
-hsm207,2021-Q3,0,0,0
 hsm207,2021-Q2,0,0,0
 hsm207,2021-Q1,0,0,0
 hsm207,2020-Q4,0,0,0
@@ -31775,8 +27803,6 @@ hsm207,2018-Q4,0,0,0
 hsm207,2018-Q3,0,0,0
 hsm207,2018-Q2,1,2,2
 hsm207,2018-Q1,3,2,2
-Madiyar,2021-Q4,0,0,0
-Madiyar,2021-Q3,0,0,0
 Madiyar,2021-Q2,0,0,0
 Madiyar,2021-Q1,0,0,0
 Madiyar,2020-Q4,0,0,0
@@ -31791,8 +27817,6 @@ Madiyar,2018-Q4,0,0,0
 Madiyar,2018-Q3,0,0,0
 Madiyar,2018-Q2,1,0,2
 Madiyar,2018-Q1,0,0,0
-SRIRAM VETURI,2021-Q4,0,0,0
-SRIRAM VETURI,2021-Q3,0,0,0
 SRIRAM VETURI,2021-Q2,0,0,0
 SRIRAM VETURI,2021-Q1,0,0,0
 SRIRAM VETURI,2020-Q4,0,0,0
@@ -31807,8 +27831,6 @@ SRIRAM VETURI,2018-Q4,0,0,0
 SRIRAM VETURI,2018-Q3,0,0,0
 SRIRAM VETURI,2018-Q2,1,0,0
 SRIRAM VETURI,2018-Q1,0,0,0
-Nishidha,2021-Q4,0,0,0
-Nishidha,2021-Q3,0,0,0
 Nishidha,2021-Q2,0,0,0
 Nishidha,2021-Q1,0,0,0
 Nishidha,2020-Q4,0,0,0
@@ -31823,8 +27845,6 @@ Nishidha,2018-Q4,0,0,0
 Nishidha,2018-Q3,0,0,0
 Nishidha,2018-Q2,1,18,10
 Nishidha,2018-Q1,0,0,0
-Hsien-Yang Li,2021-Q4,0,0,0
-Hsien-Yang Li,2021-Q3,0,0,0
 Hsien-Yang Li,2021-Q2,0,0,0
 Hsien-Yang Li,2021-Q1,0,0,0
 Hsien-Yang Li,2020-Q4,0,0,0
@@ -31839,8 +27859,6 @@ Hsien-Yang Li,2018-Q4,0,0,0
 Hsien-Yang Li,2018-Q3,0,0,0
 Hsien-Yang Li,2018-Q2,3,98,9
 Hsien-Yang Li,2018-Q1,0,0,0
-accraze,2021-Q4,0,0,0
-accraze,2021-Q3,0,0,0
 accraze,2021-Q2,0,0,0
 accraze,2021-Q1,0,0,0
 accraze,2020-Q4,0,0,0
@@ -31855,8 +27873,6 @@ accraze,2018-Q4,0,0,0
 accraze,2018-Q3,0,0,0
 accraze,2018-Q2,3,23,8
 accraze,2018-Q1,0,0,0
-tucan,2021-Q4,0,0,0
-tucan,2021-Q3,0,0,0
 tucan,2021-Q2,0,0,0
 tucan,2021-Q1,0,0,0
 tucan,2020-Q4,0,0,0
@@ -31871,8 +27887,6 @@ tucan,2018-Q4,0,0,0
 tucan,2018-Q3,0,0,0
 tucan,2018-Q2,2,0,0
 tucan,2018-Q1,0,0,0
-Karan Kaw,2021-Q4,0,0,0
-Karan Kaw,2021-Q3,0,0,0
 Karan Kaw,2021-Q2,0,0,0
 Karan Kaw,2021-Q1,0,0,0
 Karan Kaw,2020-Q4,0,0,0
@@ -31887,8 +27901,6 @@ Karan Kaw,2018-Q4,0,0,0
 Karan Kaw,2018-Q3,0,0,0
 Karan Kaw,2018-Q2,3,0,0
 Karan Kaw,2018-Q1,0,0,0
-Chikanaga Tomoyuki,2021-Q4,0,0,0
-Chikanaga Tomoyuki,2021-Q3,0,0,0
 Chikanaga Tomoyuki,2021-Q2,0,0,0
 Chikanaga Tomoyuki,2021-Q1,0,0,0
 Chikanaga Tomoyuki,2020-Q4,0,0,0
@@ -31903,8 +27915,6 @@ Chikanaga Tomoyuki,2018-Q4,0,0,0
 Chikanaga Tomoyuki,2018-Q3,0,0,0
 Chikanaga Tomoyuki,2018-Q2,2,39,2
 Chikanaga Tomoyuki,2018-Q1,3,14,0
-Benjamin H. Myara,2021-Q4,0,0,0
-Benjamin H. Myara,2021-Q3,0,0,0
 Benjamin H. Myara,2021-Q2,0,0,0
 Benjamin H. Myara,2021-Q1,0,0,0
 Benjamin H. Myara,2020-Q4,0,0,0
@@ -31919,8 +27929,6 @@ Benjamin H. Myara,2018-Q4,0,0,0
 Benjamin H. Myara,2018-Q3,0,0,0
 Benjamin H. Myara,2018-Q2,2,3,3
 Benjamin H. Myara,2018-Q1,0,0,0
-chengzhi chen,2021-Q4,0,0,0
-chengzhi chen,2021-Q3,0,0,0
 chengzhi chen,2021-Q2,0,0,0
 chengzhi chen,2021-Q1,0,0,0
 chengzhi chen,2020-Q4,0,0,0
@@ -31935,8 +27943,6 @@ chengzhi chen,2018-Q4,0,0,0
 chengzhi chen,2018-Q3,0,0,0
 chengzhi chen,2018-Q2,1,0,0
 chengzhi chen,2018-Q1,4,110,4
-An Jiaoyang,2021-Q4,0,0,0
-An Jiaoyang,2021-Q3,0,0,0
 An Jiaoyang,2021-Q2,0,0,0
 An Jiaoyang,2021-Q1,0,0,0
 An Jiaoyang,2020-Q4,0,0,0
@@ -31951,8 +27957,6 @@ An Jiaoyang,2018-Q4,0,0,0
 An Jiaoyang,2018-Q3,0,0,0
 An Jiaoyang,2018-Q2,1,2,2
 An Jiaoyang,2018-Q1,0,0,0
-apantykhin,2021-Q4,0,0,0
-apantykhin,2021-Q3,0,0,0
 apantykhin,2021-Q2,0,0,0
 apantykhin,2021-Q1,0,0,0
 apantykhin,2020-Q4,0,0,0
@@ -31967,8 +27971,6 @@ apantykhin,2018-Q4,0,0,0
 apantykhin,2018-Q3,0,0,0
 apantykhin,2018-Q2,2,17,5
 apantykhin,2018-Q1,0,0,0
-Jesse,2021-Q4,0,0,0
-Jesse,2021-Q3,0,0,0
 Jesse,2021-Q2,0,0,0
 Jesse,2021-Q1,0,0,0
 Jesse,2020-Q4,0,0,0
@@ -31983,8 +27985,6 @@ Jesse,2018-Q4,0,0,0
 Jesse,2018-Q3,0,0,0
 Jesse,2018-Q2,4,7,8
 Jesse,2018-Q1,0,0,0
-Courtial Florian,2021-Q4,0,0,0
-Courtial Florian,2021-Q3,0,0,0
 Courtial Florian,2021-Q2,0,0,0
 Courtial Florian,2021-Q1,0,0,0
 Courtial Florian,2020-Q4,0,0,0
@@ -31999,8 +27999,6 @@ Courtial Florian,2018-Q4,0,0,0
 Courtial Florian,2018-Q3,0,0,0
 Courtial Florian,2018-Q2,1,0,0
 Courtial Florian,2018-Q1,0,0,0
-KinmanLam,2021-Q4,0,0,0
-KinmanLam,2021-Q3,0,0,0
 KinmanLam,2021-Q2,0,0,0
 KinmanLam,2021-Q1,0,0,0
 KinmanLam,2020-Q4,0,0,0
@@ -32015,8 +28013,6 @@ KinmanLam,2018-Q4,0,0,0
 KinmanLam,2018-Q3,0,0,0
 KinmanLam,2018-Q2,1,0,3
 KinmanLam,2018-Q1,0,0,0
-vchigrin,2021-Q4,0,0,0
-vchigrin,2021-Q3,0,0,0
 vchigrin,2021-Q2,0,0,0
 vchigrin,2021-Q1,0,0,0
 vchigrin,2020-Q4,0,0,0
@@ -32031,8 +28027,6 @@ vchigrin,2018-Q4,0,0,0
 vchigrin,2018-Q3,0,0,0
 vchigrin,2018-Q2,7,445,120
 vchigrin,2018-Q1,4,65,14
-Dan Douthit,2021-Q4,0,0,0
-Dan Douthit,2021-Q3,0,0,0
 Dan Douthit,2021-Q2,0,0,0
 Dan Douthit,2021-Q1,0,0,0
 Dan Douthit,2020-Q4,0,0,0
@@ -32047,8 +28041,6 @@ Dan Douthit,2018-Q4,0,0,0
 Dan Douthit,2018-Q3,0,0,0
 Dan Douthit,2018-Q2,2,11,36
 Dan Douthit,2018-Q1,0,0,0
-G K,2021-Q4,0,0,0
-G K,2021-Q3,0,0,0
 G K,2021-Q2,0,0,0
 G K,2021-Q1,0,0,0
 G K,2020-Q4,0,0,0
@@ -32063,8 +28055,6 @@ G K,2018-Q4,0,0,0
 G K,2018-Q3,0,0,0
 G K,2018-Q2,3,9,3
 G K,2018-Q1,0,0,0
-Frédéric Branchaud-Charron,2021-Q4,0,0,0
-Frédéric Branchaud-Charron,2021-Q3,0,0,0
 Frédéric Branchaud-Charron,2021-Q2,0,0,0
 Frédéric Branchaud-Charron,2021-Q1,0,0,0
 Frédéric Branchaud-Charron,2020-Q4,0,0,0
@@ -32079,8 +28069,6 @@ Frédéric Branchaud-Charron,2018-Q4,0,0,0
 Frédéric Branchaud-Charron,2018-Q3,0,0,0
 Frédéric Branchaud-Charron,2018-Q2,4,68,18
 Frédéric Branchaud-Charron,2018-Q1,0,0,0
-jsawruk,2021-Q4,0,0,0
-jsawruk,2021-Q3,0,0,0
 jsawruk,2021-Q2,0,0,0
 jsawruk,2021-Q1,0,0,0
 jsawruk,2020-Q4,0,0,0
@@ -32095,8 +28083,6 @@ jsawruk,2018-Q4,0,0,0
 jsawruk,2018-Q3,0,0,0
 jsawruk,2018-Q2,1,2,2
 jsawruk,2018-Q1,0,0,0
-ImSheridan,2021-Q4,0,0,0
-ImSheridan,2021-Q3,0,0,0
 ImSheridan,2021-Q2,0,0,0
 ImSheridan,2021-Q1,0,0,0
 ImSheridan,2020-Q4,0,0,0
@@ -32111,8 +28097,6 @@ ImSheridan,2018-Q4,0,0,0
 ImSheridan,2018-Q3,0,0,0
 ImSheridan,2018-Q2,22,129,137
 ImSheridan,2018-Q1,53,213,198
-leiiwang,2021-Q4,0,0,0
-leiiwang,2021-Q3,0,0,0
 leiiwang,2021-Q2,0,0,0
 leiiwang,2021-Q1,0,0,0
 leiiwang,2020-Q4,0,0,0
@@ -32127,8 +28111,6 @@ leiiwang,2018-Q4,0,0,0
 leiiwang,2018-Q3,0,0,0
 leiiwang,2018-Q2,1,8,2
 leiiwang,2018-Q1,0,0,0
-Roland Zimmermann,2021-Q4,0,0,0
-Roland Zimmermann,2021-Q3,0,0,0
 Roland Zimmermann,2021-Q2,0,0,0
 Roland Zimmermann,2021-Q1,0,0,0
 Roland Zimmermann,2020-Q4,0,0,0
@@ -32143,8 +28125,6 @@ Roland Zimmermann,2018-Q4,0,0,0
 Roland Zimmermann,2018-Q3,0,0,0
 Roland Zimmermann,2018-Q2,2,167,61
 Roland Zimmermann,2018-Q1,0,0,0
-Martin Zeitler,2021-Q4,0,0,0
-Martin Zeitler,2021-Q3,0,0,0
 Martin Zeitler,2021-Q2,0,0,0
 Martin Zeitler,2021-Q1,0,0,0
 Martin Zeitler,2020-Q4,0,0,0
@@ -32159,8 +28139,6 @@ Martin Zeitler,2018-Q4,0,0,0
 Martin Zeitler,2018-Q3,0,0,0
 Martin Zeitler,2018-Q2,1,3,3
 Martin Zeitler,2018-Q1,0,0,0
-Benoit Steiner,2021-Q4,0,0,0
-Benoit Steiner,2021-Q3,0,0,0
 Benoit Steiner,2021-Q2,0,0,0
 Benoit Steiner,2021-Q1,0,0,0
 Benoit Steiner,2020-Q4,0,0,0
@@ -32175,8 +28153,6 @@ Benoit Steiner,2018-Q4,0,0,0
 Benoit Steiner,2018-Q3,0,0,0
 Benoit Steiner,2018-Q2,125,3113,1042
 Benoit Steiner,2018-Q1,302,261826,1302
-Xiaoqiang Zheng,2021-Q4,0,0,0
-Xiaoqiang Zheng,2021-Q3,0,0,0
 Xiaoqiang Zheng,2021-Q2,0,0,0
 Xiaoqiang Zheng,2021-Q1,0,0,0
 Xiaoqiang Zheng,2020-Q4,0,0,0
@@ -32191,8 +28167,6 @@ Xiaoqiang Zheng,2018-Q4,0,0,0
 Xiaoqiang Zheng,2018-Q3,0,0,0
 Xiaoqiang Zheng,2018-Q2,2,17,3
 Xiaoqiang Zheng,2018-Q1,4,133,4
-Felix Abecassis,2021-Q4,0,0,0
-Felix Abecassis,2021-Q3,0,0,0
 Felix Abecassis,2021-Q2,0,0,0
 Felix Abecassis,2021-Q1,0,0,0
 Felix Abecassis,2020-Q4,0,0,0
@@ -32207,8 +28181,6 @@ Felix Abecassis,2018-Q4,0,0,0
 Felix Abecassis,2018-Q3,0,0,0
 Felix Abecassis,2018-Q2,2,3,3
 Felix Abecassis,2018-Q1,1,8,0
-Jesse Benson,2021-Q4,0,0,0
-Jesse Benson,2021-Q3,0,0,0
 Jesse Benson,2021-Q2,0,0,0
 Jesse Benson,2021-Q1,0,0,0
 Jesse Benson,2020-Q4,0,0,0
@@ -32223,8 +28195,6 @@ Jesse Benson,2018-Q4,0,0,0
 Jesse Benson,2018-Q3,0,0,0
 Jesse Benson,2018-Q2,1,4,0
 Jesse Benson,2018-Q1,0,0,0
-JxKing,2021-Q4,0,0,0
-JxKing,2021-Q3,0,0,0
 JxKing,2021-Q2,0,0,0
 JxKing,2021-Q1,0,0,0
 JxKing,2020-Q4,0,0,0
@@ -32239,8 +28209,6 @@ JxKing,2018-Q4,0,0,0
 JxKing,2018-Q3,0,0,0
 JxKing,2018-Q2,6,52,35
 JxKing,2018-Q1,4,522,0
-Chris Ying,2021-Q4,0,0,0
-Chris Ying,2021-Q3,0,0,0
 Chris Ying,2021-Q2,0,0,0
 Chris Ying,2021-Q1,0,0,0
 Chris Ying,2020-Q4,0,0,0
@@ -32255,8 +28223,6 @@ Chris Ying,2018-Q4,0,0,0
 Chris Ying,2018-Q3,0,0,0
 Chris Ying,2018-Q2,16,405,78
 Chris Ying,2018-Q1,10,68,4
-Florian Courtial,2021-Q4,0,0,0
-Florian Courtial,2021-Q3,0,0,0
 Florian Courtial,2021-Q2,0,0,0
 Florian Courtial,2021-Q1,0,0,0
 Florian Courtial,2020-Q4,0,0,0
@@ -32271,8 +28237,6 @@ Florian Courtial,2018-Q4,0,0,0
 Florian Courtial,2018-Q3,0,0,0
 Florian Courtial,2018-Q2,2,30,0
 Florian Courtial,2018-Q1,0,0,0
-Rob Sloan,2021-Q4,0,0,0
-Rob Sloan,2021-Q3,0,0,0
 Rob Sloan,2021-Q2,0,0,0
 Rob Sloan,2021-Q1,0,0,0
 Rob Sloan,2020-Q4,0,0,0
@@ -32287,8 +28251,6 @@ Rob Sloan,2018-Q4,0,0,0
 Rob Sloan,2018-Q3,0,0,0
 Rob Sloan,2018-Q2,6,900,642
 Rob Sloan,2018-Q1,0,0,0
-Guido Zuidhof,2021-Q4,0,0,0
-Guido Zuidhof,2021-Q3,0,0,0
 Guido Zuidhof,2021-Q2,0,0,0
 Guido Zuidhof,2021-Q1,0,0,0
 Guido Zuidhof,2020-Q4,0,0,0
@@ -32303,8 +28265,6 @@ Guido Zuidhof,2018-Q4,0,0,0
 Guido Zuidhof,2018-Q3,0,0,0
 Guido Zuidhof,2018-Q2,1,0,0
 Guido Zuidhof,2018-Q1,0,0,0
-voegtlel,2021-Q4,0,0,0
-voegtlel,2021-Q3,0,0,0
 voegtlel,2021-Q2,0,0,0
 voegtlel,2021-Q1,0,0,0
 voegtlel,2020-Q4,0,0,0
@@ -32319,8 +28279,6 @@ voegtlel,2018-Q4,0,0,0
 voegtlel,2018-Q3,0,0,0
 voegtlel,2018-Q2,2,36,30
 voegtlel,2018-Q1,0,0,0
-braincodercn,2021-Q4,0,0,0
-braincodercn,2021-Q3,0,0,0
 braincodercn,2021-Q2,0,0,0
 braincodercn,2021-Q1,0,0,0
 braincodercn,2020-Q4,0,0,0
@@ -32335,8 +28293,6 @@ braincodercn,2018-Q4,0,0,0
 braincodercn,2018-Q3,0,0,0
 braincodercn,2018-Q2,1,0,0
 braincodercn,2018-Q1,0,0,0
-Brian Zier,2021-Q4,0,0,0
-Brian Zier,2021-Q3,0,0,0
 Brian Zier,2021-Q2,0,0,0
 Brian Zier,2021-Q1,0,0,0
 Brian Zier,2020-Q4,0,0,0
@@ -32351,8 +28307,6 @@ Brian Zier,2018-Q4,0,0,0
 Brian Zier,2018-Q3,0,0,0
 Brian Zier,2018-Q2,1,2,2
 Brian Zier,2018-Q1,0,0,0
-AD-530,2021-Q4,0,0,0
-AD-530,2021-Q3,0,0,0
 AD-530,2021-Q2,0,0,0
 AD-530,2021-Q1,0,0,0
 AD-530,2020-Q4,0,0,0
@@ -32367,8 +28321,6 @@ AD-530,2018-Q4,0,0,0
 AD-530,2018-Q3,0,0,0
 AD-530,2018-Q2,1,2,0
 AD-530,2018-Q1,0,0,0
-crafet,2021-Q4,0,0,0
-crafet,2021-Q3,0,0,0
 crafet,2021-Q2,0,0,0
 crafet,2021-Q1,0,0,0
 crafet,2020-Q4,0,0,0
@@ -32383,8 +28335,6 @@ crafet,2018-Q4,0,0,0
 crafet,2018-Q3,0,0,0
 crafet,2018-Q2,1,0,2
 crafet,2018-Q1,0,0,0
-Ankur Taly,2021-Q4,0,0,0
-Ankur Taly,2021-Q3,0,0,0
 Ankur Taly,2021-Q2,0,0,0
 Ankur Taly,2021-Q1,0,0,0
 Ankur Taly,2020-Q4,0,0,0
@@ -32399,8 +28349,6 @@ Ankur Taly,2018-Q4,0,0,0
 Ankur Taly,2018-Q3,0,0,0
 Ankur Taly,2018-Q2,2,6,6
 Ankur Taly,2018-Q1,143,1673,320
-Sdalbsoo,2021-Q4,0,0,0
-Sdalbsoo,2021-Q3,0,0,0
 Sdalbsoo,2021-Q2,0,0,0
 Sdalbsoo,2021-Q1,0,0,0
 Sdalbsoo,2020-Q4,0,0,0
@@ -32415,8 +28363,6 @@ Sdalbsoo,2018-Q4,0,0,0
 Sdalbsoo,2018-Q3,0,0,0
 Sdalbsoo,2018-Q2,1,2,2
 Sdalbsoo,2018-Q1,0,0,0
-Justine Tunney,2021-Q4,0,0,0
-Justine Tunney,2021-Q3,0,0,0
 Justine Tunney,2021-Q2,0,0,0
 Justine Tunney,2021-Q1,0,0,0
 Justine Tunney,2020-Q4,0,0,0
@@ -32431,8 +28377,6 @@ Justine Tunney,2018-Q4,0,0,0
 Justine Tunney,2018-Q3,0,0,0
 Justine Tunney,2018-Q2,14,154,207
 Justine Tunney,2018-Q1,80,4397,1978
-Fergal Cotter,2021-Q4,0,0,0
-Fergal Cotter,2021-Q3,0,0,0
 Fergal Cotter,2021-Q2,0,0,0
 Fergal Cotter,2021-Q1,0,0,0
 Fergal Cotter,2020-Q4,0,0,0
@@ -32447,8 +28391,6 @@ Fergal Cotter,2018-Q4,0,0,0
 Fergal Cotter,2018-Q3,0,0,0
 Fergal Cotter,2018-Q2,1,4,4
 Fergal Cotter,2018-Q1,0,0,0
-gdh1995,2021-Q4,0,0,0
-gdh1995,2021-Q3,0,0,0
 gdh1995,2021-Q2,0,0,0
 gdh1995,2021-Q1,0,0,0
 gdh1995,2020-Q4,0,0,0
@@ -32463,8 +28405,6 @@ gdh1995,2018-Q4,0,0,0
 gdh1995,2018-Q3,0,0,0
 gdh1995,2018-Q2,1,0,0
 gdh1995,2018-Q1,0,0,0
-Sarah Edkins,2021-Q4,0,0,0
-Sarah Edkins,2021-Q3,0,0,0
 Sarah Edkins,2021-Q2,0,0,0
 Sarah Edkins,2021-Q1,0,0,0
 Sarah Edkins,2020-Q4,0,0,0
@@ -32479,8 +28419,6 @@ Sarah Edkins,2018-Q4,0,0,0
 Sarah Edkins,2018-Q3,0,0,0
 Sarah Edkins,2018-Q2,1,0,0
 Sarah Edkins,2018-Q1,0,0,0
-soonson,2021-Q4,0,0,0
-soonson,2021-Q3,0,0,0
 soonson,2021-Q2,0,0,0
 soonson,2021-Q1,0,0,0
 soonson,2020-Q4,0,0,0
@@ -32495,8 +28433,6 @@ soonson,2018-Q4,0,0,0
 soonson,2018-Q3,0,0,0
 soonson,2018-Q2,1,25,4
 soonson,2018-Q1,0,0,0
-Nand Dalal,2021-Q4,0,0,0
-Nand Dalal,2021-Q3,0,0,0
 Nand Dalal,2021-Q2,0,0,0
 Nand Dalal,2021-Q1,0,0,0
 Nand Dalal,2020-Q4,0,0,0
@@ -32511,8 +28447,6 @@ Nand Dalal,2018-Q4,0,0,0
 Nand Dalal,2018-Q3,0,0,0
 Nand Dalal,2018-Q2,2,39,3
 Nand Dalal,2018-Q1,0,0,0
-Qing ZHao,2021-Q4,0,0,0
-Qing ZHao,2021-Q3,0,0,0
 Qing ZHao,2021-Q2,0,0,0
 Qing ZHao,2021-Q1,0,0,0
 Qing ZHao,2020-Q4,0,0,0
@@ -32527,8 +28461,6 @@ Qing ZHao,2018-Q4,0,0,0
 Qing ZHao,2018-Q3,0,0,0
 Qing ZHao,2018-Q2,1,0,0
 Qing ZHao,2018-Q1,0,0,0
-Bruno Goncalves,2021-Q4,0,0,0
-Bruno Goncalves,2021-Q3,0,0,0
 Bruno Goncalves,2021-Q2,0,0,0
 Bruno Goncalves,2021-Q1,0,0,0
 Bruno Goncalves,2020-Q4,0,0,0
@@ -32543,8 +28475,6 @@ Bruno Goncalves,2018-Q4,0,0,0
 Bruno Goncalves,2018-Q3,0,0,0
 Bruno Goncalves,2018-Q2,1,2,0
 Bruno Goncalves,2018-Q1,0,0,0
-krantideep95,2021-Q4,0,0,0
-krantideep95,2021-Q3,0,0,0
 krantideep95,2021-Q2,0,0,0
 krantideep95,2021-Q1,0,0,0
 krantideep95,2020-Q4,0,0,0
@@ -32559,8 +28489,6 @@ krantideep95,2018-Q4,0,0,0
 krantideep95,2018-Q3,0,0,0
 krantideep95,2018-Q2,2,0,0
 krantideep95,2018-Q1,0,0,0
-Jesse Gumz,2021-Q4,0,0,0
-Jesse Gumz,2021-Q3,0,0,0
 Jesse Gumz,2021-Q2,0,0,0
 Jesse Gumz,2021-Q1,0,0,0
 Jesse Gumz,2020-Q4,0,0,0
@@ -32575,8 +28503,6 @@ Jesse Gumz,2018-Q4,0,0,0
 Jesse Gumz,2018-Q3,0,0,0
 Jesse Gumz,2018-Q2,2,12,2
 Jesse Gumz,2018-Q1,0,0,0
-u2takey,2021-Q4,0,0,0
-u2takey,2021-Q3,0,0,0
 u2takey,2021-Q2,0,0,0
 u2takey,2021-Q1,0,0,0
 u2takey,2020-Q4,0,0,0
@@ -32591,8 +28517,6 @@ u2takey,2018-Q4,0,0,0
 u2takey,2018-Q3,0,0,0
 u2takey,2018-Q2,1,3,0
 u2takey,2018-Q1,0,0,0
-Utkarsh Upadhyay,2021-Q4,0,0,0
-Utkarsh Upadhyay,2021-Q3,0,0,0
 Utkarsh Upadhyay,2021-Q2,0,0,0
 Utkarsh Upadhyay,2021-Q1,0,0,0
 Utkarsh Upadhyay,2020-Q4,0,0,0
@@ -32607,8 +28531,6 @@ Utkarsh Upadhyay,2018-Q4,0,0,0
 Utkarsh Upadhyay,2018-Q3,0,0,0
 Utkarsh Upadhyay,2018-Q2,1,4,0
 Utkarsh Upadhyay,2018-Q1,0,0,0
-Joel Hestness,2021-Q4,0,0,0
-Joel Hestness,2021-Q3,0,0,0
 Joel Hestness,2021-Q2,0,0,0
 Joel Hestness,2021-Q1,0,0,0
 Joel Hestness,2020-Q4,0,0,0
@@ -32623,8 +28545,6 @@ Joel Hestness,2018-Q4,0,0,0
 Joel Hestness,2018-Q3,0,0,0
 Joel Hestness,2018-Q2,1,0,0
 Joel Hestness,2018-Q1,0,0,0
-Yilei (Dolee) Yang,2021-Q4,0,0,0
-Yilei (Dolee) Yang,2021-Q3,0,0,0
 Yilei (Dolee) Yang,2021-Q2,0,0,0
 Yilei (Dolee) Yang,2021-Q1,0,0,0
 Yilei (Dolee) Yang,2020-Q4,0,0,0
@@ -32639,8 +28559,6 @@ Yilei (Dolee) Yang,2018-Q4,0,0,0
 Yilei (Dolee) Yang,2018-Q3,0,0,0
 Yilei (Dolee) Yang,2018-Q2,1,3,3
 Yilei (Dolee) Yang,2018-Q1,0,0,0
-Jan Zikes,2021-Q4,0,0,0
-Jan Zikes,2021-Q3,0,0,0
 Jan Zikes,2021-Q2,0,0,0
 Jan Zikes,2021-Q1,0,0,0
 Jan Zikes,2020-Q4,0,0,0
@@ -32655,8 +28573,6 @@ Jan Zikes,2018-Q4,0,0,0
 Jan Zikes,2018-Q3,0,0,0
 Jan Zikes,2018-Q2,1,0,0
 Jan Zikes,2018-Q1,0,0,0
-Paul Van Eck,2021-Q4,0,0,0
-Paul Van Eck,2021-Q3,0,0,0
 Paul Van Eck,2021-Q2,0,0,0
 Paul Van Eck,2021-Q1,0,0,0
 Paul Van Eck,2020-Q4,0,0,0
@@ -32671,8 +28587,6 @@ Paul Van Eck,2018-Q4,0,0,0
 Paul Van Eck,2018-Q3,0,0,0
 Paul Van Eck,2018-Q2,8,73,28
 Paul Van Eck,2018-Q1,3,9,5
-pillarpond,2021-Q4,0,0,0
-pillarpond,2021-Q3,0,0,0
 pillarpond,2021-Q2,0,0,0
 pillarpond,2021-Q1,0,0,0
 pillarpond,2020-Q4,0,0,0
@@ -32687,8 +28601,6 @@ pillarpond,2018-Q4,0,0,0
 pillarpond,2018-Q3,0,0,0
 pillarpond,2018-Q2,1,2,0
 pillarpond,2018-Q1,0,0,0
-Achal Shah,2021-Q4,0,0,0
-Achal Shah,2021-Q3,0,0,0
 Achal Shah,2021-Q2,0,0,0
 Achal Shah,2021-Q1,0,0,0
 Achal Shah,2020-Q4,0,0,0
@@ -32703,8 +28615,6 @@ Achal Shah,2018-Q4,0,0,0
 Achal Shah,2018-Q3,0,0,0
 Achal Shah,2018-Q2,1,0,0
 Achal Shah,2018-Q1,0,0,0
-P-Hidringer,2021-Q4,0,0,0
-P-Hidringer,2021-Q3,0,0,0
 P-Hidringer,2021-Q2,0,0,0
 P-Hidringer,2021-Q1,0,0,0
 P-Hidringer,2020-Q4,0,0,0
@@ -32719,8 +28629,6 @@ P-Hidringer,2018-Q4,0,0,0
 P-Hidringer,2018-Q3,0,0,0
 P-Hidringer,2018-Q2,1,0,0
 P-Hidringer,2018-Q1,0,0,0
-Smit Shilu,2021-Q4,0,0,0
-Smit Shilu,2021-Q3,0,0,0
 Smit Shilu,2021-Q2,0,0,0
 Smit Shilu,2021-Q1,0,0,0
 Smit Shilu,2020-Q4,0,0,0
@@ -32735,8 +28643,6 @@ Smit Shilu,2018-Q4,0,0,0
 Smit Shilu,2018-Q3,0,0,0
 Smit Shilu,2018-Q2,2,0,0
 Smit Shilu,2018-Q1,1,0,2
-Zhixian Yan,2021-Q4,0,0,0
-Zhixian Yan,2021-Q3,0,0,0
 Zhixian Yan,2021-Q2,0,0,0
 Zhixian Yan,2021-Q1,0,0,0
 Zhixian Yan,2020-Q4,0,0,0
@@ -32751,8 +28657,6 @@ Zhixian Yan,2018-Q4,0,0,0
 Zhixian Yan,2018-Q3,0,0,0
 Zhixian Yan,2018-Q2,3,118,44
 Zhixian Yan,2018-Q1,34,1832,98
-Letian Feng,2021-Q4,0,0,0
-Letian Feng,2021-Q3,0,0,0
 Letian Feng,2021-Q2,0,0,0
 Letian Feng,2021-Q1,0,0,0
 Letian Feng,2020-Q4,0,0,0
@@ -32767,8 +28671,6 @@ Letian Feng,2018-Q4,0,0,0
 Letian Feng,2018-Q3,0,0,0
 Letian Feng,2018-Q2,3,3,5
 Letian Feng,2018-Q1,0,0,0
-jjsjann123,2021-Q4,0,0,0
-jjsjann123,2021-Q3,0,0,0
 jjsjann123,2021-Q2,0,0,0
 jjsjann123,2021-Q1,0,0,0
 jjsjann123,2020-Q4,0,0,0
@@ -32783,8 +28685,6 @@ jjsjann123,2018-Q4,0,0,0
 jjsjann123,2018-Q3,0,0,0
 jjsjann123,2018-Q2,3,174,318
 jjsjann123,2018-Q1,9,181,180
-tucan9389,2021-Q4,0,0,0
-tucan9389,2021-Q3,0,0,0
 tucan9389,2021-Q2,0,0,0
 tucan9389,2021-Q1,0,0,0
 tucan9389,2020-Q4,0,0,0
@@ -32799,8 +28699,6 @@ tucan9389,2018-Q4,0,0,0
 tucan9389,2018-Q3,0,0,0
 tucan9389,2018-Q2,1,0,0
 tucan9389,2018-Q1,0,0,0
-Krish Ravindranath,2021-Q4,0,0,0
-Krish Ravindranath,2021-Q3,0,0,0
 Krish Ravindranath,2021-Q2,0,0,0
 Krish Ravindranath,2021-Q1,0,0,0
 Krish Ravindranath,2020-Q4,0,0,0
@@ -32815,8 +28713,6 @@ Krish Ravindranath,2018-Q4,0,0,0
 Krish Ravindranath,2018-Q3,0,0,0
 Krish Ravindranath,2018-Q2,6,15,10
 Krish Ravindranath,2018-Q1,1,3,2
-Anya Petrova,2021-Q4,0,0,0
-Anya Petrova,2021-Q3,0,0,0
 Anya Petrova,2021-Q2,0,0,0
 Anya Petrova,2021-Q1,0,0,0
 Anya Petrova,2020-Q4,0,0,0
@@ -32831,8 +28727,6 @@ Anya Petrova,2018-Q4,0,0,0
 Anya Petrova,2018-Q3,0,0,0
 Anya Petrova,2018-Q2,1,0,0
 Anya Petrova,2018-Q1,0,0,0
-Aditya Yogi,2021-Q4,0,0,0
-Aditya Yogi,2021-Q3,0,0,0
 Aditya Yogi,2021-Q2,0,0,0
 Aditya Yogi,2021-Q1,0,0,0
 Aditya Yogi,2020-Q4,0,0,0
@@ -32847,8 +28741,6 @@ Aditya Yogi,2018-Q4,0,0,0
 Aditya Yogi,2018-Q3,0,0,0
 Aditya Yogi,2018-Q2,1,0,0
 Aditya Yogi,2018-Q1,0,0,0
-Elson Rodriguez,2021-Q4,0,0,0
-Elson Rodriguez,2021-Q3,0,0,0
 Elson Rodriguez,2021-Q2,0,0,0
 Elson Rodriguez,2021-Q1,0,0,0
 Elson Rodriguez,2020-Q4,0,0,0
@@ -32863,8 +28755,6 @@ Elson Rodriguez,2018-Q4,0,0,0
 Elson Rodriguez,2018-Q3,0,0,0
 Elson Rodriguez,2018-Q2,2,69,16
 Elson Rodriguez,2018-Q1,0,0,0
-Mostafa Alaa,2021-Q4,0,0,0
-Mostafa Alaa,2021-Q3,0,0,0
 Mostafa Alaa,2021-Q2,0,0,0
 Mostafa Alaa,2021-Q1,0,0,0
 Mostafa Alaa,2020-Q4,0,0,0
@@ -32879,8 +28769,6 @@ Mostafa Alaa,2018-Q4,0,0,0
 Mostafa Alaa,2018-Q3,0,0,0
 Mostafa Alaa,2018-Q2,1,0,0
 Mostafa Alaa,2018-Q1,0,0,0
-joel-shor,2021-Q4,0,0,0
-joel-shor,2021-Q3,0,0,0
 joel-shor,2021-Q2,0,0,0
 joel-shor,2021-Q1,0,0,0
 joel-shor,2020-Q4,0,0,0
@@ -32895,8 +28783,6 @@ joel-shor,2018-Q4,0,0,0
 joel-shor,2018-Q3,0,0,0
 joel-shor,2018-Q2,43,569,384
 joel-shor,2018-Q1,12,94,60
-Maciej,2021-Q4,0,0,0
-Maciej,2021-Q3,0,0,0
 Maciej,2021-Q2,0,0,0
 Maciej,2021-Q1,0,0,0
 Maciej,2020-Q4,0,0,0
@@ -32911,8 +28797,6 @@ Maciej,2018-Q4,0,0,0
 Maciej,2018-Q3,0,0,0
 Maciej,2018-Q2,2,7,4
 Maciej,2018-Q1,0,0,0
-Eli Bendersky,2021-Q4,0,0,0
-Eli Bendersky,2021-Q3,0,0,0
 Eli Bendersky,2021-Q2,0,0,0
 Eli Bendersky,2021-Q1,0,0,0
 Eli Bendersky,2020-Q4,0,0,0
@@ -32927,8 +28811,6 @@ Eli Bendersky,2018-Q4,0,0,0
 Eli Bendersky,2018-Q3,0,0,0
 Eli Bendersky,2018-Q2,7,24,5
 Eli Bendersky,2018-Q1,14,278,279
-rmanyari,2021-Q4,0,0,0
-rmanyari,2021-Q3,0,0,0
 rmanyari,2021-Q2,0,0,0
 rmanyari,2021-Q1,0,0,0
 rmanyari,2020-Q4,0,0,0
@@ -32943,8 +28825,6 @@ rmanyari,2018-Q4,0,0,0
 rmanyari,2018-Q3,0,0,0
 rmanyari,2018-Q2,1,0,0
 rmanyari,2018-Q1,0,0,0
-Sherry Moore,2021-Q4,0,0,0
-Sherry Moore,2021-Q3,0,0,0
 Sherry Moore,2021-Q2,0,0,0
 Sherry Moore,2021-Q1,0,0,0
 Sherry Moore,2020-Q4,0,0,0
@@ -32959,8 +28839,6 @@ Sherry Moore,2018-Q4,0,0,0
 Sherry Moore,2018-Q3,0,0,0
 Sherry Moore,2018-Q2,10,127,34
 Sherry Moore,2018-Q1,0,0,0
-QingYing Chen,2021-Q4,0,0,0
-QingYing Chen,2021-Q3,0,0,0
 QingYing Chen,2021-Q2,0,0,0
 QingYing Chen,2021-Q1,0,0,0
 QingYing Chen,2020-Q4,0,0,0
@@ -32975,8 +28853,6 @@ QingYing Chen,2018-Q4,0,0,0
 QingYing Chen,2018-Q3,0,0,0
 QingYing Chen,2018-Q2,2,39,8
 QingYing Chen,2018-Q1,0,0,0
-Stefan Schweter,2021-Q4,0,0,0
-Stefan Schweter,2021-Q3,0,0,0
 Stefan Schweter,2021-Q2,0,0,0
 Stefan Schweter,2021-Q1,0,0,0
 Stefan Schweter,2020-Q4,0,0,0
@@ -32991,8 +28867,6 @@ Stefan Schweter,2018-Q4,0,0,0
 Stefan Schweter,2018-Q3,0,0,0
 Stefan Schweter,2018-Q2,1,0,0
 Stefan Schweter,2018-Q1,0,0,0
-Sandeep N Gupta,2021-Q4,0,0,0
-Sandeep N Gupta,2021-Q3,0,0,0
 Sandeep N Gupta,2021-Q2,0,0,0
 Sandeep N Gupta,2021-Q1,0,0,0
 Sandeep N Gupta,2020-Q4,0,0,0
@@ -33007,8 +28881,6 @@ Sandeep N Gupta,2018-Q4,0,0,0
 Sandeep N Gupta,2018-Q3,0,0,0
 Sandeep N Gupta,2018-Q2,1,55,19
 Sandeep N Gupta,2018-Q1,2,83,34
-Malcolm Reynolds,2021-Q4,0,0,0
-Malcolm Reynolds,2021-Q3,0,0,0
 Malcolm Reynolds,2021-Q2,0,0,0
 Malcolm Reynolds,2021-Q1,0,0,0
 Malcolm Reynolds,2020-Q4,0,0,0
@@ -33023,8 +28895,6 @@ Malcolm Reynolds,2018-Q4,0,0,0
 Malcolm Reynolds,2018-Q3,0,0,0
 Malcolm Reynolds,2018-Q2,3,41,9
 Malcolm Reynolds,2018-Q1,0,0,0
-Junpeng Lao,2021-Q4,0,0,0
-Junpeng Lao,2021-Q3,0,0,0
 Junpeng Lao,2021-Q2,0,0,0
 Junpeng Lao,2021-Q1,0,0,0
 Junpeng Lao,2020-Q4,0,0,0
@@ -33039,8 +28909,6 @@ Junpeng Lao,2018-Q4,0,0,0
 Junpeng Lao,2018-Q3,0,0,0
 Junpeng Lao,2018-Q2,19,300,64
 Junpeng Lao,2018-Q1,0,0,0
-Filipe Filardi,2021-Q4,0,0,0
-Filipe Filardi,2021-Q3,0,0,0
 Filipe Filardi,2021-Q2,0,0,0
 Filipe Filardi,2021-Q1,0,0,0
 Filipe Filardi,2020-Q4,0,0,0
@@ -33055,8 +28923,6 @@ Filipe Filardi,2018-Q4,0,0,0
 Filipe Filardi,2018-Q3,0,0,0
 Filipe Filardi,2018-Q2,6,37,26
 Filipe Filardi,2018-Q1,0,0,0
-anj-s,2021-Q4,0,0,0
-anj-s,2021-Q3,0,0,0
 anj-s,2021-Q2,0,0,0
 anj-s,2021-Q1,0,0,0
 anj-s,2020-Q4,0,0,0
@@ -33071,8 +28937,6 @@ anj-s,2018-Q4,0,0,0
 anj-s,2018-Q3,0,0,0
 anj-s,2018-Q2,5,109,58
 anj-s,2018-Q1,0,0,0
-Sagi,2021-Q4,0,0,0
-Sagi,2021-Q3,0,0,0
 Sagi,2021-Q2,0,0,0
 Sagi,2021-Q1,0,0,0
 Sagi,2020-Q4,0,0,0
@@ -33087,8 +28951,6 @@ Sagi,2018-Q4,0,0,0
 Sagi,2018-Q3,0,0,0
 Sagi,2018-Q2,1,0,0
 Sagi,2018-Q1,0,0,0
-zhangyaobit,2021-Q4,0,0,0
-zhangyaobit,2021-Q3,0,0,0
 zhangyaobit,2021-Q2,0,0,0
 zhangyaobit,2021-Q1,0,0,0
 zhangyaobit,2020-Q4,0,0,0
@@ -33103,8 +28965,6 @@ zhangyaobit,2018-Q4,0,0,0
 zhangyaobit,2018-Q3,0,0,0
 zhangyaobit,2018-Q2,2,0,0
 zhangyaobit,2018-Q1,0,0,0
-Andy Kernahan,2021-Q4,0,0,0
-Andy Kernahan,2021-Q3,0,0,0
 Andy Kernahan,2021-Q2,0,0,0
 Andy Kernahan,2021-Q1,0,0,0
 Andy Kernahan,2020-Q4,0,0,0
@@ -33119,8 +28979,6 @@ Andy Kernahan,2018-Q4,0,0,0
 Andy Kernahan,2018-Q3,0,0,0
 Andy Kernahan,2018-Q2,1,3,3
 Andy Kernahan,2018-Q1,1,0,0
-Steven Winston,2021-Q4,0,0,0
-Steven Winston,2021-Q3,0,0,0
 Steven Winston,2021-Q2,0,0,0
 Steven Winston,2021-Q1,0,0,0
 Steven Winston,2020-Q4,0,0,0
@@ -33135,8 +28993,6 @@ Steven Winston,2018-Q4,0,0,0
 Steven Winston,2018-Q3,0,0,0
 Steven Winston,2018-Q2,1,0,0
 Steven Winston,2018-Q1,0,0,0
-Tao Wei,2021-Q4,0,0,0
-Tao Wei,2021-Q3,0,0,0
 Tao Wei,2021-Q2,0,0,0
 Tao Wei,2021-Q1,0,0,0
 Tao Wei,2020-Q4,0,0,0
@@ -33151,8 +29007,6 @@ Tao Wei,2018-Q4,0,0,0
 Tao Wei,2018-Q3,0,0,0
 Tao Wei,2018-Q2,1,0,0
 Tao Wei,2018-Q1,0,0,0
-Bryan Heden,2021-Q4,0,0,0
-Bryan Heden,2021-Q3,0,0,0
 Bryan Heden,2021-Q2,0,0,0
 Bryan Heden,2021-Q1,0,0,0
 Bryan Heden,2020-Q4,0,0,0
@@ -33167,8 +29021,6 @@ Bryan Heden,2018-Q4,0,0,0
 Bryan Heden,2018-Q3,0,0,0
 Bryan Heden,2018-Q2,1,0,0
 Bryan Heden,2018-Q1,0,0,0
-foo0x29a,2021-Q4,0,0,0
-foo0x29a,2021-Q3,0,0,0
 foo0x29a,2021-Q2,0,0,0
 foo0x29a,2021-Q1,0,0,0
 foo0x29a,2020-Q4,0,0,0
@@ -33183,8 +29035,6 @@ foo0x29a,2018-Q4,0,0,0
 foo0x29a,2018-Q3,0,0,0
 foo0x29a,2018-Q2,1,0,0
 foo0x29a,2018-Q1,0,0,0
-ADiegoCAlonso,2021-Q4,0,0,0
-ADiegoCAlonso,2021-Q3,0,0,0
 ADiegoCAlonso,2021-Q2,0,0,0
 ADiegoCAlonso,2021-Q1,0,0,0
 ADiegoCAlonso,2020-Q4,0,0,0
@@ -33199,8 +29049,6 @@ ADiegoCAlonso,2018-Q4,0,0,0
 ADiegoCAlonso,2018-Q3,0,0,0
 ADiegoCAlonso,2018-Q2,5,3,3
 ADiegoCAlonso,2018-Q1,0,0,0
-Haggai,2021-Q4,0,0,0
-Haggai,2021-Q3,0,0,0
 Haggai,2021-Q2,0,0,0
 Haggai,2021-Q1,0,0,0
 Haggai,2020-Q4,0,0,0
@@ -33215,8 +29063,6 @@ Haggai,2018-Q4,0,0,0
 Haggai,2018-Q3,0,0,0
 Haggai,2018-Q2,10,101,16
 Haggai,2018-Q1,0,0,0
-jinghuangintel,2021-Q4,0,0,0
-jinghuangintel,2021-Q3,0,0,0
 jinghuangintel,2021-Q2,0,0,0
 jinghuangintel,2021-Q1,0,0,0
 jinghuangintel,2020-Q4,0,0,0
@@ -33231,8 +29077,6 @@ jinghuangintel,2018-Q4,0,0,0
 jinghuangintel,2018-Q3,0,0,0
 jinghuangintel,2018-Q2,2,22,16
 jinghuangintel,2018-Q1,8,271,128
-Yangzihao Wang,2021-Q4,0,0,0
-Yangzihao Wang,2021-Q3,0,0,0
 Yangzihao Wang,2021-Q2,0,0,0
 Yangzihao Wang,2021-Q1,0,0,0
 Yangzihao Wang,2020-Q4,0,0,0
@@ -33247,8 +29091,6 @@ Yangzihao Wang,2018-Q4,0,0,0
 Yangzihao Wang,2018-Q3,0,0,0
 Yangzihao Wang,2018-Q2,7,426,32
 Yangzihao Wang,2018-Q1,2,30,0
-akindyakov,2021-Q4,0,0,0
-akindyakov,2021-Q3,0,0,0
 akindyakov,2021-Q2,0,0,0
 akindyakov,2021-Q1,0,0,0
 akindyakov,2020-Q4,0,0,0
@@ -33263,8 +29105,6 @@ akindyakov,2018-Q4,0,0,0
 akindyakov,2018-Q3,0,0,0
 akindyakov,2018-Q2,15,270,69
 akindyakov,2018-Q1,0,0,0
-SukHwan Kim,2021-Q4,0,0,0
-SukHwan Kim,2021-Q3,0,0,0
 SukHwan Kim,2021-Q2,0,0,0
 SukHwan Kim,2021-Q1,0,0,0
 SukHwan Kim,2020-Q4,0,0,0
@@ -33279,8 +29119,6 @@ SukHwan Kim,2018-Q4,0,0,0
 SukHwan Kim,2018-Q3,0,0,0
 SukHwan Kim,2018-Q2,1,0,0
 SukHwan Kim,2018-Q1,0,0,0
-imsheridan,2021-Q4,0,0,0
-imsheridan,2021-Q3,0,0,0
 imsheridan,2021-Q2,0,0,0
 imsheridan,2021-Q1,0,0,0
 imsheridan,2020-Q4,0,0,0
@@ -33295,8 +29133,6 @@ imsheridan,2018-Q4,0,0,0
 imsheridan,2018-Q3,0,0,0
 imsheridan,2018-Q2,87,217,223
 imsheridan,2018-Q1,15,20,19
-Jiajia Li,2021-Q4,0,0,0
-Jiajia Li,2021-Q3,0,0,0
 Jiajia Li,2021-Q2,0,0,0
 Jiajia Li,2021-Q1,0,0,0
 Jiajia Li,2020-Q4,0,0,0
@@ -33311,8 +29147,6 @@ Jiajia Li,2018-Q4,0,0,0
 Jiajia Li,2018-Q3,0,0,0
 Jiajia Li,2018-Q2,1,2,0
 Jiajia Li,2018-Q1,0,0,0
-MyungSung Kwak,2021-Q4,0,0,0
-MyungSung Kwak,2021-Q3,0,0,0
 MyungSung Kwak,2021-Q2,0,0,0
 MyungSung Kwak,2021-Q1,0,0,0
 MyungSung Kwak,2020-Q4,0,0,0
@@ -33327,8 +29161,6 @@ MyungSung Kwak,2018-Q4,0,0,0
 MyungSung Kwak,2018-Q3,0,0,0
 MyungSung Kwak,2018-Q2,1,0,0
 MyungSung Kwak,2018-Q1,0,0,0
-Karol M. Langner,2021-Q4,0,0,0
-Karol M. Langner,2021-Q3,0,0,0
 Karol M. Langner,2021-Q2,0,0,0
 Karol M. Langner,2021-Q1,0,0,0
 Karol M. Langner,2020-Q4,0,0,0
@@ -33343,8 +29175,6 @@ Karol M. Langner,2018-Q4,0,0,0
 Karol M. Langner,2018-Q3,0,0,0
 Karol M. Langner,2018-Q2,1,3,3
 Karol M. Langner,2018-Q1,0,0,0
-Wenhao Hu,2021-Q4,0,0,0
-Wenhao Hu,2021-Q3,0,0,0
 Wenhao Hu,2021-Q2,0,0,0
 Wenhao Hu,2021-Q1,0,0,0
 Wenhao Hu,2020-Q4,0,0,0
@@ -33359,8 +29189,6 @@ Wenhao Hu,2018-Q4,0,0,0
 Wenhao Hu,2018-Q3,0,0,0
 Wenhao Hu,2018-Q2,10,104,39
 Wenhao Hu,2018-Q1,10,53,36
-wenhao.hu,2021-Q4,0,0,0
-wenhao.hu,2021-Q3,0,0,0
 wenhao.hu,2021-Q2,0,0,0
 wenhao.hu,2021-Q1,0,0,0
 wenhao.hu,2020-Q4,0,0,0
@@ -33375,8 +29203,6 @@ wenhao.hu,2018-Q4,0,0,0
 wenhao.hu,2018-Q3,0,0,0
 wenhao.hu,2018-Q2,5,2,4
 wenhao.hu,2018-Q1,1,8,6
-Neil Tenenholtz,2021-Q4,0,0,0
-Neil Tenenholtz,2021-Q3,0,0,0
 Neil Tenenholtz,2021-Q2,0,0,0
 Neil Tenenholtz,2021-Q1,0,0,0
 Neil Tenenholtz,2020-Q4,0,0,0
@@ -33391,8 +29217,6 @@ Neil Tenenholtz,2018-Q4,0,0,0
 Neil Tenenholtz,2018-Q3,0,0,0
 Neil Tenenholtz,2018-Q2,1,0,5
 Neil Tenenholtz,2018-Q1,0,0,0
-Sam Sendelbach,2021-Q4,0,0,0
-Sam Sendelbach,2021-Q3,0,0,0
 Sam Sendelbach,2021-Q2,0,0,0
 Sam Sendelbach,2021-Q1,0,0,0
 Sam Sendelbach,2020-Q4,0,0,0
@@ -33407,8 +29231,6 @@ Sam Sendelbach,2018-Q4,0,0,0
 Sam Sendelbach,2018-Q3,0,0,0
 Sam Sendelbach,2018-Q2,1,2,0
 Sam Sendelbach,2018-Q1,0,0,0
-eqy,2021-Q4,0,0,0
-eqy,2021-Q3,0,0,0
 eqy,2021-Q2,0,0,0
 eqy,2021-Q1,0,0,0
 eqy,2020-Q4,0,0,0
@@ -33423,8 +29245,6 @@ eqy,2018-Q4,0,0,0
 eqy,2018-Q3,0,0,0
 eqy,2018-Q2,1,0,0
 eqy,2018-Q1,0,0,0
-David T.H. Kao,2021-Q4,0,0,0
-David T.H. Kao,2021-Q3,0,0,0
 David T.H. Kao,2021-Q2,0,0,0
 David T.H. Kao,2021-Q1,0,0,0
 David T.H. Kao,2020-Q4,0,0,0
@@ -33439,8 +29259,6 @@ David T.H. Kao,2018-Q4,0,0,0
 David T.H. Kao,2018-Q3,0,0,0
 David T.H. Kao,2018-Q2,3,17,3
 David T.H. Kao,2018-Q1,0,0,0
-James Wexler,2021-Q4,0,0,0
-James Wexler,2021-Q3,0,0,0
 James Wexler,2021-Q2,0,0,0
 James Wexler,2021-Q1,0,0,0
 James Wexler,2020-Q4,0,0,0
@@ -33455,8 +29273,6 @@ James Wexler,2018-Q4,0,0,0
 James Wexler,2018-Q3,0,0,0
 James Wexler,2018-Q2,8,48,33
 James Wexler,2018-Q1,0,0,0
-Ka Long,2021-Q4,0,0,0
-Ka Long,2021-Q3,0,0,0
 Ka Long,2021-Q2,0,0,0
 Ka Long,2021-Q1,0,0,0
 Ka Long,2020-Q4,0,0,0
@@ -33471,8 +29287,6 @@ Ka Long,2018-Q4,0,0,0
 Ka Long,2018-Q3,0,0,0
 Ka Long,2018-Q2,1,0,0
 Ka Long,2018-Q1,0,0,0
-Russell Klopfer,2021-Q4,0,0,0
-Russell Klopfer,2021-Q3,0,0,0
 Russell Klopfer,2021-Q2,0,0,0
 Russell Klopfer,2021-Q1,0,0,0
 Russell Klopfer,2020-Q4,0,0,0
@@ -33487,8 +29301,6 @@ Russell Klopfer,2018-Q4,0,0,0
 Russell Klopfer,2018-Q3,0,0,0
 Russell Klopfer,2018-Q2,2,20,3
 Russell Klopfer,2018-Q1,1,0,2
-Seyed Majid Azimi,2021-Q4,0,0,0
-Seyed Majid Azimi,2021-Q3,0,0,0
 Seyed Majid Azimi,2021-Q2,0,0,0
 Seyed Majid Azimi,2021-Q1,0,0,0
 Seyed Majid Azimi,2020-Q4,0,0,0
@@ -33503,8 +29315,6 @@ Seyed Majid Azimi,2018-Q4,0,0,0
 Seyed Majid Azimi,2018-Q3,0,0,0
 Seyed Majid Azimi,2018-Q2,1,0,0
 Seyed Majid Azimi,2018-Q1,0,0,0
-Yihong Wang,2021-Q4,0,0,0
-Yihong Wang,2021-Q3,0,0,0
 Yihong Wang,2021-Q2,0,0,0
 Yihong Wang,2021-Q1,0,0,0
 Yihong Wang,2020-Q4,0,0,0
@@ -33519,8 +29329,6 @@ Yihong Wang,2018-Q4,0,0,0
 Yihong Wang,2018-Q3,0,0,0
 Yihong Wang,2018-Q2,1,6,0
 Yihong Wang,2018-Q1,0,0,0
-Quanlong,2021-Q4,0,0,0
-Quanlong,2021-Q3,0,0,0
 Quanlong,2021-Q2,0,0,0
 Quanlong,2021-Q1,0,0,0
 Quanlong,2020-Q4,0,0,0
@@ -33535,8 +29343,6 @@ Quanlong,2018-Q4,0,0,0
 Quanlong,2018-Q3,0,0,0
 Quanlong,2018-Q2,1,2,0
 Quanlong,2018-Q1,0,0,0
-Shaoning Zeng,2021-Q4,0,0,0
-Shaoning Zeng,2021-Q3,0,0,0
 Shaoning Zeng,2021-Q2,0,0,0
 Shaoning Zeng,2021-Q1,0,0,0
 Shaoning Zeng,2020-Q4,0,0,0
@@ -33551,8 +29357,6 @@ Shaoning Zeng,2018-Q4,0,0,0
 Shaoning Zeng,2018-Q3,0,0,0
 Shaoning Zeng,2018-Q2,1,4,4
 Shaoning Zeng,2018-Q1,0,0,0
-Wai Hon Law,2021-Q4,0,0,0
-Wai Hon Law,2021-Q3,0,0,0
 Wai Hon Law,2021-Q2,0,0,0
 Wai Hon Law,2021-Q1,0,0,0
 Wai Hon Law,2020-Q4,0,0,0
@@ -33567,8 +29371,6 @@ Wai Hon Law,2018-Q4,0,0,0
 Wai Hon Law,2018-Q3,0,0,0
 Wai Hon Law,2018-Q2,1,0,0
 Wai Hon Law,2018-Q1,0,0,0
-Hovhannes Harutyunyan,2021-Q4,0,0,0
-Hovhannes Harutyunyan,2021-Q3,0,0,0
 Hovhannes Harutyunyan,2021-Q2,0,0,0
 Hovhannes Harutyunyan,2021-Q1,0,0,0
 Hovhannes Harutyunyan,2020-Q4,0,0,0
@@ -33583,8 +29385,6 @@ Hovhannes Harutyunyan,2018-Q4,0,0,0
 Hovhannes Harutyunyan,2018-Q3,0,0,0
 Hovhannes Harutyunyan,2018-Q2,2,0,53
 Hovhannes Harutyunyan,2018-Q1,12,1137,192
-Seungwoo Choi (Biggie),2021-Q4,0,0,0
-Seungwoo Choi (Biggie),2021-Q3,0,0,0
 Seungwoo Choi (Biggie),2021-Q2,0,0,0
 Seungwoo Choi (Biggie),2021-Q1,0,0,0
 Seungwoo Choi (Biggie),2020-Q4,0,0,0
@@ -33599,8 +29399,6 @@ Seungwoo Choi (Biggie),2018-Q4,0,0,0
 Seungwoo Choi (Biggie),2018-Q3,0,0,0
 Seungwoo Choi (Biggie),2018-Q2,1,0,0
 Seungwoo Choi (Biggie),2018-Q1,0,0,0
-Michal Turek,2021-Q4,0,0,0
-Michal Turek,2021-Q3,0,0,0
 Michal Turek,2021-Q2,0,0,0
 Michal Turek,2021-Q1,0,0,0
 Michal Turek,2020-Q4,0,0,0
@@ -33615,8 +29413,6 @@ Michal Turek,2018-Q4,0,0,0
 Michal Turek,2018-Q3,0,0,0
 Michal Turek,2018-Q2,2,4,0
 Michal Turek,2018-Q1,0,0,0
-tamimaddari82,2021-Q4,0,0,0
-tamimaddari82,2021-Q3,0,0,0
 tamimaddari82,2021-Q2,0,0,0
 tamimaddari82,2021-Q1,0,0,0
 tamimaddari82,2020-Q4,0,0,0
@@ -33631,8 +29427,6 @@ tamimaddari82,2018-Q4,0,0,0
 tamimaddari82,2018-Q3,0,0,0
 tamimaddari82,2018-Q2,1,22,12
 tamimaddari82,2018-Q1,0,0,0
-Ivan Zhang,2021-Q4,0,0,0
-Ivan Zhang,2021-Q3,0,0,0
 Ivan Zhang,2021-Q2,0,0,0
 Ivan Zhang,2021-Q1,0,0,0
 Ivan Zhang,2020-Q4,0,0,0
@@ -33647,8 +29441,6 @@ Ivan Zhang,2018-Q4,0,0,0
 Ivan Zhang,2018-Q3,0,0,0
 Ivan Zhang,2018-Q2,1,0,0
 Ivan Zhang,2018-Q1,0,0,0
-Vadim Markovtsev,2021-Q4,0,0,0
-Vadim Markovtsev,2021-Q3,0,0,0
 Vadim Markovtsev,2021-Q2,0,0,0
 Vadim Markovtsev,2021-Q1,0,0,0
 Vadim Markovtsev,2020-Q4,0,0,0
@@ -33663,8 +29455,6 @@ Vadim Markovtsev,2018-Q4,0,0,0
 Vadim Markovtsev,2018-Q3,0,0,0
 Vadim Markovtsev,2018-Q2,1,0,0
 Vadim Markovtsev,2018-Q1,0,0,0
-bhavani-subramanian,2021-Q4,0,0,0
-bhavani-subramanian,2021-Q3,0,0,0
 bhavani-subramanian,2021-Q2,0,0,0
 bhavani-subramanian,2021-Q1,0,0,0
 bhavani-subramanian,2020-Q4,0,0,0
@@ -33679,8 +29469,6 @@ bhavani-subramanian,2018-Q4,0,0,0
 bhavani-subramanian,2018-Q3,0,0,0
 bhavani-subramanian,2018-Q2,1,9,0
 bhavani-subramanian,2018-Q1,0,0,0
-Rajendra arora,2021-Q4,0,0,0
-Rajendra arora,2021-Q3,0,0,0
 Rajendra arora,2021-Q2,0,0,0
 Rajendra arora,2021-Q1,0,0,0
 Rajendra arora,2020-Q4,0,0,0
@@ -33695,8 +29483,6 @@ Rajendra arora,2018-Q4,0,0,0
 Rajendra arora,2018-Q3,0,0,0
 Rajendra arora,2018-Q2,1,0,0
 Rajendra arora,2018-Q1,29,64,57
-Ilya Polenov,2021-Q4,0,0,0
-Ilya Polenov,2021-Q3,0,0,0
 Ilya Polenov,2021-Q2,0,0,0
 Ilya Polenov,2021-Q1,0,0,0
 Ilya Polenov,2020-Q4,0,0,0
@@ -33711,8 +29497,6 @@ Ilya Polenov,2018-Q4,0,0,0
 Ilya Polenov,2018-Q3,0,0,0
 Ilya Polenov,2018-Q2,1,0,2
 Ilya Polenov,2018-Q1,0,0,0
-DosLin,2021-Q4,0,0,0
-DosLin,2021-Q3,0,0,0
 DosLin,2021-Q2,0,0,0
 DosLin,2021-Q1,0,0,0
 DosLin,2020-Q4,0,0,0
@@ -33727,8 +29511,6 @@ DosLin,2018-Q4,0,0,0
 DosLin,2018-Q3,0,0,0
 DosLin,2018-Q2,1,2,0
 DosLin,2018-Q1,1,0,0
-nio1814,2021-Q4,0,0,0
-nio1814,2021-Q3,0,0,0
 nio1814,2021-Q2,0,0,0
 nio1814,2021-Q1,0,0,0
 nio1814,2020-Q4,0,0,0
@@ -33743,8 +29525,6 @@ nio1814,2018-Q4,0,0,0
 nio1814,2018-Q3,0,0,0
 nio1814,2018-Q2,2,75,23
 nio1814,2018-Q1,0,0,0
-Thomas Bastiani,2021-Q4,0,0,0
-Thomas Bastiani,2021-Q3,0,0,0
 Thomas Bastiani,2021-Q2,0,0,0
 Thomas Bastiani,2021-Q1,0,0,0
 Thomas Bastiani,2020-Q4,0,0,0
@@ -33759,8 +29539,6 @@ Thomas Bastiani,2018-Q4,0,0,0
 Thomas Bastiani,2018-Q3,0,0,0
 Thomas Bastiani,2018-Q2,1,4,0
 Thomas Bastiani,2018-Q1,0,0,0
-Cédric Deltheil,2021-Q4,0,0,0
-Cédric Deltheil,2021-Q3,0,0,0
 Cédric Deltheil,2021-Q2,0,0,0
 Cédric Deltheil,2021-Q1,0,0,0
 Cédric Deltheil,2020-Q4,0,0,0
@@ -33775,8 +29553,6 @@ Cédric Deltheil,2018-Q4,0,0,0
 Cédric Deltheil,2018-Q3,0,0,0
 Cédric Deltheil,2018-Q2,1,10,5
 Cédric Deltheil,2018-Q1,1,0,0
-Sebastián Ramírez,2021-Q4,0,0,0
-Sebastián Ramírez,2021-Q3,0,0,0
 Sebastián Ramírez,2021-Q2,0,0,0
 Sebastián Ramírez,2021-Q1,0,0,0
 Sebastián Ramírez,2020-Q4,0,0,0
@@ -33791,8 +29567,6 @@ Sebastián Ramírez,2018-Q4,0,0,0
 Sebastián Ramírez,2018-Q3,0,0,0
 Sebastián Ramírez,2018-Q2,1,3,3
 Sebastián Ramírez,2018-Q1,0,0,0
-Jon Shlens,2021-Q4,0,0,0
-Jon Shlens,2021-Q3,0,0,0
 Jon Shlens,2021-Q2,0,0,0
 Jon Shlens,2021-Q1,0,0,0
 Jon Shlens,2020-Q4,0,0,0
@@ -33807,8 +29581,6 @@ Jon Shlens,2018-Q4,0,0,0
 Jon Shlens,2018-Q3,0,0,0
 Jon Shlens,2018-Q2,3,423,0
 Jon Shlens,2018-Q1,0,0,0
-Silver Chan,2021-Q4,0,0,0
-Silver Chan,2021-Q3,0,0,0
 Silver Chan,2021-Q2,0,0,0
 Silver Chan,2021-Q1,0,0,0
 Silver Chan,2020-Q4,0,0,0
@@ -33823,8 +29595,6 @@ Silver Chan,2018-Q4,0,0,0
 Silver Chan,2018-Q3,0,0,0
 Silver Chan,2018-Q2,1,0,0
 Silver Chan,2018-Q1,0,0,0
-Andrew Harp,2021-Q4,0,0,0
-Andrew Harp,2021-Q3,0,0,0
 Andrew Harp,2021-Q2,0,0,0
 Andrew Harp,2021-Q1,0,0,0
 Andrew Harp,2020-Q4,0,0,0
@@ -33839,8 +29609,6 @@ Andrew Harp,2018-Q4,0,0,0
 Andrew Harp,2018-Q3,0,0,0
 Andrew Harp,2018-Q2,0,0,0
 Andrew Harp,2018-Q1,97,8580,78
-msofka,2021-Q4,0,0,0
-msofka,2021-Q3,0,0,0
 msofka,2021-Q2,0,0,0
 msofka,2021-Q1,0,0,0
 msofka,2020-Q4,0,0,0
@@ -33855,8 +29623,6 @@ msofka,2018-Q4,0,0,0
 msofka,2018-Q3,0,0,0
 msofka,2018-Q2,0,0,0
 msofka,2018-Q1,1,0,0
-Chris Tava,2021-Q4,0,0,0
-Chris Tava,2021-Q3,0,0,0
 Chris Tava,2021-Q2,0,0,0
 Chris Tava,2021-Q1,0,0,0
 Chris Tava,2020-Q4,0,0,0
@@ -33871,8 +29637,6 @@ Chris Tava,2018-Q4,0,0,0
 Chris Tava,2018-Q3,0,0,0
 Chris Tava,2018-Q2,0,0,0
 Chris Tava,2018-Q1,1,0,0
-Nathan Burnham,2021-Q4,0,0,0
-Nathan Burnham,2021-Q3,0,0,0
 Nathan Burnham,2021-Q2,0,0,0
 Nathan Burnham,2021-Q1,0,0,0
 Nathan Burnham,2020-Q4,0,0,0
@@ -33887,8 +29651,6 @@ Nathan Burnham,2018-Q4,0,0,0
 Nathan Burnham,2018-Q3,0,0,0
 Nathan Burnham,2018-Q2,0,0,0
 Nathan Burnham,2018-Q1,1,2,2
-Jerry Liu,2021-Q4,0,0,0
-Jerry Liu,2021-Q3,0,0,0
 Jerry Liu,2021-Q2,0,0,0
 Jerry Liu,2021-Q1,0,0,0
 Jerry Liu,2020-Q4,0,0,0
@@ -33903,8 +29665,6 @@ Jerry Liu,2018-Q4,0,0,0
 Jerry Liu,2018-Q3,0,0,0
 Jerry Liu,2018-Q2,0,0,0
 Jerry Liu,2018-Q1,3,64,7
-Ou Changkun,2021-Q4,0,0,0
-Ou Changkun,2021-Q3,0,0,0
 Ou Changkun,2021-Q2,0,0,0
 Ou Changkun,2021-Q1,0,0,0
 Ou Changkun,2020-Q4,0,0,0
@@ -33919,8 +29679,6 @@ Ou Changkun,2018-Q4,0,0,0
 Ou Changkun,2018-Q3,0,0,0
 Ou Changkun,2018-Q2,0,0,0
 Ou Changkun,2018-Q1,1,2,0
-Maximilian Mitchell,2021-Q4,0,0,0
-Maximilian Mitchell,2021-Q3,0,0,0
 Maximilian Mitchell,2021-Q2,0,0,0
 Maximilian Mitchell,2021-Q1,0,0,0
 Maximilian Mitchell,2020-Q4,0,0,0
@@ -33935,8 +29693,6 @@ Maximilian Mitchell,2018-Q4,0,0,0
 Maximilian Mitchell,2018-Q3,0,0,0
 Maximilian Mitchell,2018-Q2,0,0,0
 Maximilian Mitchell,2018-Q1,2,4,4
-Stanislaw Antol,2021-Q4,0,0,0
-Stanislaw Antol,2021-Q3,0,0,0
 Stanislaw Antol,2021-Q2,0,0,0
 Stanislaw Antol,2021-Q1,0,0,0
 Stanislaw Antol,2020-Q4,0,0,0
@@ -33951,8 +29707,6 @@ Stanislaw Antol,2018-Q4,0,0,0
 Stanislaw Antol,2018-Q3,0,0,0
 Stanislaw Antol,2018-Q2,0,0,0
 Stanislaw Antol,2018-Q1,14,396,7
-Anton Matosov,2021-Q4,0,0,0
-Anton Matosov,2021-Q3,0,0,0
 Anton Matosov,2021-Q2,0,0,0
 Anton Matosov,2021-Q1,0,0,0
 Anton Matosov,2020-Q4,0,0,0
@@ -33967,8 +29721,6 @@ Anton Matosov,2018-Q4,0,0,0
 Anton Matosov,2018-Q3,0,0,0
 Anton Matosov,2018-Q2,0,0,0
 Anton Matosov,2018-Q1,13,159,79
-Yashal Shakti Kanungo,2021-Q4,0,0,0
-Yashal Shakti Kanungo,2021-Q3,0,0,0
 Yashal Shakti Kanungo,2021-Q2,0,0,0
 Yashal Shakti Kanungo,2021-Q1,0,0,0
 Yashal Shakti Kanungo,2020-Q4,0,0,0
@@ -33983,8 +29735,6 @@ Yashal Shakti Kanungo,2018-Q4,0,0,0
 Yashal Shakti Kanungo,2018-Q3,0,0,0
 Yashal Shakti Kanungo,2018-Q2,0,0,0
 Yashal Shakti Kanungo,2018-Q1,1,28,26
-Marvin Richter,2021-Q4,0,0,0
-Marvin Richter,2021-Q3,0,0,0
 Marvin Richter,2021-Q2,0,0,0
 Marvin Richter,2021-Q1,0,0,0
 Marvin Richter,2020-Q4,0,0,0
@@ -33999,8 +29749,6 @@ Marvin Richter,2018-Q4,0,0,0
 Marvin Richter,2018-Q3,0,0,0
 Marvin Richter,2018-Q2,0,0,0
 Marvin Richter,2018-Q1,1,0,0
-Joel Shor,2021-Q4,0,0,0
-Joel Shor,2021-Q3,0,0,0
 Joel Shor,2021-Q2,0,0,0
 Joel Shor,2021-Q1,0,0,0
 Joel Shor,2020-Q4,0,0,0
@@ -34015,8 +29763,6 @@ Joel Shor,2018-Q4,0,0,0
 Joel Shor,2018-Q3,0,0,0
 Joel Shor,2018-Q2,0,0,0
 Joel Shor,2018-Q1,3,46,4
-Sang Han,2021-Q4,0,0,0
-Sang Han,2021-Q3,0,0,0
 Sang Han,2021-Q2,0,0,0
 Sang Han,2021-Q1,0,0,0
 Sang Han,2020-Q4,0,0,0
@@ -34031,8 +29777,6 @@ Sang Han,2018-Q4,0,0,0
 Sang Han,2018-Q3,0,0,0
 Sang Han,2018-Q2,0,0,0
 Sang Han,2018-Q1,1,2,2
-Frank Perbet,2021-Q4,0,0,0
-Frank Perbet,2021-Q3,0,0,0
 Frank Perbet,2021-Q2,0,0,0
 Frank Perbet,2021-Q1,0,0,0
 Frank Perbet,2020-Q4,0,0,0
@@ -34047,8 +29791,6 @@ Frank Perbet,2018-Q4,0,0,0
 Frank Perbet,2018-Q3,0,0,0
 Frank Perbet,2018-Q2,0,0,0
 Frank Perbet,2018-Q1,10,391,156
-Ziyue(Louis) Lu,2021-Q4,0,0,0
-Ziyue(Louis) Lu,2021-Q3,0,0,0
 Ziyue(Louis) Lu,2021-Q2,0,0,0
 Ziyue(Louis) Lu,2021-Q1,0,0,0
 Ziyue(Louis) Lu,2020-Q4,0,0,0
@@ -34063,8 +29805,6 @@ Ziyue(Louis) Lu,2018-Q4,0,0,0
 Ziyue(Louis) Lu,2018-Q3,0,0,0
 Ziyue(Louis) Lu,2018-Q2,0,0,0
 Ziyue(Louis) Lu,2018-Q1,1,0,0
-Ankit Gupta,2021-Q4,0,0,0
-Ankit Gupta,2021-Q3,0,0,0
 Ankit Gupta,2021-Q2,0,0,0
 Ankit Gupta,2021-Q1,0,0,0
 Ankit Gupta,2020-Q4,0,0,0
@@ -34079,8 +29819,6 @@ Ankit Gupta,2018-Q4,0,0,0
 Ankit Gupta,2018-Q3,0,0,0
 Ankit Gupta,2018-Q2,0,0,0
 Ankit Gupta,2018-Q1,2,2,2
-Piotr Czapla,2021-Q4,0,0,0
-Piotr Czapla,2021-Q3,0,0,0
 Piotr Czapla,2021-Q2,0,0,0
 Piotr Czapla,2021-Q1,0,0,0
 Piotr Czapla,2020-Q4,0,0,0
@@ -34095,8 +29833,6 @@ Piotr Czapla,2018-Q4,0,0,0
 Piotr Czapla,2018-Q3,0,0,0
 Piotr Czapla,2018-Q2,0,0,0
 Piotr Czapla,2018-Q1,2,11,7
-Surya Bhupatiraju,2021-Q4,0,0,0
-Surya Bhupatiraju,2021-Q3,0,0,0
 Surya Bhupatiraju,2021-Q2,0,0,0
 Surya Bhupatiraju,2021-Q1,0,0,0
 Surya Bhupatiraju,2020-Q4,0,0,0
@@ -34111,8 +29847,6 @@ Surya Bhupatiraju,2018-Q4,0,0,0
 Surya Bhupatiraju,2018-Q3,0,0,0
 Surya Bhupatiraju,2018-Q2,0,0,0
 Surya Bhupatiraju,2018-Q1,5,318,62
-Tarang Chugh,2021-Q4,0,0,0
-Tarang Chugh,2021-Q3,0,0,0
 Tarang Chugh,2021-Q2,0,0,0
 Tarang Chugh,2021-Q1,0,0,0
 Tarang Chugh,2020-Q4,0,0,0
@@ -34127,8 +29861,6 @@ Tarang Chugh,2018-Q4,0,0,0
 Tarang Chugh,2018-Q3,0,0,0
 Tarang Chugh,2018-Q2,0,0,0
 Tarang Chugh,2018-Q1,1,0,0
-Fanjin Zeng,2021-Q4,0,0,0
-Fanjin Zeng,2021-Q3,0,0,0
 Fanjin Zeng,2021-Q2,0,0,0
 Fanjin Zeng,2021-Q1,0,0,0
 Fanjin Zeng,2020-Q4,0,0,0
@@ -34143,8 +29875,6 @@ Fanjin Zeng,2018-Q4,0,0,0
 Fanjin Zeng,2018-Q3,0,0,0
 Fanjin Zeng,2018-Q2,0,0,0
 Fanjin Zeng,2018-Q1,1,0,0
-Alan Lee,2021-Q4,0,0,0
-Alan Lee,2021-Q3,0,0,0
 Alan Lee,2021-Q2,0,0,0
 Alan Lee,2021-Q1,0,0,0
 Alan Lee,2020-Q4,0,0,0
@@ -34159,8 +29889,6 @@ Alan Lee,2018-Q4,0,0,0
 Alan Lee,2018-Q3,0,0,0
 Alan Lee,2018-Q2,0,0,0
 Alan Lee,2018-Q1,1,0,0
-Brent Yi,2021-Q4,0,0,0
-Brent Yi,2021-Q3,0,0,0
 Brent Yi,2021-Q2,0,0,0
 Brent Yi,2021-Q1,0,0,0
 Brent Yi,2020-Q4,0,0,0
@@ -34175,8 +29903,6 @@ Brent Yi,2018-Q4,0,0,0
 Brent Yi,2018-Q3,0,0,0
 Brent Yi,2018-Q2,0,0,0
 Brent Yi,2018-Q1,1,0,0
-Aghasy,2021-Q4,0,0,0
-Aghasy,2021-Q3,0,0,0
 Aghasy,2021-Q2,0,0,0
 Aghasy,2021-Q1,0,0,0
 Aghasy,2020-Q4,0,0,0
@@ -34191,8 +29917,6 @@ Aghasy,2018-Q4,0,0,0
 Aghasy,2018-Q3,0,0,0
 Aghasy,2018-Q2,0,0,0
 Aghasy,2018-Q1,1,3,3
-Giovanni Terlingen,2021-Q4,0,0,0
-Giovanni Terlingen,2021-Q3,0,0,0
 Giovanni Terlingen,2021-Q2,0,0,0
 Giovanni Terlingen,2021-Q1,0,0,0
 Giovanni Terlingen,2020-Q4,0,0,0
@@ -34207,8 +29931,6 @@ Giovanni Terlingen,2018-Q4,0,0,0
 Giovanni Terlingen,2018-Q3,0,0,0
 Giovanni Terlingen,2018-Q2,0,0,0
 Giovanni Terlingen,2018-Q1,1,4,2
-Jiongyan Zhang (张炯衍),2021-Q4,0,0,0
-Jiongyan Zhang (张炯衍),2021-Q3,0,0,0
 Jiongyan Zhang (张炯衍),2021-Q2,0,0,0
 Jiongyan Zhang (张炯衍),2021-Q1,0,0,0
 Jiongyan Zhang (张炯衍),2020-Q4,0,0,0
@@ -34223,8 +29945,6 @@ Jiongyan Zhang (张炯衍),2018-Q4,0,0,0
 Jiongyan Zhang (张炯衍),2018-Q3,0,0,0
 Jiongyan Zhang (张炯衍),2018-Q2,0,0,0
 Jiongyan Zhang (张炯衍),2018-Q1,3,5,3
-Jakub Kolodziejczyk,2021-Q4,0,0,0
-Jakub Kolodziejczyk,2021-Q3,0,0,0
 Jakub Kolodziejczyk,2021-Q2,0,0,0
 Jakub Kolodziejczyk,2021-Q1,0,0,0
 Jakub Kolodziejczyk,2020-Q4,0,0,0
@@ -34239,8 +29959,6 @@ Jakub Kolodziejczyk,2018-Q4,0,0,0
 Jakub Kolodziejczyk,2018-Q3,0,0,0
 Jakub Kolodziejczyk,2018-Q2,0,0,0
 Jakub Kolodziejczyk,2018-Q1,1,2,0
-Jong Wook Kim,2021-Q4,0,0,0
-Jong Wook Kim,2021-Q3,0,0,0
 Jong Wook Kim,2021-Q2,0,0,0
 Jong Wook Kim,2021-Q1,0,0,0
 Jong Wook Kim,2020-Q4,0,0,0
@@ -34255,8 +29973,6 @@ Jong Wook Kim,2018-Q4,0,0,0
 Jong Wook Kim,2018-Q3,0,0,0
 Jong Wook Kim,2018-Q2,0,0,0
 Jong Wook Kim,2018-Q1,1,10,8
-Xian Xu,2021-Q4,0,0,0
-Xian Xu,2021-Q3,0,0,0
 Xian Xu,2021-Q2,0,0,0
 Xian Xu,2021-Q1,0,0,0
 Xian Xu,2020-Q4,0,0,0
@@ -34271,8 +29987,6 @@ Xian Xu,2018-Q4,0,0,0
 Xian Xu,2018-Q3,0,0,0
 Xian Xu,2018-Q2,0,0,0
 Xian Xu,2018-Q1,1,0,0
-Aris L,2021-Q4,0,0,0
-Aris L,2021-Q3,0,0,0
 Aris L,2021-Q2,0,0,0
 Aris L,2021-Q1,0,0,0
 Aris L,2020-Q4,0,0,0
@@ -34287,8 +30001,6 @@ Aris L,2018-Q4,0,0,0
 Aris L,2018-Q3,0,0,0
 Aris L,2018-Q2,0,0,0
 Aris L,2018-Q1,1,0,0
-qjivy,2021-Q4,0,0,0
-qjivy,2021-Q3,0,0,0
 qjivy,2021-Q2,0,0,0
 qjivy,2021-Q1,0,0,0
 qjivy,2020-Q4,0,0,0
@@ -34303,8 +30015,6 @@ qjivy,2018-Q4,0,0,0
 qjivy,2018-Q3,0,0,0
 qjivy,2018-Q2,0,0,0
 qjivy,2018-Q1,1,0,0
-Rodrigo Formigone,2021-Q4,0,0,0
-Rodrigo Formigone,2021-Q3,0,0,0
 Rodrigo Formigone,2021-Q2,0,0,0
 Rodrigo Formigone,2021-Q1,0,0,0
 Rodrigo Formigone,2020-Q4,0,0,0
@@ -34319,8 +30029,6 @@ Rodrigo Formigone,2018-Q4,0,0,0
 Rodrigo Formigone,2018-Q3,0,0,0
 Rodrigo Formigone,2018-Q2,0,0,0
 Rodrigo Formigone,2018-Q1,1,8,0
-Laurence Moroney,2021-Q4,0,0,0
-Laurence Moroney,2021-Q3,0,0,0
 Laurence Moroney,2021-Q2,0,0,0
 Laurence Moroney,2021-Q1,0,0,0
 Laurence Moroney,2020-Q4,0,0,0
@@ -34335,8 +30043,6 @@ Laurence Moroney,2018-Q4,0,0,0
 Laurence Moroney,2018-Q3,0,0,0
 Laurence Moroney,2018-Q2,0,0,0
 Laurence Moroney,2018-Q1,2,9,0
-Gor Baghdasaryan,2021-Q4,0,0,0
-Gor Baghdasaryan,2021-Q3,0,0,0
 Gor Baghdasaryan,2021-Q2,0,0,0
 Gor Baghdasaryan,2021-Q1,0,0,0
 Gor Baghdasaryan,2020-Q4,0,0,0
@@ -34351,8 +30057,6 @@ Gor Baghdasaryan,2018-Q4,0,0,0
 Gor Baghdasaryan,2018-Q3,0,0,0
 Gor Baghdasaryan,2018-Q2,0,0,0
 Gor Baghdasaryan,2018-Q1,1,0,0
-Julian Eisenschlos,2021-Q4,0,0,0
-Julian Eisenschlos,2021-Q3,0,0,0
 Julian Eisenschlos,2021-Q2,0,0,0
 Julian Eisenschlos,2021-Q1,0,0,0
 Julian Eisenschlos,2020-Q4,0,0,0
@@ -34367,8 +30071,6 @@ Julian Eisenschlos,2018-Q4,0,0,0
 Julian Eisenschlos,2018-Q3,0,0,0
 Julian Eisenschlos,2018-Q2,0,0,0
 Julian Eisenschlos,2018-Q1,14,22,22
-Mustafa Kasap,2021-Q4,0,0,0
-Mustafa Kasap,2021-Q3,0,0,0
 Mustafa Kasap,2021-Q2,0,0,0
 Mustafa Kasap,2021-Q1,0,0,0
 Mustafa Kasap,2020-Q4,0,0,0
@@ -34383,8 +30085,6 @@ Mustafa Kasap,2018-Q4,0,0,0
 Mustafa Kasap,2018-Q3,0,0,0
 Mustafa Kasap,2018-Q2,0,0,0
 Mustafa Kasap,2018-Q1,1,4,0
-yaox12,2021-Q4,0,0,0
-yaox12,2021-Q3,0,0,0
 yaox12,2021-Q2,0,0,0
 yaox12,2021-Q1,0,0,0
 yaox12,2020-Q4,0,0,0
@@ -34399,8 +30099,6 @@ yaox12,2018-Q4,0,0,0
 yaox12,2018-Q3,0,0,0
 yaox12,2018-Q2,0,0,0
 yaox12,2018-Q1,1,2,2
-Animesh Karnewar,2021-Q4,0,0,0
-Animesh Karnewar,2021-Q3,0,0,0
 Animesh Karnewar,2021-Q2,0,0,0
 Animesh Karnewar,2021-Q1,0,0,0
 Animesh Karnewar,2020-Q4,0,0,0
@@ -34415,8 +30113,6 @@ Animesh Karnewar,2018-Q4,0,0,0
 Animesh Karnewar,2018-Q3,0,0,0
 Animesh Karnewar,2018-Q2,0,0,0
 Animesh Karnewar,2018-Q1,1,11,6
-Jason Sadler,2021-Q4,0,0,0
-Jason Sadler,2021-Q3,0,0,0
 Jason Sadler,2021-Q2,0,0,0
 Jason Sadler,2021-Q1,0,0,0
 Jason Sadler,2020-Q4,0,0,0
@@ -34431,8 +30127,6 @@ Jason Sadler,2018-Q4,0,0,0
 Jason Sadler,2018-Q3,0,0,0
 Jason Sadler,2018-Q2,0,0,0
 Jason Sadler,2018-Q1,1,0,2
-Oleg Zabluda,2021-Q4,0,0,0
-Oleg Zabluda,2021-Q3,0,0,0
 Oleg Zabluda,2021-Q2,0,0,0
 Oleg Zabluda,2021-Q1,0,0,0
 Oleg Zabluda,2020-Q4,0,0,0
@@ -34447,8 +30141,6 @@ Oleg Zabluda,2018-Q4,0,0,0
 Oleg Zabluda,2018-Q3,0,0,0
 Oleg Zabluda,2018-Q2,0,0,0
 Oleg Zabluda,2018-Q1,1,0,0
-Daniel Erenrich,2021-Q4,0,0,0
-Daniel Erenrich,2021-Q3,0,0,0
 Daniel Erenrich,2021-Q2,0,0,0
 Daniel Erenrich,2021-Q1,0,0,0
 Daniel Erenrich,2020-Q4,0,0,0
@@ -34463,8 +30155,6 @@ Daniel Erenrich,2018-Q4,0,0,0
 Daniel Erenrich,2018-Q3,0,0,0
 Daniel Erenrich,2018-Q2,0,0,0
 Daniel Erenrich,2018-Q1,1,2,2
-ryantimjohn,2021-Q4,0,0,0
-ryantimjohn,2021-Q3,0,0,0
 ryantimjohn,2021-Q2,0,0,0
 ryantimjohn,2021-Q1,0,0,0
 ryantimjohn,2020-Q4,0,0,0
@@ -34479,8 +30169,6 @@ ryantimjohn,2018-Q4,0,0,0
 ryantimjohn,2018-Q3,0,0,0
 ryantimjohn,2018-Q2,0,0,0
 ryantimjohn,2018-Q1,1,2,2
-Hanchen Li,2021-Q4,0,0,0
-Hanchen Li,2021-Q3,0,0,0
 Hanchen Li,2021-Q2,0,0,0
 Hanchen Li,2021-Q1,0,0,0
 Hanchen Li,2020-Q4,0,0,0
@@ -34495,8 +30183,6 @@ Hanchen Li,2018-Q4,0,0,0
 Hanchen Li,2018-Q3,0,0,0
 Hanchen Li,2018-Q2,0,0,0
 Hanchen Li,2018-Q1,10,238,12
-Siby Jose Plathottam,2021-Q4,0,0,0
-Siby Jose Plathottam,2021-Q3,0,0,0
 Siby Jose Plathottam,2021-Q2,0,0,0
 Siby Jose Plathottam,2021-Q1,0,0,0
 Siby Jose Plathottam,2020-Q4,0,0,0
@@ -34511,8 +30197,6 @@ Siby Jose Plathottam,2018-Q4,0,0,0
 Siby Jose Plathottam,2018-Q3,0,0,0
 Siby Jose Plathottam,2018-Q2,0,0,0
 Siby Jose Plathottam,2018-Q1,1,0,0
-Carl Thomé,2021-Q4,0,0,0
-Carl Thomé,2021-Q3,0,0,0
 Carl Thomé,2021-Q2,0,0,0
 Carl Thomé,2021-Q1,0,0,0
 Carl Thomé,2020-Q4,0,0,0
@@ -34527,8 +30211,6 @@ Carl Thomé,2018-Q4,0,0,0
 Carl Thomé,2018-Q3,0,0,0
 Carl Thomé,2018-Q2,0,0,0
 Carl Thomé,2018-Q1,7,47,10
-Panos Ipeirotis,2021-Q4,0,0,0
-Panos Ipeirotis,2021-Q3,0,0,0
 Panos Ipeirotis,2021-Q2,0,0,0
 Panos Ipeirotis,2021-Q1,0,0,0
 Panos Ipeirotis,2020-Q4,0,0,0
@@ -34543,8 +30225,6 @@ Panos Ipeirotis,2018-Q4,0,0,0
 Panos Ipeirotis,2018-Q3,0,0,0
 Panos Ipeirotis,2018-Q2,0,0,0
 Panos Ipeirotis,2018-Q1,2,7,2
-Dahan Gong,2021-Q4,0,0,0
-Dahan Gong,2021-Q3,0,0,0
 Dahan Gong,2021-Q2,0,0,0
 Dahan Gong,2021-Q1,0,0,0
 Dahan Gong,2020-Q4,0,0,0
@@ -34559,8 +30239,6 @@ Dahan Gong,2018-Q4,0,0,0
 Dahan Gong,2018-Q3,0,0,0
 Dahan Gong,2018-Q2,0,0,0
 Dahan Gong,2018-Q1,2,4,2
-Giuseppe,2021-Q4,0,0,0
-Giuseppe,2021-Q3,0,0,0
 Giuseppe,2021-Q2,0,0,0
 Giuseppe,2021-Q1,0,0,0
 Giuseppe,2020-Q4,0,0,0
@@ -34575,8 +30253,6 @@ Giuseppe,2018-Q4,0,0,0
 Giuseppe,2018-Q3,0,0,0
 Giuseppe,2018-Q2,0,0,0
 Giuseppe,2018-Q1,3,5,9
-Luke Iwanski,2021-Q4,0,0,0
-Luke Iwanski,2021-Q3,0,0,0
 Luke Iwanski,2021-Q2,0,0,0
 Luke Iwanski,2021-Q1,0,0,0
 Luke Iwanski,2020-Q4,0,0,0
@@ -34591,8 +30267,6 @@ Luke Iwanski,2018-Q4,0,0,0
 Luke Iwanski,2018-Q3,0,0,0
 Luke Iwanski,2018-Q2,0,0,0
 Luke Iwanski,2018-Q1,0,0,0
-Chi Zeng,2021-Q4,0,0,0
-Chi Zeng,2021-Q3,0,0,0
 Chi Zeng,2021-Q2,0,0,0
 Chi Zeng,2021-Q1,0,0,0
 Chi Zeng,2020-Q4,0,0,0
@@ -34607,8 +30281,6 @@ Chi Zeng,2018-Q4,0,0,0
 Chi Zeng,2018-Q3,0,0,0
 Chi Zeng,2018-Q2,0,0,0
 Chi Zeng,2018-Q1,1,13,5
-Yin Li,2021-Q4,0,0,0
-Yin Li,2021-Q3,0,0,0
 Yin Li,2021-Q2,0,0,0
 Yin Li,2021-Q1,0,0,0
 Yin Li,2020-Q4,0,0,0
@@ -34623,8 +30295,6 @@ Yin Li,2018-Q4,0,0,0
 Yin Li,2018-Q3,0,0,0
 Yin Li,2018-Q2,0,0,0
 Yin Li,2018-Q1,0,0,0
-Peter Lee,2021-Q4,0,0,0
-Peter Lee,2021-Q3,0,0,0
 Peter Lee,2021-Q2,0,0,0
 Peter Lee,2021-Q1,0,0,0
 Peter Lee,2020-Q4,0,0,0
@@ -34639,8 +30309,6 @@ Peter Lee,2018-Q4,0,0,0
 Peter Lee,2018-Q3,0,0,0
 Peter Lee,2018-Q2,0,0,0
 Peter Lee,2018-Q1,1,0,0
-Minmin Sun,2021-Q4,0,0,0
-Minmin Sun,2021-Q3,0,0,0
 Minmin Sun,2021-Q2,0,0,0
 Minmin Sun,2021-Q1,0,0,0
 Minmin Sun,2020-Q4,0,0,0
@@ -34655,8 +30323,6 @@ Minmin Sun,2018-Q4,0,0,0
 Minmin Sun,2018-Q3,0,0,0
 Minmin Sun,2018-Q2,0,0,0
 Minmin Sun,2018-Q1,5,901,6
-Penghao Cen,2021-Q4,0,0,0
-Penghao Cen,2021-Q3,0,0,0
 Penghao Cen,2021-Q2,0,0,0
 Penghao Cen,2021-Q1,0,0,0
 Penghao Cen,2020-Q4,0,0,0
@@ -34671,8 +30337,6 @@ Penghao Cen,2018-Q4,0,0,0
 Penghao Cen,2018-Q3,0,0,0
 Penghao Cen,2018-Q2,0,0,0
 Penghao Cen,2018-Q1,2,16,14
-june-one,2021-Q4,0,0,0
-june-one,2021-Q3,0,0,0
 june-one,2021-Q2,0,0,0
 june-one,2021-Q1,0,0,0
 june-one,2020-Q4,0,0,0
@@ -34687,8 +30351,6 @@ june-one,2018-Q4,0,0,0
 june-one,2018-Q3,0,0,0
 june-one,2018-Q2,0,0,0
 june-one,2018-Q1,1,3,3
-MandarJKulkarni,2021-Q4,0,0,0
-MandarJKulkarni,2021-Q3,0,0,0
 MandarJKulkarni,2021-Q2,0,0,0
 MandarJKulkarni,2021-Q1,0,0,0
 MandarJKulkarni,2020-Q4,0,0,0
@@ -34703,8 +30365,6 @@ MandarJKulkarni,2018-Q4,0,0,0
 MandarJKulkarni,2018-Q3,0,0,0
 MandarJKulkarni,2018-Q2,0,0,0
 MandarJKulkarni,2018-Q1,2,5,5
-vihanjain,2021-Q4,0,0,0
-vihanjain,2021-Q3,0,0,0
 vihanjain,2021-Q2,0,0,0
 vihanjain,2021-Q1,0,0,0
 vihanjain,2020-Q4,0,0,0
@@ -34719,8 +30379,6 @@ vihanjain,2018-Q4,0,0,0
 vihanjain,2018-Q3,0,0,0
 vihanjain,2018-Q2,0,0,0
 vihanjain,2018-Q1,2,8,2
-Jingwen,2021-Q4,0,0,0
-Jingwen,2021-Q3,0,0,0
 Jingwen,2021-Q2,0,0,0
 Jingwen,2021-Q1,0,0,0
 Jingwen,2020-Q4,0,0,0
@@ -34735,8 +30393,6 @@ Jingwen,2018-Q4,0,0,0
 Jingwen,2018-Q3,0,0,0
 Jingwen,2018-Q2,0,0,0
 Jingwen,2018-Q1,1,0,0
-Daniel Trebbien,2021-Q4,0,0,0
-Daniel Trebbien,2021-Q3,0,0,0
 Daniel Trebbien,2021-Q2,0,0,0
 Daniel Trebbien,2021-Q1,0,0,0
 Daniel Trebbien,2020-Q4,0,0,0
@@ -34751,8 +30407,6 @@ Daniel Trebbien,2018-Q4,0,0,0
 Daniel Trebbien,2018-Q3,0,0,0
 Daniel Trebbien,2018-Q2,0,0,0
 Daniel Trebbien,2018-Q1,3,0,0
-Seo Sanghyeon,2021-Q4,0,0,0
-Seo Sanghyeon,2021-Q3,0,0,0
 Seo Sanghyeon,2021-Q2,0,0,0
 Seo Sanghyeon,2021-Q1,0,0,0
 Seo Sanghyeon,2020-Q4,0,0,0
@@ -34767,8 +30421,6 @@ Seo Sanghyeon,2018-Q4,0,0,0
 Seo Sanghyeon,2018-Q3,0,0,0
 Seo Sanghyeon,2018-Q2,0,0,0
 Seo Sanghyeon,2018-Q1,1,0,0
-Martin Pool,2021-Q4,0,0,0
-Martin Pool,2021-Q3,0,0,0
 Martin Pool,2021-Q2,0,0,0
 Martin Pool,2021-Q1,0,0,0
 Martin Pool,2020-Q4,0,0,0
@@ -34783,8 +30435,6 @@ Martin Pool,2018-Q4,0,0,0
 Martin Pool,2018-Q3,0,0,0
 Martin Pool,2018-Q2,0,0,0
 Martin Pool,2018-Q1,1,3,2
-terrytangyuan,2021-Q4,0,0,0
-terrytangyuan,2021-Q3,0,0,0
 terrytangyuan,2021-Q2,0,0,0
 terrytangyuan,2021-Q1,0,0,0
 terrytangyuan,2020-Q4,0,0,0
@@ -34799,8 +30449,6 @@ terrytangyuan,2018-Q4,0,0,0
 terrytangyuan,2018-Q3,0,0,0
 terrytangyuan,2018-Q2,0,0,0
 terrytangyuan,2018-Q1,9,54,47
-Seungil You,2021-Q4,0,0,0
-Seungil You,2021-Q3,0,0,0
 Seungil You,2021-Q2,0,0,0
 Seungil You,2021-Q1,0,0,0
 Seungil You,2020-Q4,0,0,0
@@ -34815,8 +30463,6 @@ Seungil You,2018-Q4,0,0,0
 Seungil You,2018-Q3,0,0,0
 Seungil You,2018-Q2,0,0,0
 Seungil You,2018-Q1,4,0,0
-harumitsu.nobuta,2021-Q4,0,0,0
-harumitsu.nobuta,2021-Q3,0,0,0
 harumitsu.nobuta,2021-Q2,0,0,0
 harumitsu.nobuta,2021-Q1,0,0,0
 harumitsu.nobuta,2020-Q4,0,0,0
@@ -34831,8 +30477,6 @@ harumitsu.nobuta,2018-Q4,0,0,0
 harumitsu.nobuta,2018-Q3,0,0,0
 harumitsu.nobuta,2018-Q2,0,0,0
 harumitsu.nobuta,2018-Q1,1,0,0
-Danny Goodman,2021-Q4,0,0,0
-Danny Goodman,2021-Q3,0,0,0
 Danny Goodman,2021-Q2,0,0,0
 Danny Goodman,2021-Q1,0,0,0
 Danny Goodman,2020-Q4,0,0,0
@@ -34847,8 +30491,6 @@ Danny Goodman,2018-Q4,0,0,0
 Danny Goodman,2018-Q3,0,0,0
 Danny Goodman,2018-Q2,0,0,0
 Danny Goodman,2018-Q1,1,0,0
-Henry Spivey,2021-Q4,0,0,0
-Henry Spivey,2021-Q3,0,0,0
 Henry Spivey,2021-Q2,0,0,0
 Henry Spivey,2021-Q1,0,0,0
 Henry Spivey,2020-Q4,0,0,0
@@ -34863,8 +30505,6 @@ Henry Spivey,2018-Q4,0,0,0
 Henry Spivey,2018-Q3,0,0,0
 Henry Spivey,2018-Q2,0,0,0
 Henry Spivey,2018-Q1,1,0,0
-Deron Eriksson,2021-Q4,0,0,0
-Deron Eriksson,2021-Q3,0,0,0
 Deron Eriksson,2021-Q2,0,0,0
 Deron Eriksson,2021-Q1,0,0,0
 Deron Eriksson,2020-Q4,0,0,0
@@ -34879,8 +30519,6 @@ Deron Eriksson,2018-Q4,0,0,0
 Deron Eriksson,2018-Q3,0,0,0
 Deron Eriksson,2018-Q2,0,0,0
 Deron Eriksson,2018-Q1,2,14,14
-Michael Zhou,2021-Q4,0,0,0
-Michael Zhou,2021-Q3,0,0,0
 Michael Zhou,2021-Q2,0,0,0
 Michael Zhou,2021-Q1,0,0,0
 Michael Zhou,2020-Q4,0,0,0
@@ -34895,8 +30533,6 @@ Michael Zhou,2018-Q4,0,0,0
 Michael Zhou,2018-Q3,0,0,0
 Michael Zhou,2018-Q2,0,0,0
 Michael Zhou,2018-Q1,5,133,48
-Abe,2021-Q4,0,0,0
-Abe,2021-Q3,0,0,0
 Abe,2021-Q2,0,0,0
 Abe,2021-Q1,0,0,0
 Abe,2020-Q4,0,0,0
@@ -34911,8 +30547,6 @@ Abe,2018-Q4,0,0,0
 Abe,2018-Q3,0,0,0
 Abe,2018-Q2,0,0,0
 Abe,2018-Q1,2,2,2
-kdavis-mozilla,2021-Q4,0,0,0
-kdavis-mozilla,2021-Q3,0,0,0
 kdavis-mozilla,2021-Q2,0,0,0
 kdavis-mozilla,2021-Q1,0,0,0
 kdavis-mozilla,2020-Q4,0,0,0
@@ -34927,8 +30561,6 @@ kdavis-mozilla,2018-Q4,0,0,0
 kdavis-mozilla,2018-Q3,0,0,0
 kdavis-mozilla,2018-Q2,0,0,0
 kdavis-mozilla,2018-Q1,1,8,0
-Naman Kamra,2021-Q4,0,0,0
-Naman Kamra,2021-Q3,0,0,0
 Naman Kamra,2021-Q2,0,0,0
 Naman Kamra,2021-Q1,0,0,0
 Naman Kamra,2020-Q4,0,0,0
@@ -34943,8 +30575,6 @@ Naman Kamra,2018-Q4,0,0,0
 Naman Kamra,2018-Q3,0,0,0
 Naman Kamra,2018-Q2,0,0,0
 Naman Kamra,2018-Q1,1,0,0
-Donny Viszneki,2021-Q4,0,0,0
-Donny Viszneki,2021-Q3,0,0,0
 Donny Viszneki,2021-Q2,0,0,0
 Donny Viszneki,2021-Q1,0,0,0
 Donny Viszneki,2020-Q4,0,0,0
@@ -34959,8 +30589,6 @@ Donny Viszneki,2018-Q4,0,0,0
 Donny Viszneki,2018-Q3,0,0,0
 Donny Viszneki,2018-Q2,0,0,0
 Donny Viszneki,2018-Q1,1,0,0
-Jiongyan Zhang,2021-Q4,0,0,0
-Jiongyan Zhang,2021-Q3,0,0,0
 Jiongyan Zhang,2021-Q2,0,0,0
 Jiongyan Zhang,2021-Q1,0,0,0
 Jiongyan Zhang,2020-Q4,0,0,0
@@ -34975,8 +30603,6 @@ Jiongyan Zhang,2018-Q4,0,0,0
 Jiongyan Zhang,2018-Q3,0,0,0
 Jiongyan Zhang,2018-Q2,0,0,0
 Jiongyan Zhang,2018-Q1,3,14,0
-DONGGEON LIM,2021-Q4,0,0,0
-DONGGEON LIM,2021-Q3,0,0,0
 DONGGEON LIM,2021-Q2,0,0,0
 DONGGEON LIM,2021-Q1,0,0,0
 DONGGEON LIM,2020-Q4,0,0,0
@@ -34991,8 +30617,6 @@ DONGGEON LIM,2018-Q4,0,0,0
 DONGGEON LIM,2018-Q3,0,0,0
 DONGGEON LIM,2018-Q2,0,0,0
 DONGGEON LIM,2018-Q1,1,136,0
-MyungsungKwak,2021-Q4,0,0,0
-MyungsungKwak,2021-Q3,0,0,0
 MyungsungKwak,2021-Q2,0,0,0
 MyungsungKwak,2021-Q1,0,0,0
 MyungsungKwak,2020-Q4,0,0,0
@@ -35007,8 +30631,6 @@ MyungsungKwak,2018-Q4,0,0,0
 MyungsungKwak,2018-Q3,0,0,0
 MyungsungKwak,2018-Q2,0,0,0
 MyungsungKwak,2018-Q1,1,3,3
-seaotterman,2021-Q4,0,0,0
-seaotterman,2021-Q3,0,0,0
 seaotterman,2021-Q2,0,0,0
 seaotterman,2021-Q1,0,0,0
 seaotterman,2020-Q4,0,0,0
@@ -35023,8 +30645,6 @@ seaotterman,2018-Q4,0,0,0
 seaotterman,2018-Q3,0,0,0
 seaotterman,2018-Q2,0,0,0
 seaotterman,2018-Q1,1,0,0
-Yukun Chen,2021-Q4,0,0,0
-Yukun Chen,2021-Q3,0,0,0
 Yukun Chen,2021-Q2,0,0,0
 Yukun Chen,2021-Q1,0,0,0
 Yukun Chen,2020-Q4,0,0,0
@@ -35039,8 +30659,6 @@ Yukun Chen,2018-Q4,0,0,0
 Yukun Chen,2018-Q3,0,0,0
 Yukun Chen,2018-Q2,0,0,0
 Yukun Chen,2018-Q1,13,88,88
-MyungJoo Ham,2021-Q4,0,0,0
-MyungJoo Ham,2021-Q3,0,0,0
 MyungJoo Ham,2021-Q2,0,0,0
 MyungJoo Ham,2021-Q1,0,0,0
 MyungJoo Ham,2020-Q4,0,0,0
@@ -35055,8 +30673,6 @@ MyungJoo Ham,2018-Q4,0,0,0
 MyungJoo Ham,2018-Q3,0,0,0
 MyungJoo Ham,2018-Q2,0,0,0
 MyungJoo Ham,2018-Q1,3,82,48
-DylanDmitri,2021-Q4,0,0,0
-DylanDmitri,2021-Q3,0,0,0
 DylanDmitri,2021-Q2,0,0,0
 DylanDmitri,2021-Q1,0,0,0
 DylanDmitri,2020-Q4,0,0,0
@@ -35071,8 +30687,6 @@ DylanDmitri,2018-Q4,0,0,0
 DylanDmitri,2018-Q3,0,0,0
 DylanDmitri,2018-Q2,0,0,0
 DylanDmitri,2018-Q1,1,2,2
-Sukriti Ramesh,2021-Q4,0,0,0
-Sukriti Ramesh,2021-Q3,0,0,0
 Sukriti Ramesh,2021-Q2,0,0,0
 Sukriti Ramesh,2021-Q1,0,0,0
 Sukriti Ramesh,2020-Q4,0,0,0
@@ -35087,8 +30701,6 @@ Sukriti Ramesh,2018-Q4,0,0,0
 Sukriti Ramesh,2018-Q3,0,0,0
 Sukriti Ramesh,2018-Q2,0,0,0
 Sukriti Ramesh,2018-Q1,2,9,3
-mholzel,2021-Q4,0,0,0
-mholzel,2021-Q3,0,0,0
 mholzel,2021-Q2,0,0,0
 mholzel,2021-Q1,0,0,0
 mholzel,2020-Q4,0,0,0
@@ -35103,8 +30715,6 @@ mholzel,2018-Q4,0,0,0
 mholzel,2018-Q3,0,0,0
 mholzel,2018-Q2,0,0,0
 mholzel,2018-Q1,1,37,0
-matthieudelaro,2021-Q4,0,0,0
-matthieudelaro,2021-Q3,0,0,0
 matthieudelaro,2021-Q2,0,0,0
 matthieudelaro,2021-Q1,0,0,0
 matthieudelaro,2020-Q4,0,0,0
@@ -35119,8 +30729,6 @@ matthieudelaro,2018-Q4,0,0,0
 matthieudelaro,2018-Q3,0,0,0
 matthieudelaro,2018-Q2,0,0,0
 matthieudelaro,2018-Q1,1,0,0
-Johnson145,2021-Q4,0,0,0
-Johnson145,2021-Q3,0,0,0
 Johnson145,2021-Q2,0,0,0
 Johnson145,2021-Q1,0,0,0
 Johnson145,2020-Q4,0,0,0
@@ -35135,8 +30743,6 @@ Johnson145,2018-Q4,0,0,0
 Johnson145,2018-Q3,0,0,0
 Johnson145,2018-Q2,0,0,0
 Johnson145,2018-Q1,1,0,0
-Jerome,2021-Q4,0,0,0
-Jerome,2021-Q3,0,0,0
 Jerome,2021-Q2,0,0,0
 Jerome,2021-Q1,0,0,0
 Jerome,2020-Q4,0,0,0
@@ -35151,8 +30757,6 @@ Jerome,2018-Q4,0,0,0
 Jerome,2018-Q3,0,0,0
 Jerome,2018-Q2,0,0,0
 Jerome,2018-Q1,8,159,16
-Liang-Chi Hsieh,2021-Q4,0,0,0
-Liang-Chi Hsieh,2021-Q3,0,0,0
 Liang-Chi Hsieh,2021-Q2,0,0,0
 Liang-Chi Hsieh,2021-Q1,0,0,0
 Liang-Chi Hsieh,2020-Q4,0,0,0
@@ -35167,8 +30771,6 @@ Liang-Chi Hsieh,2018-Q4,0,0,0
 Liang-Chi Hsieh,2018-Q3,0,0,0
 Liang-Chi Hsieh,2018-Q2,0,0,0
 Liang-Chi Hsieh,2018-Q1,2,2,2
-Haichen "HC" Li,2021-Q4,0,0,0
-Haichen "HC" Li,2021-Q3,0,0,0
 Haichen "HC" Li,2021-Q2,0,0,0
 Haichen "HC" Li,2021-Q1,0,0,0
 Haichen "HC" Li,2020-Q4,0,0,0
@@ -35183,8 +30785,6 @@ Haichen "HC" Li,2018-Q4,0,0,0
 Haichen "HC" Li,2018-Q3,0,0,0
 Haichen "HC" Li,2018-Q2,0,0,0
 Haichen "HC" Li,2018-Q1,1,0,0
-lazypanda1,2021-Q4,0,0,0
-lazypanda1,2021-Q3,0,0,0
 lazypanda1,2021-Q2,0,0,0
 lazypanda1,2021-Q1,0,0,0
 lazypanda1,2020-Q4,0,0,0
@@ -35199,8 +30799,6 @@ lazypanda1,2018-Q4,0,0,0
 lazypanda1,2018-Q3,0,0,0
 lazypanda1,2018-Q2,0,0,0
 lazypanda1,2018-Q1,2,4,2
-Phil,2021-Q4,0,0,0
-Phil,2021-Q3,0,0,0
 Phil,2021-Q2,0,0,0
 Phil,2021-Q1,0,0,0
 Phil,2020-Q4,0,0,0
@@ -35215,8 +30813,6 @@ Phil,2018-Q4,0,0,0
 Phil,2018-Q3,0,0,0
 Phil,2018-Q2,0,0,0
 Phil,2018-Q1,18,955,437
-Brad Wannow,2021-Q4,0,0,0
-Brad Wannow,2021-Q3,0,0,0
 Brad Wannow,2021-Q2,0,0,0
 Brad Wannow,2021-Q1,0,0,0
 Brad Wannow,2020-Q4,0,0,0
@@ -35231,8 +30827,6 @@ Brad Wannow,2018-Q4,0,0,0
 Brad Wannow,2018-Q3,0,0,0
 Brad Wannow,2018-Q2,0,0,0
 Brad Wannow,2018-Q1,1,2,2
-Glenn Weidner,2021-Q4,0,0,0
-Glenn Weidner,2021-Q3,0,0,0
 Glenn Weidner,2021-Q2,0,0,0
 Glenn Weidner,2021-Q1,0,0,0
 Glenn Weidner,2020-Q4,0,0,0
@@ -35247,8 +30841,6 @@ Glenn Weidner,2018-Q4,0,0,0
 Glenn Weidner,2018-Q3,0,0,0
 Glenn Weidner,2018-Q2,0,0,0
 Glenn Weidner,2018-Q1,2,0,0
-Julian Wolff,2021-Q4,0,0,0
-Julian Wolff,2021-Q3,0,0,0
 Julian Wolff,2021-Q2,0,0,0
 Julian Wolff,2021-Q1,0,0,0
 Julian Wolff,2020-Q4,0,0,0
@@ -35263,8 +30855,6 @@ Julian Wolff,2018-Q4,0,0,0
 Julian Wolff,2018-Q3,0,0,0
 Julian Wolff,2018-Q2,0,0,0
 Julian Wolff,2018-Q1,4,2,2
-Yusuke Yamada,2021-Q4,0,0,0
-Yusuke Yamada,2021-Q3,0,0,0
 Yusuke Yamada,2021-Q2,0,0,0
 Yusuke Yamada,2021-Q1,0,0,0
 Yusuke Yamada,2020-Q4,0,0,0
@@ -35279,8 +30869,6 @@ Yusuke Yamada,2018-Q4,0,0,0
 Yusuke Yamada,2018-Q3,0,0,0
 Yusuke Yamada,2018-Q2,0,0,0
 Yusuke Yamada,2018-Q1,1,0,0
-Marcus Ong,2021-Q4,0,0,0
-Marcus Ong,2021-Q3,0,0,0
 Marcus Ong,2021-Q2,0,0,0
 Marcus Ong,2021-Q1,0,0,0
 Marcus Ong,2020-Q4,0,0,0
@@ -35295,8 +30883,6 @@ Marcus Ong,2018-Q4,0,0,0
 Marcus Ong,2018-Q3,0,0,0
 Marcus Ong,2018-Q2,0,0,0
 Marcus Ong,2018-Q1,24,185,43
-Francisco Guerrero,2021-Q4,0,0,0
-Francisco Guerrero,2021-Q3,0,0,0
 Francisco Guerrero,2021-Q2,0,0,0
 Francisco Guerrero,2021-Q1,0,0,0
 Francisco Guerrero,2020-Q4,0,0,0
@@ -35311,8 +30897,6 @@ Francisco Guerrero,2018-Q4,0,0,0
 Francisco Guerrero,2018-Q3,0,0,0
 Francisco Guerrero,2018-Q2,0,0,0
 Francisco Guerrero,2018-Q1,1,2,0
-Tim H,2021-Q4,0,0,0
-Tim H,2021-Q3,0,0,0
 Tim H,2021-Q2,0,0,0
 Tim H,2021-Q1,0,0,0
 Tim H,2020-Q4,0,0,0
@@ -35327,8 +30911,6 @@ Tim H,2018-Q4,0,0,0
 Tim H,2018-Q3,0,0,0
 Tim H,2018-Q2,0,0,0
 Tim H,2018-Q1,17,1512,234
-Tod,2021-Q4,0,0,0
-Tod,2021-Q3,0,0,0
 Tod,2021-Q2,0,0,0
 Tod,2021-Q1,0,0,0
 Tod,2020-Q4,0,0,0
@@ -35343,8 +30925,6 @@ Tod,2018-Q4,0,0,0
 Tod,2018-Q3,0,0,0
 Tod,2018-Q2,0,0,0
 Tod,2018-Q1,1,0,0
-Mahesh Bhosale,2021-Q4,0,0,0
-Mahesh Bhosale,2021-Q3,0,0,0
 Mahesh Bhosale,2021-Q2,0,0,0
 Mahesh Bhosale,2021-Q1,0,0,0
 Mahesh Bhosale,2020-Q4,0,0,0
@@ -35359,8 +30939,6 @@ Mahesh Bhosale,2018-Q4,0,0,0
 Mahesh Bhosale,2018-Q3,0,0,0
 Mahesh Bhosale,2018-Q2,0,0,0
 Mahesh Bhosale,2018-Q1,1,0,0
-Rohin Mohanadas,2021-Q4,0,0,0
-Rohin Mohanadas,2021-Q3,0,0,0
 Rohin Mohanadas,2021-Q2,0,0,0
 Rohin Mohanadas,2021-Q1,0,0,0
 Rohin Mohanadas,2020-Q4,0,0,0
@@ -35375,8 +30953,6 @@ Rohin Mohanadas,2018-Q4,0,0,0
 Rohin Mohanadas,2018-Q3,0,0,0
 Rohin Mohanadas,2018-Q2,0,0,0
 Rohin Mohanadas,2018-Q1,1,0,0
-JackyKo,2021-Q4,0,0,0
-JackyKo,2021-Q3,0,0,0
 JackyKo,2021-Q2,0,0,0
 JackyKo,2021-Q1,0,0,0
 JackyKo,2020-Q4,0,0,0
@@ -35391,8 +30967,6 @@ JackyKo,2018-Q4,0,0,0
 JackyKo,2018-Q3,0,0,0
 JackyKo,2018-Q2,0,0,0
 JackyKo,2018-Q1,20,330,90
-Chris Drake,2021-Q4,0,0,0
-Chris Drake,2021-Q3,0,0,0
 Chris Drake,2021-Q2,0,0,0
 Chris Drake,2021-Q1,0,0,0
 Chris Drake,2020-Q4,0,0,0
@@ -35407,8 +30981,6 @@ Chris Drake,2018-Q4,0,0,0
 Chris Drake,2018-Q3,0,0,0
 Chris Drake,2018-Q2,0,0,0
 Chris Drake,2018-Q1,1,0,0
-Kenji,2021-Q4,0,0,0
-Kenji,2021-Q3,0,0,0
 Kenji,2021-Q2,0,0,0
 Kenji,2021-Q1,0,0,0
 Kenji,2020-Q4,0,0,0
@@ -35423,8 +30995,6 @@ Kenji,2018-Q4,0,0,0
 Kenji,2018-Q3,0,0,0
 Kenji,2018-Q2,0,0,0
 Kenji,2018-Q1,1,0,0
-lissyx,2021-Q4,0,0,0
-lissyx,2021-Q3,0,0,0
 lissyx,2021-Q2,0,0,0
 lissyx,2021-Q1,0,0,0
 lissyx,2020-Q4,0,0,0
@@ -35439,8 +31009,6 @@ lissyx,2018-Q4,0,0,0
 lissyx,2018-Q3,0,0,0
 lissyx,2018-Q2,0,0,0
 lissyx,2018-Q1,2,2,2
-Jeff Tang,2021-Q4,0,0,0
-Jeff Tang,2021-Q3,0,0,0
 Jeff Tang,2021-Q2,0,0,0
 Jeff Tang,2021-Q1,0,0,0
 Jeff Tang,2020-Q4,0,0,0
@@ -35455,8 +31023,6 @@ Jeff Tang,2018-Q4,0,0,0
 Jeff Tang,2018-Q3,0,0,0
 Jeff Tang,2018-Q2,0,0,0
 Jeff Tang,2018-Q1,1,0,0
-Jin-Hwan CHO,2021-Q4,0,0,0
-Jin-Hwan CHO,2021-Q3,0,0,0
 Jin-Hwan CHO,2021-Q2,0,0,0
 Jin-Hwan CHO,2021-Q1,0,0,0
 Jin-Hwan CHO,2020-Q4,0,0,0
@@ -35471,8 +31037,6 @@ Jin-Hwan CHO,2018-Q4,0,0,0
 Jin-Hwan CHO,2018-Q3,0,0,0
 Jin-Hwan CHO,2018-Q2,0,0,0
 Jin-Hwan CHO,2018-Q1,2,8,8
-jackyko,2021-Q4,0,0,0
-jackyko,2021-Q3,0,0,0
 jackyko,2021-Q2,0,0,0
 jackyko,2021-Q1,0,0,0
 jackyko,2020-Q4,0,0,0
@@ -35487,8 +31051,6 @@ jackyko,2018-Q4,0,0,0
 jackyko,2018-Q3,0,0,0
 jackyko,2018-Q2,0,0,0
 jackyko,2018-Q1,33,210,131
-Anjum Sayed,2021-Q4,0,0,0
-Anjum Sayed,2021-Q3,0,0,0
 Anjum Sayed,2021-Q2,0,0,0
 Anjum Sayed,2021-Q1,0,0,0
 Anjum Sayed,2020-Q4,0,0,0
@@ -35503,8 +31065,6 @@ Anjum Sayed,2018-Q4,0,0,0
 Anjum Sayed,2018-Q3,0,0,0
 Anjum Sayed,2018-Q2,0,0,0
 Anjum Sayed,2018-Q1,1,4,2
-Colin Raffel,2021-Q4,0,0,0
-Colin Raffel,2021-Q3,0,0,0
 Colin Raffel,2021-Q2,0,0,0
 Colin Raffel,2021-Q1,0,0,0
 Colin Raffel,2020-Q4,0,0,0
@@ -35519,8 +31079,6 @@ Colin Raffel,2018-Q4,0,0,0
 Colin Raffel,2018-Q3,0,0,0
 Colin Raffel,2018-Q2,0,0,0
 Colin Raffel,2018-Q1,1,0,2
-Dandelion Mané,2021-Q4,0,0,0
-Dandelion Mané,2021-Q3,0,0,0
 Dandelion Mané,2021-Q2,0,0,0
 Dandelion Mané,2021-Q1,0,0,0
 Dandelion Mané,2020-Q4,0,0,0
@@ -35535,8 +31093,6 @@ Dandelion Mané,2018-Q4,0,0,0
 Dandelion Mané,2018-Q3,0,0,0
 Dandelion Mané,2018-Q2,0,0,0
 Dandelion Mané,2018-Q1,1,0,0
-simsicon,2021-Q4,0,0,0
-simsicon,2021-Q3,0,0,0
 simsicon,2021-Q2,0,0,0
 simsicon,2021-Q1,0,0,0
 simsicon,2020-Q4,0,0,0
@@ -35551,8 +31107,6 @@ simsicon,2018-Q4,0,0,0
 simsicon,2018-Q3,0,0,0
 simsicon,2018-Q2,0,0,0
 simsicon,2018-Q1,1,0,6
-Cole Gerdemann,2021-Q4,0,0,0
-Cole Gerdemann,2021-Q3,0,0,0
 Cole Gerdemann,2021-Q2,0,0,0
 Cole Gerdemann,2021-Q1,0,0,0
 Cole Gerdemann,2020-Q4,0,0,0
@@ -35567,8 +31121,6 @@ Cole Gerdemann,2018-Q4,0,0,0
 Cole Gerdemann,2018-Q3,0,0,0
 Cole Gerdemann,2018-Q2,0,0,0
 Cole Gerdemann,2018-Q1,1,2,2
-yegord,2021-Q4,0,0,0
-yegord,2021-Q3,0,0,0
 yegord,2021-Q2,0,0,0
 yegord,2021-Q1,0,0,0
 yegord,2020-Q4,0,0,0
@@ -35583,8 +31135,6 @@ yegord,2018-Q4,0,0,0
 yegord,2018-Q3,0,0,0
 yegord,2018-Q2,0,0,0
 yegord,2018-Q1,2,48,42
-Boris Pfahringer,2021-Q4,0,0,0
-Boris Pfahringer,2021-Q3,0,0,0
 Boris Pfahringer,2021-Q2,0,0,0
 Boris Pfahringer,2021-Q1,0,0,0
 Boris Pfahringer,2020-Q4,0,0,0
@@ -35599,8 +31149,6 @@ Boris Pfahringer,2018-Q4,0,0,0
 Boris Pfahringer,2018-Q3,0,0,0
 Boris Pfahringer,2018-Q2,0,0,0
 Boris Pfahringer,2018-Q1,4,8,8
-Omar Aflak,2021-Q4,0,0,0
-Omar Aflak,2021-Q3,0,0,0
 Omar Aflak,2021-Q2,0,0,0
 Omar Aflak,2021-Q1,0,0,0
 Omar Aflak,2020-Q4,0,0,0
@@ -35615,8 +31163,6 @@ Omar Aflak,2018-Q4,0,0,0
 Omar Aflak,2018-Q3,0,0,0
 Omar Aflak,2018-Q2,0,0,0
 Omar Aflak,2018-Q1,1,0,0
-Qiumin Xu,2021-Q4,0,0,0
-Qiumin Xu,2021-Q3,0,0,0
 Qiumin Xu,2021-Q2,0,0,0
 Qiumin Xu,2021-Q1,0,0,0
 Qiumin Xu,2020-Q4,0,0,0
@@ -35631,8 +31177,6 @@ Qiumin Xu,2018-Q4,0,0,0
 Qiumin Xu,2018-Q3,0,0,0
 Qiumin Xu,2018-Q2,0,0,0
 Qiumin Xu,2018-Q1,4,20,15
-Jean Flaherty,2021-Q4,0,0,0
-Jean Flaherty,2021-Q3,0,0,0
 Jean Flaherty,2021-Q2,0,0,0
 Jean Flaherty,2021-Q1,0,0,0
 Jean Flaherty,2020-Q4,0,0,0
@@ -35647,8 +31191,6 @@ Jean Flaherty,2018-Q4,0,0,0
 Jean Flaherty,2018-Q3,0,0,0
 Jean Flaherty,2018-Q2,0,0,0
 Jean Flaherty,2018-Q1,22,1237,0
-elilienstein,2021-Q4,0,0,0
-elilienstein,2021-Q3,0,0,0
 elilienstein,2021-Q2,0,0,0
 elilienstein,2021-Q1,0,0,0
 elilienstein,2020-Q4,0,0,0
@@ -35663,8 +31205,6 @@ elilienstein,2018-Q4,0,0,0
 elilienstein,2018-Q3,0,0,0
 elilienstein,2018-Q2,0,0,0
 elilienstein,2018-Q1,3,4,4
-resec,2021-Q4,0,0,0
-resec,2021-Q3,0,0,0
 resec,2021-Q2,0,0,0
 resec,2021-Q1,0,0,0
 resec,2020-Q4,0,0,0
@@ -35679,8 +31219,6 @@ resec,2018-Q4,0,0,0
 resec,2018-Q3,0,0,0
 resec,2018-Q2,0,0,0
 resec,2018-Q1,1,0,0
-mjwen,2021-Q4,0,0,0
-mjwen,2021-Q3,0,0,0
 mjwen,2021-Q2,0,0,0
 mjwen,2021-Q1,0,0,0
 mjwen,2020-Q4,0,0,0
@@ -35695,8 +31233,6 @@ mjwen,2018-Q4,0,0,0
 mjwen,2018-Q3,0,0,0
 mjwen,2018-Q2,0,0,0
 mjwen,2018-Q1,2,39,4
-Po-Hsien Chu,2021-Q4,0,0,0
-Po-Hsien Chu,2021-Q3,0,0,0
 Po-Hsien Chu,2021-Q2,0,0,0
 Po-Hsien Chu,2021-Q1,0,0,0
 Po-Hsien Chu,2020-Q4,0,0,0
@@ -35711,8 +31247,6 @@ Po-Hsien Chu,2018-Q4,0,0,0
 Po-Hsien Chu,2018-Q3,0,0,0
 Po-Hsien Chu,2018-Q2,0,0,0
 Po-Hsien Chu,2018-Q1,2,18,20
-Jun Wang,2021-Q4,0,0,0
-Jun Wang,2021-Q3,0,0,0
 Jun Wang,2021-Q2,0,0,0
 Jun Wang,2021-Q1,0,0,0
 Jun Wang,2020-Q4,0,0,0
@@ -35727,8 +31261,6 @@ Jun Wang,2018-Q4,0,0,0
 Jun Wang,2018-Q3,0,0,0
 Jun Wang,2018-Q2,0,0,0
 Jun Wang,2018-Q1,1,2,3
-Yoni Tsafir,2021-Q4,0,0,0
-Yoni Tsafir,2021-Q3,0,0,0
 Yoni Tsafir,2021-Q2,0,0,0
 Yoni Tsafir,2021-Q1,0,0,0
 Yoni Tsafir,2020-Q4,0,0,0
@@ -35743,8 +31275,6 @@ Yoni Tsafir,2018-Q4,0,0,0
 Yoni Tsafir,2018-Q3,0,0,0
 Yoni Tsafir,2018-Q2,0,0,0
 Yoni Tsafir,2018-Q1,1,12,0
-Shrinidhi KL,2021-Q4,0,0,0
-Shrinidhi KL,2021-Q3,0,0,0
 Shrinidhi KL,2021-Q2,0,0,0
 Shrinidhi KL,2021-Q1,0,0,0
 Shrinidhi KL,2020-Q4,0,0,0
@@ -35759,8 +31289,6 @@ Shrinidhi KL,2018-Q4,0,0,0
 Shrinidhi KL,2018-Q3,0,0,0
 Shrinidhi KL,2018-Q2,0,0,0
 Shrinidhi KL,2018-Q1,2,2,0
-Shengpeng Liu,2021-Q4,0,0,0
-Shengpeng Liu,2021-Q3,0,0,0
 Shengpeng Liu,2021-Q2,0,0,0
 Shengpeng Liu,2021-Q1,0,0,0
 Shengpeng Liu,2020-Q4,0,0,0
@@ -35775,8 +31303,6 @@ Shengpeng Liu,2018-Q4,0,0,0
 Shengpeng Liu,2018-Q3,0,0,0
 Shengpeng Liu,2018-Q2,0,0,0
 Shengpeng Liu,2018-Q1,1,6,0
-Santiago Castro,2021-Q4,0,0,0
-Santiago Castro,2021-Q3,0,0,0
 Santiago Castro,2021-Q2,0,0,0
 Santiago Castro,2021-Q1,0,0,0
 Santiago Castro,2020-Q4,0,0,0
@@ -35791,8 +31317,6 @@ Santiago Castro,2018-Q4,0,0,0
 Santiago Castro,2018-Q3,0,0,0
 Santiago Castro,2018-Q2,0,0,0
 Santiago Castro,2018-Q1,3,84,61
-Keiji Ariyama,2021-Q4,0,0,0
-Keiji Ariyama,2021-Q3,0,0,0
 Keiji Ariyama,2021-Q2,0,0,0
 Keiji Ariyama,2021-Q1,0,0,0
 Keiji Ariyama,2020-Q4,0,0,0
@@ -35807,8 +31331,6 @@ Keiji Ariyama,2018-Q4,0,0,0
 Keiji Ariyama,2018-Q3,0,0,0
 Keiji Ariyama,2018-Q2,0,0,0
 Keiji Ariyama,2018-Q1,1,2,2
-Armando Fandango,2021-Q4,0,0,0
-Armando Fandango,2021-Q3,0,0,0
 Armando Fandango,2021-Q2,0,0,0
 Armando Fandango,2021-Q1,0,0,0
 Armando Fandango,2020-Q4,0,0,0
@@ -35823,8 +31345,6 @@ Armando Fandango,2018-Q4,0,0,0
 Armando Fandango,2018-Q3,0,0,0
 Armando Fandango,2018-Q2,0,0,0
 Armando Fandango,2018-Q1,1,5,2
-Luke Schaefer,2021-Q4,0,0,0
-Luke Schaefer,2021-Q3,0,0,0
 Luke Schaefer,2021-Q2,0,0,0
 Luke Schaefer,2021-Q1,0,0,0
 Luke Schaefer,2020-Q4,0,0,0
@@ -35839,8 +31359,6 @@ Luke Schaefer,2018-Q4,0,0,0
 Luke Schaefer,2018-Q3,0,0,0
 Luke Schaefer,2018-Q2,0,0,0
 Luke Schaefer,2018-Q1,1,0,0
-Stanislav Levental,2021-Q4,0,0,0
-Stanislav Levental,2021-Q3,0,0,0
 Stanislav Levental,2021-Q2,0,0,0
 Stanislav Levental,2021-Q1,0,0,0
 Stanislav Levental,2020-Q4,0,0,0
@@ -35855,8 +31373,6 @@ Stanislav Levental,2018-Q4,0,0,0
 Stanislav Levental,2018-Q3,0,0,0
 Stanislav Levental,2018-Q2,0,0,0
 Stanislav Levental,2018-Q1,4,24,2
-Jian Lin,2021-Q4,0,0,0
-Jian Lin,2021-Q3,0,0,0
 Jian Lin,2021-Q2,0,0,0
 Jian Lin,2021-Q1,0,0,0
 Jian Lin,2020-Q4,0,0,0
@@ -35871,8 +31387,6 @@ Jian Lin,2018-Q4,0,0,0
 Jian Lin,2018-Q3,0,0,0
 Jian Lin,2018-Q2,0,0,0
 Jian Lin,2018-Q1,1,3,0
-Ashish Kumar Ram,2021-Q4,0,0,0
-Ashish Kumar Ram,2021-Q3,0,0,0
 Ashish Kumar Ram,2021-Q2,0,0,0
 Ashish Kumar Ram,2021-Q1,0,0,0
 Ashish Kumar Ram,2020-Q4,0,0,0
@@ -35887,8 +31401,6 @@ Ashish Kumar Ram,2018-Q4,0,0,0
 Ashish Kumar Ram,2018-Q3,0,0,0
 Ashish Kumar Ram,2018-Q2,0,0,0
 Ashish Kumar Ram,2018-Q1,1,0,0
-Viraj Navkal,2021-Q4,0,0,0
-Viraj Navkal,2021-Q3,0,0,0
 Viraj Navkal,2021-Q2,0,0,0
 Viraj Navkal,2021-Q1,0,0,0
 Viraj Navkal,2020-Q4,0,0,0
@@ -35903,8 +31415,6 @@ Viraj Navkal,2018-Q4,0,0,0
 Viraj Navkal,2018-Q3,0,0,0
 Viraj Navkal,2018-Q2,0,0,0
 Viraj Navkal,2018-Q1,1,26,33
-Sam Matzek,2021-Q4,0,0,0
-Sam Matzek,2021-Q3,0,0,0
 Sam Matzek,2021-Q2,0,0,0
 Sam Matzek,2021-Q1,0,0,0
 Sam Matzek,2020-Q4,0,0,0
@@ -35919,8 +31429,6 @@ Sam Matzek,2018-Q4,0,0,0
 Sam Matzek,2018-Q3,0,0,0
 Sam Matzek,2018-Q2,0,0,0
 Sam Matzek,2018-Q1,1,51,0
-David Goodwin,2021-Q4,0,0,0
-David Goodwin,2021-Q3,0,0,0
 David Goodwin,2021-Q2,0,0,0
 David Goodwin,2021-Q1,0,0,0
 David Goodwin,2020-Q4,0,0,0
@@ -35935,8 +31443,6 @@ David Goodwin,2018-Q4,0,0,0
 David Goodwin,2018-Q3,0,0,0
 David Goodwin,2018-Q2,0,0,0
 David Goodwin,2018-Q1,1,8,2
-Paweł Kapica,2021-Q4,0,0,0
-Paweł Kapica,2021-Q3,0,0,0
 Paweł Kapica,2021-Q2,0,0,0
 Paweł Kapica,2021-Q1,0,0,0
 Paweł Kapica,2020-Q4,0,0,0
@@ -35951,8 +31457,6 @@ Paweł Kapica,2018-Q4,0,0,0
 Paweł Kapica,2018-Q3,0,0,0
 Paweł Kapica,2018-Q2,0,0,0
 Paweł Kapica,2018-Q1,4,181,0
-Jekyll Song,2021-Q4,0,0,0
-Jekyll Song,2021-Q3,0,0,0
 Jekyll Song,2021-Q2,0,0,0
 Jekyll Song,2021-Q1,0,0,0
 Jekyll Song,2020-Q4,0,0,0
@@ -35967,8 +31471,6 @@ Jekyll Song,2018-Q4,0,0,0
 Jekyll Song,2018-Q3,0,0,0
 Jekyll Song,2018-Q2,0,0,0
 Jekyll Song,2018-Q1,1,0,0
-Mohamed Aly,2021-Q4,0,0,0
-Mohamed Aly,2021-Q3,0,0,0
 Mohamed Aly,2021-Q2,0,0,0
 Mohamed Aly,2021-Q1,0,0,0
 Mohamed Aly,2020-Q4,0,0,0
@@ -35983,8 +31485,6 @@ Mohamed Aly,2018-Q4,0,0,0
 Mohamed Aly,2018-Q3,0,0,0
 Mohamed Aly,2018-Q2,0,0,0
 Mohamed Aly,2018-Q1,3,10,3
-Darjan Salaj,2021-Q4,0,0,0
-Darjan Salaj,2021-Q3,0,0,0
 Darjan Salaj,2021-Q2,0,0,0
 Darjan Salaj,2021-Q1,0,0,0
 Darjan Salaj,2020-Q4,0,0,0
@@ -35999,8 +31499,6 @@ Darjan Salaj,2018-Q4,0,0,0
 Darjan Salaj,2018-Q3,0,0,0
 Darjan Salaj,2018-Q2,0,0,0
 Darjan Salaj,2018-Q1,1,3,3
-Renat Idrisov,2021-Q4,0,0,0
-Renat Idrisov,2021-Q3,0,0,0
 Renat Idrisov,2021-Q2,0,0,0
 Renat Idrisov,2021-Q1,0,0,0
 Renat Idrisov,2020-Q4,0,0,0
@@ -36015,8 +31513,6 @@ Renat Idrisov,2018-Q4,0,0,0
 Renat Idrisov,2018-Q3,0,0,0
 Renat Idrisov,2018-Q2,0,0,0
 Renat Idrisov,2018-Q1,1,0,0
-Cesc,2021-Q4,0,0,0
-Cesc,2021-Q3,0,0,0
 Cesc,2021-Q2,0,0,0
 Cesc,2021-Q1,0,0,0
 Cesc,2020-Q4,0,0,0
@@ -36031,8 +31527,6 @@ Cesc,2018-Q4,0,0,0
 Cesc,2018-Q3,0,0,0
 Cesc,2018-Q2,0,0,0
 Cesc,2018-Q1,4,129,26
-lspvic,2021-Q4,0,0,0
-lspvic,2021-Q3,0,0,0
 lspvic,2021-Q2,0,0,0
 lspvic,2021-Q1,0,0,0
 lspvic,2020-Q4,0,0,0
@@ -36047,8 +31541,6 @@ lspvic,2018-Q4,0,0,0
 lspvic,2018-Q3,0,0,0
 lspvic,2018-Q2,0,0,0
 lspvic,2018-Q1,3,34,29
-Jesse Kinkead,2021-Q4,0,0,0
-Jesse Kinkead,2021-Q3,0,0,0
 Jesse Kinkead,2021-Q2,0,0,0
 Jesse Kinkead,2021-Q1,0,0,0
 Jesse Kinkead,2020-Q4,0,0,0
@@ -36063,8 +31555,6 @@ Jesse Kinkead,2018-Q4,0,0,0
 Jesse Kinkead,2018-Q3,0,0,0
 Jesse Kinkead,2018-Q2,0,0,0
 Jesse Kinkead,2018-Q1,3,135,116
-michaelkhan3,2021-Q4,0,0,0
-michaelkhan3,2021-Q3,0,0,0
 michaelkhan3,2021-Q2,0,0,0
 michaelkhan3,2021-Q1,0,0,0
 michaelkhan3,2020-Q4,0,0,0
@@ -36079,8 +31569,6 @@ michaelkhan3,2018-Q4,0,0,0
 michaelkhan3,2018-Q3,0,0,0
 michaelkhan3,2018-Q2,0,0,0
 michaelkhan3,2018-Q1,3,14,0
-Victor Costan,2021-Q4,0,0,0
-Victor Costan,2021-Q3,0,0,0
 Victor Costan,2021-Q2,0,0,0
 Victor Costan,2021-Q1,0,0,0
 Victor Costan,2020-Q4,0,0,0
@@ -36095,8 +31583,6 @@ Victor Costan,2018-Q4,0,0,0
 Victor Costan,2018-Q3,0,0,0
 Victor Costan,2018-Q2,0,0,0
 Victor Costan,2018-Q1,1,5,5
-Netzeband,2021-Q4,0,0,0
-Netzeband,2021-Q3,0,0,0
 Netzeband,2021-Q2,0,0,0
 Netzeband,2021-Q1,0,0,0
 Netzeband,2020-Q4,0,0,0
@@ -36111,8 +31597,6 @@ Netzeband,2018-Q4,0,0,0
 Netzeband,2018-Q3,0,0,0
 Netzeband,2018-Q2,0,0,0
 Netzeband,2018-Q1,1,6,2
-Clemens Schulz,2021-Q4,0,0,0
-Clemens Schulz,2021-Q3,0,0,0
 Clemens Schulz,2021-Q2,0,0,0
 Clemens Schulz,2021-Q1,0,0,0
 Clemens Schulz,2020-Q4,0,0,0
@@ -36127,8 +31611,6 @@ Clemens Schulz,2018-Q4,0,0,0
 Clemens Schulz,2018-Q3,0,0,0
 Clemens Schulz,2018-Q2,0,0,0
 Clemens Schulz,2018-Q1,2,43,42
-eladweiss,2021-Q4,0,0,0
-eladweiss,2021-Q3,0,0,0
 eladweiss,2021-Q2,0,0,0
 eladweiss,2021-Q1,0,0,0
 eladweiss,2020-Q4,0,0,0
@@ -36143,8 +31625,6 @@ eladweiss,2018-Q4,0,0,0
 eladweiss,2018-Q3,0,0,0
 eladweiss,2018-Q2,0,0,0
 eladweiss,2018-Q1,17,1601,897
-dssgsra,2021-Q4,0,0,0
-dssgsra,2021-Q3,0,0,0
 dssgsra,2021-Q2,0,0,0
 dssgsra,2021-Q1,0,0,0
 dssgsra,2020-Q4,0,0,0
@@ -36159,8 +31639,6 @@ dssgsra,2018-Q4,0,0,0
 dssgsra,2018-Q3,0,0,0
 dssgsra,2018-Q2,0,0,0
 dssgsra,2018-Q1,1,0,0
-Valentin Khrulkov,2021-Q4,0,0,0
-Valentin Khrulkov,2021-Q3,0,0,0
 Valentin Khrulkov,2021-Q2,0,0,0
 Valentin Khrulkov,2021-Q1,0,0,0
 Valentin Khrulkov,2020-Q4,0,0,0
@@ -36175,8 +31653,6 @@ Valentin Khrulkov,2018-Q4,0,0,0
 Valentin Khrulkov,2018-Q3,0,0,0
 Valentin Khrulkov,2018-Q2,0,0,0
 Valentin Khrulkov,2018-Q1,2,33,0
-starsblinking,2021-Q4,0,0,0
-starsblinking,2021-Q3,0,0,0
 starsblinking,2021-Q2,0,0,0
 starsblinking,2021-Q1,0,0,0
 starsblinking,2020-Q4,0,0,0
@@ -36191,8 +31667,6 @@ starsblinking,2018-Q4,0,0,0
 starsblinking,2018-Q3,0,0,0
 starsblinking,2018-Q2,0,0,0
 starsblinking,2018-Q1,1,0,0
-yordun,2021-Q4,0,0,0
-yordun,2021-Q3,0,0,0
 yordun,2021-Q2,0,0,0
 yordun,2021-Q1,0,0,0
 yordun,2020-Q4,0,0,0
@@ -36207,8 +31681,6 @@ yordun,2018-Q4,0,0,0
 yordun,2018-Q3,0,0,0
 yordun,2018-Q2,0,0,0
 yordun,2018-Q1,1,0,0
-Ashwini Shukla,2021-Q4,0,0,0
-Ashwini Shukla,2021-Q3,0,0,0
 Ashwini Shukla,2021-Q2,0,0,0
 Ashwini Shukla,2021-Q1,0,0,0
 Ashwini Shukla,2020-Q4,0,0,0
@@ -36223,8 +31695,6 @@ Ashwini Shukla,2018-Q4,0,0,0
 Ashwini Shukla,2018-Q3,0,0,0
 Ashwini Shukla,2018-Q2,0,0,0
 Ashwini Shukla,2018-Q1,2,350,0
-Ozge Yalcinkaya,2021-Q4,0,0,0
-Ozge Yalcinkaya,2021-Q3,0,0,0
 Ozge Yalcinkaya,2021-Q2,0,0,0
 Ozge Yalcinkaya,2021-Q1,0,0,0
 Ozge Yalcinkaya,2020-Q4,0,0,0
@@ -36239,8 +31709,6 @@ Ozge Yalcinkaya,2018-Q4,0,0,0
 Ozge Yalcinkaya,2018-Q3,0,0,0
 Ozge Yalcinkaya,2018-Q2,0,0,0
 Ozge Yalcinkaya,2018-Q1,1,85,19
-Parth P Panchal,2021-Q4,0,0,0
-Parth P Panchal,2021-Q3,0,0,0
 Parth P Panchal,2021-Q2,0,0,0
 Parth P Panchal,2021-Q1,0,0,0
 Parth P Panchal,2020-Q4,0,0,0
@@ -36255,8 +31723,6 @@ Parth P Panchal,2018-Q4,0,0,0
 Parth P Panchal,2018-Q3,0,0,0
 Parth P Panchal,2018-Q2,0,0,0
 Parth P Panchal,2018-Q1,4,28,5
-nathansilberman,2021-Q4,0,0,0
-nathansilberman,2021-Q3,0,0,0
 nathansilberman,2021-Q2,0,0,0
 nathansilberman,2021-Q1,0,0,0
 nathansilberman,2020-Q4,0,0,0
@@ -36271,8 +31737,6 @@ nathansilberman,2018-Q4,0,0,0
 nathansilberman,2018-Q3,0,0,0
 nathansilberman,2018-Q2,0,0,0
 nathansilberman,2018-Q1,3,122,0
-JerrikEph,2021-Q4,0,0,0
-JerrikEph,2021-Q3,0,0,0
 JerrikEph,2021-Q2,0,0,0
 JerrikEph,2021-Q1,0,0,0
 JerrikEph,2020-Q4,0,0,0
@@ -36287,8 +31751,6 @@ JerrikEph,2018-Q4,0,0,0
 JerrikEph,2018-Q3,0,0,0
 JerrikEph,2018-Q2,0,0,0
 JerrikEph,2018-Q1,2,103,16
-dmaclach,2021-Q4,0,0,0
-dmaclach,2021-Q3,0,0,0
 dmaclach,2021-Q2,0,0,0
 dmaclach,2021-Q1,0,0,0
 dmaclach,2020-Q4,0,0,0
@@ -36303,8 +31765,6 @@ dmaclach,2018-Q4,0,0,0
 dmaclach,2018-Q3,0,0,0
 dmaclach,2018-Q2,0,0,0
 dmaclach,2018-Q1,1,9,4
-cph,2021-Q4,0,0,0
-cph,2021-Q3,0,0,0
 cph,2021-Q2,0,0,0
 cph,2021-Q1,0,0,0
 cph,2020-Q4,0,0,0
@@ -36319,8 +31779,6 @@ cph,2018-Q4,0,0,0
 cph,2018-Q3,0,0,0
 cph,2018-Q2,0,0,0
 cph,2018-Q1,2,15,11
-Kiril Gorovoy,2021-Q4,0,0,0
-Kiril Gorovoy,2021-Q3,0,0,0
 Kiril Gorovoy,2021-Q2,0,0,0
 Kiril Gorovoy,2021-Q1,0,0,0
 Kiril Gorovoy,2020-Q4,0,0,0
@@ -36335,8 +31793,6 @@ Kiril Gorovoy,2018-Q4,0,0,0
 Kiril Gorovoy,2018-Q3,0,0,0
 Kiril Gorovoy,2018-Q2,0,0,0
 Kiril Gorovoy,2018-Q1,1,2,2
-loki der quaeler,2021-Q4,0,0,0
-loki der quaeler,2021-Q3,0,0,0
 loki der quaeler,2021-Q2,0,0,0
 loki der quaeler,2021-Q1,0,0,0
 loki der quaeler,2020-Q4,0,0,0
@@ -36351,8 +31807,6 @@ loki der quaeler,2018-Q4,0,0,0
 loki der quaeler,2018-Q3,0,0,0
 loki der quaeler,2018-Q2,0,0,0
 loki der quaeler,2018-Q1,1,16,0
-fanlu,2021-Q4,0,0,0
-fanlu,2021-Q3,0,0,0
 fanlu,2021-Q2,0,0,0
 fanlu,2021-Q1,0,0,0
 fanlu,2020-Q4,0,0,0
@@ -36367,8 +31821,6 @@ fanlu,2018-Q4,0,0,0
 fanlu,2018-Q3,0,0,0
 fanlu,2018-Q2,0,0,0
 fanlu,2018-Q1,1,2,2
-Eunji Jeong,2021-Q4,0,0,0
-Eunji Jeong,2021-Q3,0,0,0
 Eunji Jeong,2021-Q2,0,0,0
 Eunji Jeong,2021-Q1,0,0,0
 Eunji Jeong,2020-Q4,0,0,0
@@ -36383,8 +31835,6 @@ Eunji Jeong,2018-Q4,0,0,0
 Eunji Jeong,2018-Q3,0,0,0
 Eunji Jeong,2018-Q2,0,0,0
 Eunji Jeong,2018-Q1,3,3,0
-Vivek Rane,2021-Q4,0,0,0
-Vivek Rane,2021-Q3,0,0,0
 Vivek Rane,2021-Q2,0,0,0
 Vivek Rane,2021-Q1,0,0,0
 Vivek Rane,2020-Q4,0,0,0
@@ -36399,8 +31849,6 @@ Vivek Rane,2018-Q4,0,0,0
 Vivek Rane,2018-Q3,0,0,0
 Vivek Rane,2018-Q2,0,0,0
 Vivek Rane,2018-Q1,3,15,10
-hyunyoung2,2021-Q4,0,0,0
-hyunyoung2,2021-Q3,0,0,0
 hyunyoung2,2021-Q2,0,0,0
 hyunyoung2,2021-Q1,0,0,0
 hyunyoung2,2020-Q4,0,0,0
@@ -36415,8 +31863,6 @@ hyunyoung2,2018-Q4,0,0,0
 hyunyoung2,2018-Q3,0,0,0
 hyunyoung2,2018-Q2,0,0,0
 hyunyoung2,2018-Q1,1,0,0
-tkunic,2021-Q4,0,0,0
-tkunic,2021-Q3,0,0,0
 tkunic,2021-Q2,0,0,0
 tkunic,2021-Q1,0,0,0
 tkunic,2020-Q4,0,0,0
@@ -36431,8 +31877,6 @@ tkunic,2018-Q4,0,0,0
 tkunic,2018-Q3,0,0,0
 tkunic,2018-Q2,0,0,0
 tkunic,2018-Q1,2,37,12
-Kasper Marstal,2021-Q4,0,0,0
-Kasper Marstal,2021-Q3,0,0,0
 Kasper Marstal,2021-Q2,0,0,0
 Kasper Marstal,2021-Q1,0,0,0
 Kasper Marstal,2020-Q4,0,0,0
@@ -36447,8 +31891,6 @@ Kasper Marstal,2018-Q4,0,0,0
 Kasper Marstal,2018-Q3,0,0,0
 Kasper Marstal,2018-Q2,0,0,0
 Kasper Marstal,2018-Q1,9,9,45
-Yusef Shafi,2021-Q4,0,0,0
-Yusef Shafi,2021-Q3,0,0,0
 Yusef Shafi,2021-Q2,0,0,0
 Yusef Shafi,2021-Q1,0,0,0
 Yusef Shafi,2020-Q4,0,0,0
@@ -36463,8 +31905,6 @@ Yusef Shafi,2018-Q4,0,0,0
 Yusef Shafi,2018-Q3,0,0,0
 Yusef Shafi,2018-Q2,0,0,0
 Yusef Shafi,2018-Q1,1,0,0
-Takuya Wakisaka,2021-Q4,0,0,0
-Takuya Wakisaka,2021-Q3,0,0,0
 Takuya Wakisaka,2021-Q2,0,0,0
 Takuya Wakisaka,2021-Q1,0,0,0
 Takuya Wakisaka,2020-Q4,0,0,0
@@ -36479,8 +31919,6 @@ Takuya Wakisaka,2018-Q4,0,0,0
 Takuya Wakisaka,2018-Q3,0,0,0
 Takuya Wakisaka,2018-Q2,0,0,0
 Takuya Wakisaka,2018-Q1,1,2,2
-Raghu Krishnamoorthi,2021-Q4,0,0,0
-Raghu Krishnamoorthi,2021-Q3,0,0,0
 Raghu Krishnamoorthi,2021-Q2,0,0,0
 Raghu Krishnamoorthi,2021-Q1,0,0,0
 Raghu Krishnamoorthi,2020-Q4,0,0,0
@@ -36495,8 +31933,6 @@ Raghu Krishnamoorthi,2018-Q4,0,0,0
 Raghu Krishnamoorthi,2018-Q3,0,0,0
 Raghu Krishnamoorthi,2018-Q2,0,0,0
 Raghu Krishnamoorthi,2018-Q1,6,55,30
-Aiden Scandella,2021-Q4,0,0,0
-Aiden Scandella,2021-Q3,0,0,0
 Aiden Scandella,2021-Q2,0,0,0
 Aiden Scandella,2021-Q1,0,0,0
 Aiden Scandella,2020-Q4,0,0,0
@@ -36511,8 +31947,6 @@ Aiden Scandella,2018-Q4,0,0,0
 Aiden Scandella,2018-Q3,0,0,0
 Aiden Scandella,2018-Q2,0,0,0
 Aiden Scandella,2018-Q1,1,0,0
-Tijmen Verhulsdonck,2021-Q4,0,0,0
-Tijmen Verhulsdonck,2021-Q3,0,0,0
 Tijmen Verhulsdonck,2021-Q2,0,0,0
 Tijmen Verhulsdonck,2021-Q1,0,0,0
 Tijmen Verhulsdonck,2020-Q4,0,0,0
@@ -36527,8 +31961,6 @@ Tijmen Verhulsdonck,2018-Q4,0,0,0
 Tijmen Verhulsdonck,2018-Q3,0,0,0
 Tijmen Verhulsdonck,2018-Q2,0,0,0
 Tijmen Verhulsdonck,2018-Q1,2,49,8
-Kamil Sindi,2021-Q4,0,0,0
-Kamil Sindi,2021-Q3,0,0,0
 Kamil Sindi,2021-Q2,0,0,0
 Kamil Sindi,2021-Q1,0,0,0
 Kamil Sindi,2020-Q4,0,0,0
@@ -36543,8 +31975,6 @@ Kamil Sindi,2018-Q4,0,0,0
 Kamil Sindi,2018-Q3,0,0,0
 Kamil Sindi,2018-Q2,0,0,0
 Kamil Sindi,2018-Q1,2,51,0
-vade,2021-Q4,0,0,0
-vade,2021-Q3,0,0,0
 vade,2021-Q2,0,0,0
 vade,2021-Q1,0,0,0
 vade,2020-Q4,0,0,0
@@ -36559,8 +31989,6 @@ vade,2018-Q4,0,0,0
 vade,2018-Q3,0,0,0
 vade,2018-Q2,0,0,0
 vade,2018-Q1,1,0,0
-powderluv,2021-Q4,0,0,0
-powderluv,2021-Q3,0,0,0
 powderluv,2021-Q2,0,0,0
 powderluv,2021-Q1,0,0,0
 powderluv,2020-Q4,0,0,0
@@ -36575,8 +32003,6 @@ powderluv,2018-Q4,0,0,0
 powderluv,2018-Q3,0,0,0
 powderluv,2018-Q2,0,0,0
 powderluv,2018-Q1,2,63,9
-Allen Goodman,2021-Q4,0,0,0
-Allen Goodman,2021-Q3,0,0,0
 Allen Goodman,2021-Q2,0,0,0
 Allen Goodman,2021-Q1,0,0,0
 Allen Goodman,2020-Q4,0,0,0
@@ -36591,8 +32017,6 @@ Allen Goodman,2018-Q4,0,0,0
 Allen Goodman,2018-Q3,0,0,0
 Allen Goodman,2018-Q2,0,0,0
 Allen Goodman,2018-Q1,1,0,0
-Eric Lilienstein,2021-Q4,0,0,0
-Eric Lilienstein,2021-Q3,0,0,0
 Eric Lilienstein,2021-Q2,0,0,0
 Eric Lilienstein,2021-Q1,0,0,0
 Eric Lilienstein,2020-Q4,0,0,0
@@ -36607,8 +32031,6 @@ Eric Lilienstein,2018-Q4,0,0,0
 Eric Lilienstein,2018-Q3,0,0,0
 Eric Lilienstein,2018-Q2,0,0,0
 Eric Lilienstein,2018-Q1,1,2,2
-Philip Yang,2021-Q4,0,0,0
-Philip Yang,2021-Q3,0,0,0
 Philip Yang,2021-Q2,0,0,0
 Philip Yang,2021-Q1,0,0,0
 Philip Yang,2020-Q4,0,0,0
@@ -36623,8 +32045,6 @@ Philip Yang,2018-Q4,0,0,0
 Philip Yang,2018-Q3,0,0,0
 Philip Yang,2018-Q2,0,0,0
 Philip Yang,2018-Q1,1,24,2
-Matt Basta,2021-Q4,0,0,0
-Matt Basta,2021-Q3,0,0,0
 Matt Basta,2021-Q2,0,0,0
 Matt Basta,2021-Q1,0,0,0
 Matt Basta,2020-Q4,0,0,0
@@ -36639,8 +32059,6 @@ Matt Basta,2018-Q4,0,0,0
 Matt Basta,2018-Q3,0,0,0
 Matt Basta,2018-Q2,0,0,0
 Matt Basta,2018-Q1,1,0,0
-dongsamb,2021-Q4,0,0,0
-dongsamb,2021-Q3,0,0,0
 dongsamb,2021-Q2,0,0,0
 dongsamb,2021-Q1,0,0,0
 dongsamb,2020-Q4,0,0,0
@@ -36655,8 +32073,6 @@ dongsamb,2018-Q4,0,0,0
 dongsamb,2018-Q3,0,0,0
 dongsamb,2018-Q2,0,0,0
 dongsamb,2018-Q1,1,3,3
-Miguel Piedrafita,2021-Q4,0,0,0
-Miguel Piedrafita,2021-Q3,0,0,0
 Miguel Piedrafita,2021-Q2,0,0,0
 Miguel Piedrafita,2021-Q1,0,0,0
 Miguel Piedrafita,2020-Q4,0,0,0
@@ -36671,8 +32087,6 @@ Miguel Piedrafita,2018-Q4,0,0,0
 Miguel Piedrafita,2018-Q3,0,0,0
 Miguel Piedrafita,2018-Q2,0,0,0
 Miguel Piedrafita,2018-Q1,1,0,0
-Jay Young,2021-Q4,0,0,0
-Jay Young,2021-Q3,0,0,0
 Jay Young,2021-Q2,0,0,0
 Jay Young,2021-Q1,0,0,0
 Jay Young,2020-Q4,0,0,0
@@ -36687,8 +32101,6 @@ Jay Young,2018-Q4,0,0,0
 Jay Young,2018-Q3,0,0,0
 Jay Young,2018-Q2,0,0,0
 Jay Young,2018-Q1,1,0,0
-clint (woonhyuk baek),2021-Q4,0,0,0
-clint (woonhyuk baek),2021-Q3,0,0,0
 clint (woonhyuk baek),2021-Q2,0,0,0
 clint (woonhyuk baek),2021-Q1,0,0,0
 clint (woonhyuk baek),2020-Q4,0,0,0
@@ -36703,8 +32115,6 @@ clint (woonhyuk baek),2018-Q4,0,0,0
 clint (woonhyuk baek),2018-Q3,0,0,0
 clint (woonhyuk baek),2018-Q2,0,0,0
 clint (woonhyuk baek),2018-Q1,2,63,25
-Patryk Chrabaszcz,2021-Q4,0,0,0
-Patryk Chrabaszcz,2021-Q3,0,0,0
 Patryk Chrabaszcz,2021-Q2,0,0,0
 Patryk Chrabaszcz,2021-Q1,0,0,0
 Patryk Chrabaszcz,2020-Q4,0,0,0
@@ -36719,8 +32129,6 @@ Patryk Chrabaszcz,2018-Q4,0,0,0
 Patryk Chrabaszcz,2018-Q3,0,0,0
 Patryk Chrabaszcz,2018-Q2,0,0,0
 Patryk Chrabaszcz,2018-Q1,7,185,340
-Lynn Jackson,2021-Q4,0,0,0
-Lynn Jackson,2021-Q3,0,0,0
 Lynn Jackson,2021-Q2,0,0,0
 Lynn Jackson,2021-Q1,0,0,0
 Lynn Jackson,2020-Q4,0,0,0
@@ -36735,8 +32143,6 @@ Lynn Jackson,2018-Q4,0,0,0
 Lynn Jackson,2018-Q3,0,0,0
 Lynn Jackson,2018-Q2,0,0,0
 Lynn Jackson,2018-Q1,1,9,4
-Puyu Wang,2021-Q4,0,0,0
-Puyu Wang,2021-Q3,0,0,0
 Puyu Wang,2021-Q2,0,0,0
 Puyu Wang,2021-Q1,0,0,0
 Puyu Wang,2020-Q4,0,0,0
@@ -36751,8 +32157,6 @@ Puyu Wang,2018-Q4,0,0,0
 Puyu Wang,2018-Q3,0,0,0
 Puyu Wang,2018-Q2,0,0,0
 Puyu Wang,2018-Q1,0,0,0
-田传武,2021-Q4,0,0,0
-田传武,2021-Q3,0,0,0
 田传武,2021-Q2,0,0,0
 田传武,2021-Q1,0,0,0
 田传武,2020-Q4,0,0,0
@@ -36767,8 +32171,6 @@ Puyu Wang,2018-Q1,0,0,0
 田传武,2018-Q3,0,0,0
 田传武,2018-Q2,0,0,0
 田传武,2018-Q1,3,0,0
-Simone Cirillo,2021-Q4,0,0,0
-Simone Cirillo,2021-Q3,0,0,0
 Simone Cirillo,2021-Q2,0,0,0
 Simone Cirillo,2021-Q1,0,0,0
 Simone Cirillo,2020-Q4,0,0,0
@@ -36783,8 +32185,6 @@ Simone Cirillo,2018-Q4,0,0,0
 Simone Cirillo,2018-Q3,0,0,0
 Simone Cirillo,2018-Q2,0,0,0
 Simone Cirillo,2018-Q1,0,0,0
-Timofey Kondrashov,2021-Q4,0,0,0
-Timofey Kondrashov,2021-Q3,0,0,0
 Timofey Kondrashov,2021-Q2,0,0,0
 Timofey Kondrashov,2021-Q1,0,0,0
 Timofey Kondrashov,2020-Q4,0,0,0
@@ -36799,8 +32199,6 @@ Timofey Kondrashov,2018-Q4,0,0,0
 Timofey Kondrashov,2018-Q3,0,0,0
 Timofey Kondrashov,2018-Q2,0,0,0
 Timofey Kondrashov,2018-Q1,0,0,0
-JoshVarty,2021-Q4,0,0,0
-JoshVarty,2021-Q3,0,0,0
 JoshVarty,2021-Q2,0,0,0
 JoshVarty,2021-Q1,0,0,0
 JoshVarty,2020-Q4,0,0,0
@@ -36815,8 +32213,6 @@ JoshVarty,2018-Q4,0,0,0
 JoshVarty,2018-Q3,0,0,0
 JoshVarty,2018-Q2,0,0,0
 JoshVarty,2018-Q1,0,0,0
-Edward H,2021-Q4,0,0,0
-Edward H,2021-Q3,0,0,0
 Edward H,2021-Q2,0,0,0
 Edward H,2021-Q1,0,0,0
 Edward H,2020-Q4,0,0,0
@@ -36831,8 +32227,6 @@ Edward H,2018-Q4,0,0,0
 Edward H,2018-Q3,0,0,0
 Edward H,2018-Q2,0,0,0
 Edward H,2018-Q1,0,0,0
-jing1.huang,2021-Q4,0,0,0
-jing1.huang,2021-Q3,0,0,0
 jing1.huang,2021-Q2,0,0,0
 jing1.huang,2021-Q1,0,0,0
 jing1.huang,2020-Q4,0,0,0
@@ -36847,8 +32241,6 @@ jing1.huang,2018-Q4,0,0,0
 jing1.huang,2018-Q3,0,0,0
 jing1.huang,2018-Q2,0,0,0
 jing1.huang,2018-Q1,0,0,0
-codrut3,2021-Q4,0,0,0
-codrut3,2021-Q3,0,0,0
 codrut3,2021-Q2,0,0,0
 codrut3,2021-Q1,0,0,0
 codrut3,2020-Q4,0,0,0
@@ -36863,8 +32255,6 @@ codrut3,2018-Q4,0,0,0
 codrut3,2018-Q3,0,0,0
 codrut3,2018-Q2,0,0,0
 codrut3,2018-Q1,0,0,0
-k-w-w,2021-Q4,0,0,0
-k-w-w,2021-Q3,0,0,0
 k-w-w,2021-Q2,0,0,0
 k-w-w,2021-Q1,0,0,0
 k-w-w,2020-Q4,0,0,0
@@ -36879,8 +32269,6 @@ k-w-w,2018-Q4,0,0,0
 k-w-w,2018-Q3,0,0,0
 k-w-w,2018-Q2,0,0,0
 k-w-w,2018-Q1,0,0,0
-Dong--Jian,2021-Q4,0,0,0
-Dong--Jian,2021-Q3,0,0,0
 Dong--Jian,2021-Q2,0,0,0
 Dong--Jian,2021-Q1,0,0,0
 Dong--Jian,2020-Q4,0,0,0
@@ -36895,8 +32283,6 @@ Dong--Jian,2018-Q4,0,0,0
 Dong--Jian,2018-Q3,0,0,0
 Dong--Jian,2018-Q2,0,0,0
 Dong--Jian,2018-Q1,0,0,0
-Johnny Chan,2021-Q4,0,0,0
-Johnny Chan,2021-Q3,0,0,0
 Johnny Chan,2021-Q2,0,0,0
 Johnny Chan,2021-Q1,0,0,0
 Johnny Chan,2020-Q4,0,0,0
@@ -36911,8 +32297,6 @@ Johnny Chan,2018-Q4,0,0,0
 Johnny Chan,2018-Q3,0,0,0
 Johnny Chan,2018-Q2,0,0,0
 Johnny Chan,2018-Q1,0,0,0
-Stephen Lumenta,2021-Q4,0,0,0
-Stephen Lumenta,2021-Q3,0,0,0
 Stephen Lumenta,2021-Q2,0,0,0
 Stephen Lumenta,2021-Q1,0,0,0
 Stephen Lumenta,2020-Q4,0,0,0
@@ -36927,8 +32311,6 @@ Stephen Lumenta,2018-Q4,0,0,0
 Stephen Lumenta,2018-Q3,0,0,0
 Stephen Lumenta,2018-Q2,0,0,0
 Stephen Lumenta,2018-Q1,0,0,0
-Rasmus,2021-Q4,0,0,0
-Rasmus,2021-Q3,0,0,0
 Rasmus,2021-Q2,0,0,0
 Rasmus,2021-Q1,0,0,0
 Rasmus,2020-Q4,0,0,0
@@ -36943,8 +32325,6 @@ Rasmus,2018-Q4,0,0,0
 Rasmus,2018-Q3,0,0,0
 Rasmus,2018-Q2,0,0,0
 Rasmus,2018-Q1,0,0,0
-patrickzzy,2021-Q4,0,0,0
-patrickzzy,2021-Q3,0,0,0
 patrickzzy,2021-Q2,0,0,0
 patrickzzy,2021-Q1,0,0,0
 patrickzzy,2020-Q4,0,0,0
@@ -36959,8 +32339,6 @@ patrickzzy,2018-Q4,0,0,0
 patrickzzy,2018-Q3,0,0,0
 patrickzzy,2018-Q2,0,0,0
 patrickzzy,2018-Q1,0,0,0
-Pierre BLONDEAU,2021-Q4,0,0,0
-Pierre BLONDEAU,2021-Q3,0,0,0
 Pierre BLONDEAU,2021-Q2,0,0,0
 Pierre BLONDEAU,2021-Q1,0,0,0
 Pierre BLONDEAU,2020-Q4,0,0,0
@@ -36975,8 +32353,6 @@ Pierre BLONDEAU,2018-Q4,0,0,0
 Pierre BLONDEAU,2018-Q3,0,0,0
 Pierre BLONDEAU,2018-Q2,0,0,0
 Pierre BLONDEAU,2018-Q1,0,0,0
-Sahil Singh,2021-Q4,0,0,0
-Sahil Singh,2021-Q3,0,0,0
 Sahil Singh,2021-Q2,0,0,0
 Sahil Singh,2021-Q1,0,0,0
 Sahil Singh,2020-Q4,0,0,0
@@ -36991,8 +32367,6 @@ Sahil Singh,2018-Q4,0,0,0
 Sahil Singh,2018-Q3,0,0,0
 Sahil Singh,2018-Q2,0,0,0
 Sahil Singh,2018-Q1,0,0,0
-sandipmgiri,2021-Q4,0,0,0
-sandipmgiri,2021-Q3,0,0,0
 sandipmgiri,2021-Q2,0,0,0
 sandipmgiri,2021-Q1,0,0,0
 sandipmgiri,2020-Q4,0,0,0
@@ -37007,8 +32381,6 @@ sandipmgiri,2018-Q4,0,0,0
 sandipmgiri,2018-Q3,0,0,0
 sandipmgiri,2018-Q2,0,0,0
 sandipmgiri,2018-Q1,0,0,0
-Su Tang,2021-Q4,0,0,0
-Su Tang,2021-Q3,0,0,0
 Su Tang,2021-Q2,0,0,0
 Su Tang,2021-Q1,0,0,0
 Su Tang,2020-Q4,0,0,0
@@ -37023,8 +32395,6 @@ Su Tang,2018-Q4,0,0,0
 Su Tang,2018-Q3,0,0,0
 Su Tang,2018-Q2,0,0,0
 Su Tang,2018-Q1,0,0,0
-Changming Sun,2021-Q4,0,0,0
-Changming Sun,2021-Q3,0,0,0
 Changming Sun,2021-Q2,0,0,0
 Changming Sun,2021-Q1,0,0,0
 Changming Sun,2020-Q4,0,0,0
@@ -37039,8 +32409,6 @@ Changming Sun,2018-Q4,0,0,0
 Changming Sun,2018-Q3,0,0,0
 Changming Sun,2018-Q2,0,0,0
 Changming Sun,2018-Q1,0,0,0
-error.d,2021-Q4,0,0,0
-error.d,2021-Q3,0,0,0
 error.d,2021-Q2,0,0,0
 error.d,2021-Q1,0,0,0
 error.d,2020-Q4,0,0,0
@@ -37055,8 +32423,6 @@ error.d,2018-Q4,0,0,0
 error.d,2018-Q3,0,0,0
 error.d,2018-Q2,0,0,0
 error.d,2018-Q1,0,0,0
-Yaroslav Bulatov,2021-Q4,0,0,0
-Yaroslav Bulatov,2021-Q3,0,0,0
 Yaroslav Bulatov,2021-Q2,0,0,0
 Yaroslav Bulatov,2021-Q1,0,0,0
 Yaroslav Bulatov,2020-Q4,0,0,0
@@ -37071,8 +32437,6 @@ Yaroslav Bulatov,2018-Q4,0,0,0
 Yaroslav Bulatov,2018-Q3,0,0,0
 Yaroslav Bulatov,2018-Q2,0,0,0
 Yaroslav Bulatov,2018-Q1,0,0,0
-Ronald Eddy Jr,2021-Q4,0,0,0
-Ronald Eddy Jr,2021-Q3,0,0,0
 Ronald Eddy Jr,2021-Q2,0,0,0
 Ronald Eddy Jr,2021-Q1,0,0,0
 Ronald Eddy Jr,2020-Q4,0,0,0
@@ -37087,8 +32451,6 @@ Ronald Eddy Jr,2018-Q4,0,0,0
 Ronald Eddy Jr,2018-Q3,0,0,0
 Ronald Eddy Jr,2018-Q2,0,0,0
 Ronald Eddy Jr,2018-Q1,0,0,0
-Matthew Schulkind,2021-Q4,0,0,0
-Matthew Schulkind,2021-Q3,0,0,0
 Matthew Schulkind,2021-Q2,0,0,0
 Matthew Schulkind,2021-Q1,0,0,0
 Matthew Schulkind,2020-Q4,0,0,0
@@ -37103,8 +32465,6 @@ Matthew Schulkind,2018-Q4,0,0,0
 Matthew Schulkind,2018-Q3,0,0,0
 Matthew Schulkind,2018-Q2,0,0,0
 Matthew Schulkind,2018-Q1,0,0,0
-Dandelion Man?,2021-Q4,0,0,0
-Dandelion Man?,2021-Q3,0,0,0
 Dandelion Man?,2021-Q2,0,0,0
 Dandelion Man?,2021-Q1,0,0,0
 Dandelion Man?,2020-Q4,0,0,0
@@ -37119,8 +32479,6 @@ Dandelion Man?,2018-Q4,0,0,0
 Dandelion Man?,2018-Q3,0,0,0
 Dandelion Man?,2018-Q2,0,0,0
 Dandelion Man?,2018-Q1,0,0,0
-wagonhelm,2021-Q4,0,0,0
-wagonhelm,2021-Q3,0,0,0
 wagonhelm,2021-Q2,0,0,0
 wagonhelm,2021-Q1,0,0,0
 wagonhelm,2020-Q4,0,0,0
@@ -37135,8 +32493,6 @@ wagonhelm,2018-Q4,0,0,0
 wagonhelm,2018-Q3,0,0,0
 wagonhelm,2018-Q2,0,0,0
 wagonhelm,2018-Q1,0,0,0
-Lucas Sloan,2021-Q4,0,0,0
-Lucas Sloan,2021-Q3,0,0,0
 Lucas Sloan,2021-Q2,0,0,0
 Lucas Sloan,2021-Q1,0,0,0
 Lucas Sloan,2020-Q4,0,0,0
@@ -37151,8 +32507,6 @@ Lucas Sloan,2018-Q4,0,0,0
 Lucas Sloan,2018-Q3,0,0,0
 Lucas Sloan,2018-Q2,0,0,0
 Lucas Sloan,2018-Q1,0,0,0
-Shreyash sharma,2021-Q4,0,0,0
-Shreyash sharma,2021-Q3,0,0,0
 Shreyash sharma,2021-Q2,0,0,0
 Shreyash sharma,2021-Q1,0,0,0
 Shreyash sharma,2020-Q4,0,0,0
@@ -37167,8 +32521,6 @@ Shreyash sharma,2018-Q4,0,0,0
 Shreyash sharma,2018-Q3,0,0,0
 Shreyash sharma,2018-Q2,0,0,0
 Shreyash sharma,2018-Q1,0,0,0
-Randy West,2021-Q4,0,0,0
-Randy West,2021-Q3,0,0,0
 Randy West,2021-Q2,0,0,0
 Randy West,2021-Q1,0,0,0
 Randy West,2020-Q4,0,0,0
@@ -37183,8 +32535,6 @@ Randy West,2018-Q4,0,0,0
 Randy West,2018-Q3,0,0,0
 Randy West,2018-Q2,0,0,0
 Randy West,2018-Q1,0,0,0
-Ted Ying,2021-Q4,0,0,0
-Ted Ying,2021-Q3,0,0,0
 Ted Ying,2021-Q2,0,0,0
 Ted Ying,2021-Q1,0,0,0
 Ted Ying,2020-Q4,0,0,0
@@ -37199,8 +32549,6 @@ Ted Ying,2018-Q4,0,0,0
 Ted Ying,2018-Q3,0,0,0
 Ted Ying,2018-Q2,0,0,0
 Ted Ying,2018-Q1,0,0,0
-Erich Elsen,2021-Q4,0,0,0
-Erich Elsen,2021-Q3,0,0,0
 Erich Elsen,2021-Q2,0,0,0
 Erich Elsen,2021-Q1,0,0,0
 Erich Elsen,2020-Q4,0,0,0
@@ -37215,8 +32563,6 @@ Erich Elsen,2018-Q4,0,0,0
 Erich Elsen,2018-Q3,0,0,0
 Erich Elsen,2018-Q2,0,0,0
 Erich Elsen,2018-Q1,0,0,0
-Andrei Costinescu,2021-Q4,0,0,0
-Andrei Costinescu,2021-Q3,0,0,0
 Andrei Costinescu,2021-Q2,0,0,0
 Andrei Costinescu,2021-Q1,0,0,0
 Andrei Costinescu,2020-Q4,0,0,0
@@ -37231,8 +32577,6 @@ Andrei Costinescu,2018-Q4,0,0,0
 Andrei Costinescu,2018-Q3,0,0,0
 Andrei Costinescu,2018-Q2,0,0,0
 Andrei Costinescu,2018-Q1,0,0,0
-Daniel Ylitalo,2021-Q4,0,0,0
-Daniel Ylitalo,2021-Q3,0,0,0
 Daniel Ylitalo,2021-Q2,0,0,0
 Daniel Ylitalo,2021-Q1,0,0,0
 Daniel Ylitalo,2020-Q4,0,0,0
@@ -37247,8 +32591,6 @@ Daniel Ylitalo,2018-Q4,0,0,0
 Daniel Ylitalo,2018-Q3,0,0,0
 Daniel Ylitalo,2018-Q2,0,0,0
 Daniel Ylitalo,2018-Q1,0,0,0
-Mike Knapp,2021-Q4,0,0,0
-Mike Knapp,2021-Q3,0,0,0
 Mike Knapp,2021-Q2,0,0,0
 Mike Knapp,2021-Q1,0,0,0
 Mike Knapp,2020-Q4,0,0,0
@@ -37263,8 +32605,6 @@ Mike Knapp,2018-Q4,0,0,0
 Mike Knapp,2018-Q3,0,0,0
 Mike Knapp,2018-Q2,0,0,0
 Mike Knapp,2018-Q1,0,0,0
-Viraj,2021-Q4,0,0,0
-Viraj,2021-Q3,0,0,0
 Viraj,2021-Q2,0,0,0
 Viraj,2021-Q1,0,0,0
 Viraj,2020-Q4,0,0,0
@@ -37279,8 +32619,6 @@ Viraj,2018-Q4,0,0,0
 Viraj,2018-Q3,0,0,0
 Viraj,2018-Q2,0,0,0
 Viraj,2018-Q1,0,0,0
-jfaath,2021-Q4,0,0,0
-jfaath,2021-Q3,0,0,0
 jfaath,2021-Q2,0,0,0
 jfaath,2021-Q1,0,0,0
 jfaath,2020-Q4,0,0,0
@@ -37295,8 +32633,6 @@ jfaath,2018-Q4,0,0,0
 jfaath,2018-Q3,0,0,0
 jfaath,2018-Q2,0,0,0
 jfaath,2018-Q1,0,0,0
-CQY,2021-Q4,0,0,0
-CQY,2021-Q3,0,0,0
 CQY,2021-Q2,0,0,0
 CQY,2021-Q1,0,0,0
 CQY,2020-Q4,0,0,0
@@ -37311,8 +32647,6 @@ CQY,2018-Q4,0,0,0
 CQY,2018-Q3,0,0,0
 CQY,2018-Q2,0,0,0
 CQY,2018-Q1,0,0,0
-Chris Donahue,2021-Q4,0,0,0
-Chris Donahue,2021-Q3,0,0,0
 Chris Donahue,2021-Q2,0,0,0
 Chris Donahue,2021-Q1,0,0,0
 Chris Donahue,2020-Q4,0,0,0
@@ -37327,8 +32661,6 @@ Chris Donahue,2018-Q4,0,0,0
 Chris Donahue,2018-Q3,0,0,0
 Chris Donahue,2018-Q2,0,0,0
 Chris Donahue,2018-Q1,0,0,0
-Akimasa KIMURA,2021-Q4,0,0,0
-Akimasa KIMURA,2021-Q3,0,0,0
 Akimasa KIMURA,2021-Q2,0,0,0
 Akimasa KIMURA,2021-Q1,0,0,0
 Akimasa KIMURA,2020-Q4,0,0,0
@@ -37343,8 +32675,6 @@ Akimasa KIMURA,2018-Q4,0,0,0
 Akimasa KIMURA,2018-Q3,0,0,0
 Akimasa KIMURA,2018-Q2,0,0,0
 Akimasa KIMURA,2018-Q1,0,0,0
-Johan Ju,2021-Q4,0,0,0
-Johan Ju,2021-Q3,0,0,0
 Johan Ju,2021-Q2,0,0,0
 Johan Ju,2021-Q1,0,0,0
 Johan Ju,2020-Q4,0,0,0
@@ -37359,8 +32689,6 @@ Johan Ju,2018-Q4,0,0,0
 Johan Ju,2018-Q3,0,0,0
 Johan Ju,2018-Q2,0,0,0
 Johan Ju,2018-Q1,0,0,0
-Codrut Grosu,2021-Q4,0,0,0
-Codrut Grosu,2021-Q3,0,0,0
 Codrut Grosu,2021-Q2,0,0,0
 Codrut Grosu,2021-Q1,0,0,0
 Codrut Grosu,2020-Q4,0,0,0
@@ -37375,8 +32703,6 @@ Codrut Grosu,2018-Q4,0,0,0
 Codrut Grosu,2018-Q3,0,0,0
 Codrut Grosu,2018-Q2,0,0,0
 Codrut Grosu,2018-Q1,0,0,0
-Zhengsheng Wei,2021-Q4,0,0,0
-Zhengsheng Wei,2021-Q3,0,0,0
 Zhengsheng Wei,2021-Q2,0,0,0
 Zhengsheng Wei,2021-Q1,0,0,0
 Zhengsheng Wei,2020-Q4,0,0,0
@@ -37391,8 +32717,6 @@ Zhengsheng Wei,2018-Q4,0,0,0
 Zhengsheng Wei,2018-Q3,0,0,0
 Zhengsheng Wei,2018-Q2,0,0,0
 Zhengsheng Wei,2018-Q1,0,0,0
-FirefoxMetzger,2021-Q4,0,0,0
-FirefoxMetzger,2021-Q3,0,0,0
 FirefoxMetzger,2021-Q2,0,0,0
 FirefoxMetzger,2021-Q1,0,0,0
 FirefoxMetzger,2020-Q4,0,0,0
@@ -37407,8 +32731,6 @@ FirefoxMetzger,2018-Q4,0,0,0
 FirefoxMetzger,2018-Q3,0,0,0
 FirefoxMetzger,2018-Q2,0,0,0
 FirefoxMetzger,2018-Q1,0,0,0
-Chris Filo Gorgolewski,2021-Q4,0,0,0
-Chris Filo Gorgolewski,2021-Q3,0,0,0
 Chris Filo Gorgolewski,2021-Q2,0,0,0
 Chris Filo Gorgolewski,2021-Q1,0,0,0
 Chris Filo Gorgolewski,2020-Q4,0,0,0
@@ -37423,8 +32745,6 @@ Chris Filo Gorgolewski,2018-Q4,0,0,0
 Chris Filo Gorgolewski,2018-Q3,0,0,0
 Chris Filo Gorgolewski,2018-Q2,0,0,0
 Chris Filo Gorgolewski,2018-Q1,0,0,0
-arixlin,2021-Q4,0,0,0
-arixlin,2021-Q3,0,0,0
 arixlin,2021-Q2,0,0,0
 arixlin,2021-Q1,0,0,0
 arixlin,2020-Q4,0,0,0
@@ -37439,8 +32759,6 @@ arixlin,2018-Q4,0,0,0
 arixlin,2018-Q3,0,0,0
 arixlin,2018-Q2,0,0,0
 arixlin,2018-Q1,0,0,0
-hannesa2,2021-Q4,0,0,0
-hannesa2,2021-Q3,0,0,0
 hannesa2,2021-Q2,0,0,0
 hannesa2,2021-Q1,0,0,0
 hannesa2,2020-Q4,0,0,0
@@ -37455,8 +32773,6 @@ hannesa2,2018-Q4,0,0,0
 hannesa2,2018-Q3,0,0,0
 hannesa2,2018-Q2,0,0,0
 hannesa2,2018-Q1,0,0,0
-Adam Zahran,2021-Q4,0,0,0
-Adam Zahran,2021-Q3,0,0,0
 Adam Zahran,2021-Q2,0,0,0
 Adam Zahran,2021-Q1,0,0,0
 Adam Zahran,2020-Q4,0,0,0
@@ -37471,8 +32787,6 @@ Adam Zahran,2018-Q4,0,0,0
 Adam Zahran,2018-Q3,0,0,0
 Adam Zahran,2018-Q2,0,0,0
 Adam Zahran,2018-Q1,0,0,0
-MathSquared,2021-Q4,0,0,0
-MathSquared,2021-Q3,0,0,0
 MathSquared,2021-Q2,0,0,0
 MathSquared,2021-Q1,0,0,0
 MathSquared,2020-Q4,0,0,0
@@ -37487,8 +32801,6 @@ MathSquared,2018-Q4,0,0,0
 MathSquared,2018-Q3,0,0,0
 MathSquared,2018-Q2,0,0,0
 MathSquared,2018-Q1,0,0,0
-dongpilYu,2021-Q4,0,0,0
-dongpilYu,2021-Q3,0,0,0
 dongpilYu,2021-Q2,0,0,0
 dongpilYu,2021-Q1,0,0,0
 dongpilYu,2020-Q4,0,0,0
@@ -37503,8 +32815,6 @@ dongpilYu,2018-Q4,0,0,0
 dongpilYu,2018-Q3,0,0,0
 dongpilYu,2018-Q2,0,0,0
 dongpilYu,2018-Q1,0,0,0
-Josh Varty,2021-Q4,0,0,0
-Josh Varty,2021-Q3,0,0,0
 Josh Varty,2021-Q2,0,0,0
 Josh Varty,2021-Q1,0,0,0
 Josh Varty,2020-Q4,0,0,0
@@ -37519,8 +32829,6 @@ Josh Varty,2018-Q4,0,0,0
 Josh Varty,2018-Q3,0,0,0
 Josh Varty,2018-Q2,0,0,0
 Josh Varty,2018-Q1,0,0,0
-Dan Becker,2021-Q4,0,0,0
-Dan Becker,2021-Q3,0,0,0
 Dan Becker,2021-Q2,0,0,0
 Dan Becker,2021-Q1,0,0,0
 Dan Becker,2020-Q4,0,0,0
@@ -37535,8 +32843,6 @@ Dan Becker,2018-Q4,0,0,0
 Dan Becker,2018-Q3,0,0,0
 Dan Becker,2018-Q2,0,0,0
 Dan Becker,2018-Q1,0,0,0
-peisong,2021-Q4,0,0,0
-peisong,2021-Q3,0,0,0
 peisong,2021-Q2,0,0,0
 peisong,2021-Q1,0,0,0
 peisong,2020-Q4,0,0,0
@@ -37551,8 +32857,6 @@ peisong,2018-Q4,0,0,0
 peisong,2018-Q3,0,0,0
 peisong,2018-Q2,0,0,0
 peisong,2018-Q1,0,0,0
-Toni Kunic,2021-Q4,0,0,0
-Toni Kunic,2021-Q3,0,0,0
 Toni Kunic,2021-Q2,0,0,0
 Toni Kunic,2021-Q1,0,0,0
 Toni Kunic,2020-Q4,0,0,0
@@ -37567,8 +32871,6 @@ Toni Kunic,2018-Q4,0,0,0
 Toni Kunic,2018-Q3,0,0,0
 Toni Kunic,2018-Q2,0,0,0
 Toni Kunic,2018-Q1,0,0,0
-Matt Wytock,2021-Q4,0,0,0
-Matt Wytock,2021-Q3,0,0,0
 Matt Wytock,2021-Q2,0,0,0
 Matt Wytock,2021-Q1,0,0,0
 Matt Wytock,2020-Q4,0,0,0
@@ -37583,8 +32885,6 @@ Matt Wytock,2018-Q4,0,0,0
 Matt Wytock,2018-Q3,0,0,0
 Matt Wytock,2018-Q2,0,0,0
 Matt Wytock,2018-Q1,0,0,0
-Jan,2021-Q4,0,0,0
-Jan,2021-Q3,0,0,0
 Jan,2021-Q2,0,0,0
 Jan,2021-Q1,0,0,0
 Jan,2020-Q4,0,0,0
@@ -37599,8 +32899,6 @@ Jan,2018-Q4,0,0,0
 Jan,2018-Q3,0,0,0
 Jan,2018-Q2,0,0,0
 Jan,2018-Q1,0,0,0
-Jeff,2021-Q4,0,0,0
-Jeff,2021-Q3,0,0,0
 Jeff,2021-Q2,0,0,0
 Jeff,2021-Q1,0,0,0
 Jeff,2020-Q4,0,0,0
@@ -37615,8 +32913,6 @@ Jeff,2018-Q4,0,0,0
 Jeff,2018-Q3,0,0,0
 Jeff,2018-Q2,0,0,0
 Jeff,2018-Q1,0,0,0
-John Sungjin Park,2021-Q4,0,0,0
-John Sungjin Park,2021-Q3,0,0,0
 John Sungjin Park,2021-Q2,0,0,0
 John Sungjin Park,2021-Q1,0,0,0
 John Sungjin Park,2020-Q4,0,0,0
@@ -37631,8 +32927,6 @@ John Sungjin Park,2018-Q4,0,0,0
 John Sungjin Park,2018-Q3,0,0,0
 John Sungjin Park,2018-Q2,0,0,0
 John Sungjin Park,2018-Q1,0,0,0
-Vishvananda Ishaya Abrams,2021-Q4,0,0,0
-Vishvananda Ishaya Abrams,2021-Q3,0,0,0
 Vishvananda Ishaya Abrams,2021-Q2,0,0,0
 Vishvananda Ishaya Abrams,2021-Q1,0,0,0
 Vishvananda Ishaya Abrams,2020-Q4,0,0,0
@@ -37647,8 +32941,6 @@ Vishvananda Ishaya Abrams,2018-Q4,0,0,0
 Vishvananda Ishaya Abrams,2018-Q3,0,0,0
 Vishvananda Ishaya Abrams,2018-Q2,0,0,0
 Vishvananda Ishaya Abrams,2018-Q1,0,0,0
-Ishant Mrinal Haloi,2021-Q4,0,0,0
-Ishant Mrinal Haloi,2021-Q3,0,0,0
 Ishant Mrinal Haloi,2021-Q2,0,0,0
 Ishant Mrinal Haloi,2021-Q1,0,0,0
 Ishant Mrinal Haloi,2020-Q4,0,0,0
@@ -37663,8 +32955,6 @@ Ishant Mrinal Haloi,2018-Q4,0,0,0
 Ishant Mrinal Haloi,2018-Q3,0,0,0
 Ishant Mrinal Haloi,2018-Q2,0,0,0
 Ishant Mrinal Haloi,2018-Q1,0,0,0
-FredZhang,2021-Q4,0,0,0
-FredZhang,2021-Q3,0,0,0
 FredZhang,2021-Q2,0,0,0
 FredZhang,2021-Q1,0,0,0
 FredZhang,2020-Q4,0,0,0
@@ -37679,8 +32969,6 @@ FredZhang,2018-Q4,0,0,0
 FredZhang,2018-Q3,0,0,0
 FredZhang,2018-Q2,0,0,0
 FredZhang,2018-Q1,0,0,0
-Gary Deer,2021-Q4,0,0,0
-Gary Deer,2021-Q3,0,0,0
 Gary Deer,2021-Q2,0,0,0
 Gary Deer,2021-Q1,0,0,0
 Gary Deer,2020-Q4,0,0,0
@@ -37695,8 +32983,6 @@ Gary Deer,2018-Q4,0,0,0
 Gary Deer,2018-Q3,0,0,0
 Gary Deer,2018-Q2,0,0,0
 Gary Deer,2018-Q1,0,0,0
-Alexander,2021-Q4,0,0,0
-Alexander,2021-Q3,0,0,0
 Alexander,2021-Q2,0,0,0
 Alexander,2021-Q1,0,0,0
 Alexander,2020-Q4,0,0,0
@@ -37711,8 +32997,6 @@ Alexander,2018-Q4,0,0,0
 Alexander,2018-Q3,0,0,0
 Alexander,2018-Q2,0,0,0
 Alexander,2018-Q1,0,0,0
-Charles Shenton,2021-Q4,0,0,0
-Charles Shenton,2021-Q3,0,0,0
 Charles Shenton,2021-Q2,0,0,0
 Charles Shenton,2021-Q1,0,0,0
 Charles Shenton,2020-Q4,0,0,0
@@ -37727,8 +33011,6 @@ Charles Shenton,2018-Q4,0,0,0
 Charles Shenton,2018-Q3,0,0,0
 Charles Shenton,2018-Q2,0,0,0
 Charles Shenton,2018-Q1,0,0,0
-Jimmy Jia,2021-Q4,0,0,0
-Jimmy Jia,2021-Q3,0,0,0
 Jimmy Jia,2021-Q2,0,0,0
 Jimmy Jia,2021-Q1,0,0,0
 Jimmy Jia,2020-Q4,0,0,0
@@ -37743,8 +33025,6 @@ Jimmy Jia,2018-Q4,0,0,0
 Jimmy Jia,2018-Q3,0,0,0
 Jimmy Jia,2018-Q2,0,0,0
 Jimmy Jia,2018-Q1,0,0,0
-Guenther Schmuelling,2021-Q4,0,0,0
-Guenther Schmuelling,2021-Q3,0,0,0
 Guenther Schmuelling,2021-Q2,0,0,0
 Guenther Schmuelling,2021-Q1,0,0,0
 Guenther Schmuelling,2020-Q4,0,0,0
@@ -37759,8 +33039,6 @@ Guenther Schmuelling,2018-Q4,0,0,0
 Guenther Schmuelling,2018-Q3,0,0,0
 Guenther Schmuelling,2018-Q2,0,0,0
 Guenther Schmuelling,2018-Q1,0,0,0
-Marek Šuppa,2021-Q4,0,0,0
-Marek Šuppa,2021-Q3,0,0,0
 Marek Šuppa,2021-Q2,0,0,0
 Marek Šuppa,2021-Q1,0,0,0
 Marek Šuppa,2020-Q4,0,0,0
@@ -37775,8 +33053,6 @@ Marek Šuppa,2018-Q4,0,0,0
 Marek Šuppa,2018-Q3,0,0,0
 Marek Šuppa,2018-Q2,0,0,0
 Marek Šuppa,2018-Q1,0,0,0
-László Csomor,2021-Q4,0,0,0
-László Csomor,2021-Q3,0,0,0
 László Csomor,2021-Q2,0,0,0
 László Csomor,2021-Q1,0,0,0
 László Csomor,2020-Q4,0,0,0
@@ -37791,8 +33067,6 @@ László Csomor,2018-Q4,0,0,0
 László Csomor,2018-Q3,0,0,0
 László Csomor,2018-Q2,0,0,0
 László Csomor,2018-Q1,0,0,0
-scott,2021-Q4,0,0,0
-scott,2021-Q3,0,0,0
 scott,2021-Q2,0,0,0
 scott,2021-Q1,0,0,0
 scott,2020-Q4,0,0,0
@@ -37807,8 +33081,6 @@ scott,2018-Q4,0,0,0
 scott,2018-Q3,0,0,0
 scott,2018-Q2,0,0,0
 scott,2018-Q1,0,0,0
-concerttttt,2021-Q4,0,0,0
-concerttttt,2021-Q3,0,0,0
 concerttttt,2021-Q2,0,0,0
 concerttttt,2021-Q1,0,0,0
 concerttttt,2020-Q4,0,0,0
@@ -37823,8 +33095,6 @@ concerttttt,2018-Q4,0,0,0
 concerttttt,2018-Q3,0,0,0
 concerttttt,2018-Q2,0,0,0
 concerttttt,2018-Q1,0,0,0
-Keven Wang,2021-Q4,0,0,0
-Keven Wang,2021-Q3,0,0,0
 Keven Wang,2021-Q2,0,0,0
 Keven Wang,2021-Q1,0,0,0
 Keven Wang,2020-Q4,0,0,0
@@ -37839,8 +33109,6 @@ Keven Wang,2018-Q4,0,0,0
 Keven Wang,2018-Q3,0,0,0
 Keven Wang,2018-Q2,0,0,0
 Keven Wang,2018-Q1,0,0,0
-zxcqwe4906,2021-Q4,0,0,0
-zxcqwe4906,2021-Q3,0,0,0
 zxcqwe4906,2021-Q2,0,0,0
 zxcqwe4906,2021-Q1,0,0,0
 zxcqwe4906,2020-Q4,0,0,0
@@ -37855,8 +33123,6 @@ zxcqwe4906,2018-Q4,0,0,0
 zxcqwe4906,2018-Q3,0,0,0
 zxcqwe4906,2018-Q2,0,0,0
 zxcqwe4906,2018-Q1,0,0,0
-CSJY,2021-Q4,0,0,0
-CSJY,2021-Q3,0,0,0
 CSJY,2021-Q2,0,0,0
 CSJY,2021-Q1,0,0,0
 CSJY,2020-Q4,0,0,0
@@ -37871,8 +33137,6 @@ CSJY,2018-Q4,0,0,0
 CSJY,2018-Q3,0,0,0
 CSJY,2018-Q2,0,0,0
 CSJY,2018-Q1,0,0,0
-Chris Hoyean Song,2021-Q4,0,0,0
-Chris Hoyean Song,2021-Q3,0,0,0
 Chris Hoyean Song,2021-Q2,0,0,0
 Chris Hoyean Song,2021-Q1,0,0,0
 Chris Hoyean Song,2020-Q4,0,0,0
@@ -37887,8 +33151,6 @@ Chris Hoyean Song,2018-Q4,0,0,0
 Chris Hoyean Song,2018-Q3,0,0,0
 Chris Hoyean Song,2018-Q2,0,0,0
 Chris Hoyean Song,2018-Q1,0,0,0
-Christopher Shallue,2021-Q4,0,0,0
-Christopher Shallue,2021-Q3,0,0,0
 Christopher Shallue,2021-Q2,0,0,0
 Christopher Shallue,2021-Q1,0,0,0
 Christopher Shallue,2020-Q4,0,0,0
@@ -37903,8 +33165,6 @@ Christopher Shallue,2018-Q4,0,0,0
 Christopher Shallue,2018-Q3,0,0,0
 Christopher Shallue,2018-Q2,0,0,0
 Christopher Shallue,2018-Q1,0,0,0
-Kyle Mills,2021-Q4,0,0,0
-Kyle Mills,2021-Q3,0,0,0
 Kyle Mills,2021-Q2,0,0,0
 Kyle Mills,2021-Q1,0,0,0
 Kyle Mills,2020-Q4,0,0,0
@@ -37919,8 +33179,6 @@ Kyle Mills,2018-Q4,0,0,0
 Kyle Mills,2018-Q3,0,0,0
 Kyle Mills,2018-Q2,0,0,0
 Kyle Mills,2018-Q1,0,0,0
-cinqS,2021-Q4,0,0,0
-cinqS,2021-Q3,0,0,0
 cinqS,2021-Q2,0,0,0
 cinqS,2021-Q1,0,0,0
 cinqS,2020-Q4,0,0,0
@@ -37935,8 +33193,6 @@ cinqS,2018-Q4,0,0,0
 cinqS,2018-Q3,0,0,0
 cinqS,2018-Q2,0,0,0
 cinqS,2018-Q1,0,0,0
-Daniyar,2021-Q4,0,0,0
-Daniyar,2021-Q3,0,0,0
 Daniyar,2021-Q2,0,0,0
 Daniyar,2021-Q1,0,0,0
 Daniyar,2020-Q4,0,0,0
@@ -37951,8 +33207,6 @@ Daniyar,2018-Q4,0,0,0
 Daniyar,2018-Q3,0,0,0
 Daniyar,2018-Q2,0,0,0
 Daniyar,2018-Q1,0,0,0
-Alistair Low,2021-Q4,0,0,0
-Alistair Low,2021-Q3,0,0,0
 Alistair Low,2021-Q2,0,0,0
 Alistair Low,2021-Q1,0,0,0
 Alistair Low,2020-Q4,0,0,0
@@ -37967,8 +33221,6 @@ Alistair Low,2018-Q4,0,0,0
 Alistair Low,2018-Q3,0,0,0
 Alistair Low,2018-Q2,0,0,0
 Alistair Low,2018-Q1,0,0,0
-Youssef Hesham,2021-Q4,0,0,0
-Youssef Hesham,2021-Q3,0,0,0
 Youssef Hesham,2021-Q2,0,0,0
 Youssef Hesham,2021-Q1,0,0,0
 Youssef Hesham,2020-Q4,0,0,0
@@ -37983,8 +33235,6 @@ Youssef Hesham,2018-Q4,0,0,0
 Youssef Hesham,2018-Q3,0,0,0
 Youssef Hesham,2018-Q2,0,0,0
 Youssef Hesham,2018-Q1,0,0,0
-Gregg Helt,2021-Q4,0,0,0
-Gregg Helt,2021-Q3,0,0,0
 Gregg Helt,2021-Q2,0,0,0
 Gregg Helt,2021-Q1,0,0,0
 Gregg Helt,2020-Q4,0,0,0
@@ -37999,8 +33249,6 @@ Gregg Helt,2018-Q4,0,0,0
 Gregg Helt,2018-Q3,0,0,0
 Gregg Helt,2018-Q2,0,0,0
 Gregg Helt,2018-Q1,0,0,0
-Sandeep Dcunha,2021-Q4,0,0,0
-Sandeep Dcunha,2021-Q3,0,0,0
 Sandeep Dcunha,2021-Q2,0,0,0
 Sandeep Dcunha,2021-Q1,0,0,0
 Sandeep Dcunha,2020-Q4,0,0,0
@@ -38015,8 +33263,6 @@ Sandeep Dcunha,2018-Q4,0,0,0
 Sandeep Dcunha,2018-Q3,0,0,0
 Sandeep Dcunha,2018-Q2,0,0,0
 Sandeep Dcunha,2018-Q1,0,0,0
-Winnie Tsang,2021-Q4,0,0,0
-Winnie Tsang,2021-Q3,0,0,0
 Winnie Tsang,2021-Q2,0,0,0
 Winnie Tsang,2021-Q1,0,0,0
 Winnie Tsang,2020-Q4,0,0,0
@@ -38031,8 +33277,6 @@ Winnie Tsang,2018-Q4,0,0,0
 Winnie Tsang,2018-Q3,0,0,0
 Winnie Tsang,2018-Q2,0,0,0
 Winnie Tsang,2018-Q1,0,0,0
-Samuel He,2021-Q4,0,0,0
-Samuel He,2021-Q3,0,0,0
 Samuel He,2021-Q2,0,0,0
 Samuel He,2021-Q1,0,0,0
 Samuel He,2020-Q4,0,0,0
@@ -38047,8 +33291,6 @@ Samuel He,2018-Q4,0,0,0
 Samuel He,2018-Q3,0,0,0
 Samuel He,2018-Q2,0,0,0
 Samuel He,2018-Q1,0,0,0
-PinkySan,2021-Q4,0,0,0
-PinkySan,2021-Q3,0,0,0
 PinkySan,2021-Q2,0,0,0
 PinkySan,2021-Q1,0,0,0
 PinkySan,2020-Q4,0,0,0
@@ -38063,8 +33305,6 @@ PinkySan,2018-Q4,0,0,0
 PinkySan,2018-Q3,0,0,0
 PinkySan,2018-Q2,0,0,0
 PinkySan,2018-Q1,0,0,0
-Mats Linander,2021-Q4,0,0,0
-Mats Linander,2021-Q3,0,0,0
 Mats Linander,2021-Q2,0,0,0
 Mats Linander,2021-Q1,0,0,0
 Mats Linander,2020-Q4,0,0,0
@@ -38079,8 +33319,6 @@ Mats Linander,2018-Q4,0,0,0
 Mats Linander,2018-Q3,0,0,0
 Mats Linander,2018-Q2,0,0,0
 Mats Linander,2018-Q1,0,0,0
-Alex Rothberg,2021-Q4,0,0,0
-Alex Rothberg,2021-Q3,0,0,0
 Alex Rothberg,2021-Q2,0,0,0
 Alex Rothberg,2021-Q1,0,0,0
 Alex Rothberg,2020-Q4,0,0,0
@@ -38095,8 +33333,6 @@ Alex Rothberg,2018-Q4,0,0,0
 Alex Rothberg,2018-Q3,0,0,0
 Alex Rothberg,2018-Q2,0,0,0
 Alex Rothberg,2018-Q1,0,0,0
-Dave MacLachlan,2021-Q4,0,0,0
-Dave MacLachlan,2021-Q3,0,0,0
 Dave MacLachlan,2021-Q2,0,0,0
 Dave MacLachlan,2021-Q1,0,0,0
 Dave MacLachlan,2020-Q4,0,0,0
@@ -38111,8 +33347,6 @@ Dave MacLachlan,2018-Q4,0,0,0
 Dave MacLachlan,2018-Q3,0,0,0
 Dave MacLachlan,2018-Q2,0,0,0
 Dave MacLachlan,2018-Q1,0,0,0
-dariavel,2021-Q4,0,0,0
-dariavel,2021-Q3,0,0,0
 dariavel,2021-Q2,0,0,0
 dariavel,2021-Q1,0,0,0
 dariavel,2020-Q4,0,0,0
@@ -38127,8 +33361,6 @@ dariavel,2018-Q4,0,0,0
 dariavel,2018-Q3,0,0,0
 dariavel,2018-Q2,0,0,0
 dariavel,2018-Q1,0,0,0
-Joe Castagneri,2021-Q4,0,0,0
-Joe Castagneri,2021-Q3,0,0,0
 Joe Castagneri,2021-Q2,0,0,0
 Joe Castagneri,2021-Q1,0,0,0
 Joe Castagneri,2020-Q4,0,0,0
@@ -38143,8 +33375,6 @@ Joe Castagneri,2018-Q4,0,0,0
 Joe Castagneri,2018-Q3,0,0,0
 Joe Castagneri,2018-Q2,0,0,0
 Joe Castagneri,2018-Q1,0,0,0
-TTrapper,2021-Q4,0,0,0
-TTrapper,2021-Q3,0,0,0
 TTrapper,2021-Q2,0,0,0
 TTrapper,2021-Q1,0,0,0
 TTrapper,2020-Q4,0,0,0
@@ -38159,8 +33389,6 @@ TTrapper,2018-Q4,0,0,0
 TTrapper,2018-Q3,0,0,0
 TTrapper,2018-Q2,0,0,0
 TTrapper,2018-Q1,0,0,0
-Tim,2021-Q4,0,0,0
-Tim,2021-Q3,0,0,0
 Tim,2021-Q2,0,0,0
 Tim,2021-Q1,0,0,0
 Tim,2020-Q4,0,0,0
@@ -38175,8 +33403,6 @@ Tim,2018-Q4,0,0,0
 Tim,2018-Q3,0,0,0
 Tim,2018-Q2,0,0,0
 Tim,2018-Q1,0,0,0
-Daniel Zhang,2021-Q4,0,0,0
-Daniel Zhang,2021-Q3,0,0,0
 Daniel Zhang,2021-Q2,0,0,0
 Daniel Zhang,2021-Q1,0,0,0
 Daniel Zhang,2020-Q4,0,0,0
@@ -38191,8 +33417,6 @@ Daniel Zhang,2018-Q4,0,0,0
 Daniel Zhang,2018-Q3,0,0,0
 Daniel Zhang,2018-Q2,0,0,0
 Daniel Zhang,2018-Q1,0,0,0
-Thomas Schumm,2021-Q4,0,0,0
-Thomas Schumm,2021-Q3,0,0,0
 Thomas Schumm,2021-Q2,0,0,0
 Thomas Schumm,2021-Q1,0,0,0
 Thomas Schumm,2020-Q4,0,0,0
@@ -38207,8 +33431,6 @@ Thomas Schumm,2018-Q4,0,0,0
 Thomas Schumm,2018-Q3,0,0,0
 Thomas Schumm,2018-Q2,0,0,0
 Thomas Schumm,2018-Q1,0,0,0
-PW486,2021-Q4,0,0,0
-PW486,2021-Q3,0,0,0
 PW486,2021-Q2,0,0,0
 PW486,2021-Q1,0,0,0
 PW486,2020-Q4,0,0,0
@@ -38223,8 +33445,6 @@ PW486,2018-Q4,0,0,0
 PW486,2018-Q3,0,0,0
 PW486,2018-Q2,0,0,0
 PW486,2018-Q1,0,0,0
-Ralph Tang,2021-Q4,0,0,0
-Ralph Tang,2021-Q3,0,0,0
 Ralph Tang,2021-Q2,0,0,0
 Ralph Tang,2021-Q1,0,0,0
 Ralph Tang,2020-Q4,0,0,0
@@ -38239,8 +33459,6 @@ Ralph Tang,2018-Q4,0,0,0
 Ralph Tang,2018-Q3,0,0,0
 Ralph Tang,2018-Q2,0,0,0
 Ralph Tang,2018-Q1,0,0,0
-Cem Eteke,2021-Q4,0,0,0
-Cem Eteke,2021-Q3,0,0,0
 Cem Eteke,2021-Q2,0,0,0
 Cem Eteke,2021-Q1,0,0,0
 Cem Eteke,2020-Q4,0,0,0
@@ -38255,8 +33473,6 @@ Cem Eteke,2018-Q4,0,0,0
 Cem Eteke,2018-Q3,0,0,0
 Cem Eteke,2018-Q2,0,0,0
 Cem Eteke,2018-Q1,0,0,0
-amilioto,2021-Q4,0,0,0
-amilioto,2021-Q3,0,0,0
 amilioto,2021-Q2,0,0,0
 amilioto,2021-Q1,0,0,0
 amilioto,2020-Q4,0,0,0
@@ -38271,8 +33487,6 @@ amilioto,2018-Q4,0,0,0
 amilioto,2018-Q3,0,0,0
 amilioto,2018-Q2,0,0,0
 amilioto,2018-Q1,0,0,0
-Amy,2021-Q4,0,0,0
-Amy,2021-Q3,0,0,0
 Amy,2021-Q2,0,0,0
 Amy,2021-Q1,0,0,0
 Amy,2020-Q4,0,0,0
@@ -38287,8 +33501,6 @@ Amy,2018-Q4,0,0,0
 Amy,2018-Q3,0,0,0
 Amy,2018-Q2,0,0,0
 Amy,2018-Q1,0,0,0
-Ilya Edrenkin,2021-Q4,0,0,0
-Ilya Edrenkin,2021-Q3,0,0,0
 Ilya Edrenkin,2021-Q2,0,0,0
 Ilya Edrenkin,2021-Q1,0,0,0
 Ilya Edrenkin,2020-Q4,0,0,0
@@ -38303,8 +33515,6 @@ Ilya Edrenkin,2018-Q4,0,0,0
 Ilya Edrenkin,2018-Q3,0,0,0
 Ilya Edrenkin,2018-Q2,0,0,0
 Ilya Edrenkin,2018-Q1,0,0,0
-Cameron Thomas,2021-Q4,0,0,0
-Cameron Thomas,2021-Q3,0,0,0
 Cameron Thomas,2021-Q2,0,0,0
 Cameron Thomas,2021-Q1,0,0,0
 Cameron Thomas,2020-Q4,0,0,0
@@ -38319,8 +33529,6 @@ Cameron Thomas,2018-Q4,0,0,0
 Cameron Thomas,2018-Q3,0,0,0
 Cameron Thomas,2018-Q2,0,0,0
 Cameron Thomas,2018-Q1,0,0,0
-Amir H. Jadidinejad,2021-Q4,0,0,0
-Amir H. Jadidinejad,2021-Q3,0,0,0
 Amir H. Jadidinejad,2021-Q2,0,0,0
 Amir H. Jadidinejad,2021-Q1,0,0,0
 Amir H. Jadidinejad,2020-Q4,0,0,0
@@ -38335,8 +33543,6 @@ Amir H. Jadidinejad,2018-Q4,0,0,0
 Amir H. Jadidinejad,2018-Q3,0,0,0
 Amir H. Jadidinejad,2018-Q2,0,0,0
 Amir H. Jadidinejad,2018-Q1,0,0,0
-fcharras,2021-Q4,0,0,0
-fcharras,2021-Q3,0,0,0
 fcharras,2021-Q2,0,0,0
 fcharras,2021-Q1,0,0,0
 fcharras,2020-Q4,0,0,0
@@ -38351,8 +33557,6 @@ fcharras,2018-Q4,0,0,0
 fcharras,2018-Q3,0,0,0
 fcharras,2018-Q2,0,0,0
 fcharras,2018-Q1,0,0,0
-Nathan van Doorn,2021-Q4,0,0,0
-Nathan van Doorn,2021-Q3,0,0,0
 Nathan van Doorn,2021-Q2,0,0,0
 Nathan van Doorn,2021-Q1,0,0,0
 Nathan van Doorn,2020-Q4,0,0,0
@@ -38367,8 +33571,6 @@ Nathan van Doorn,2018-Q4,0,0,0
 Nathan van Doorn,2018-Q3,0,0,0
 Nathan van Doorn,2018-Q2,0,0,0
 Nathan van Doorn,2018-Q1,0,0,0
-pks,2021-Q4,0,0,0
-pks,2021-Q3,0,0,0
 pks,2021-Q2,0,0,0
 pks,2021-Q1,0,0,0
 pks,2020-Q4,0,0,0
@@ -38383,8 +33585,6 @@ pks,2018-Q4,0,0,0
 pks,2018-Q3,0,0,0
 pks,2018-Q2,0,0,0
 pks,2018-Q1,0,0,0
-Maximilian Bachl,2021-Q4,0,0,0
-Maximilian Bachl,2021-Q3,0,0,0
 Maximilian Bachl,2021-Q2,0,0,0
 Maximilian Bachl,2021-Q1,0,0,0
 Maximilian Bachl,2020-Q4,0,0,0
@@ -38399,8 +33599,6 @@ Maximilian Bachl,2018-Q4,0,0,0
 Maximilian Bachl,2018-Q3,0,0,0
 Maximilian Bachl,2018-Q2,0,0,0
 Maximilian Bachl,2018-Q1,0,0,0
-Noa Ezra,2021-Q4,0,0,0
-Noa Ezra,2021-Q3,0,0,0
 Noa Ezra,2021-Q2,0,0,0
 Noa Ezra,2021-Q1,0,0,0
 Noa Ezra,2020-Q4,0,0,0
@@ -38415,8 +33613,6 @@ Noa Ezra,2018-Q4,0,0,0
 Noa Ezra,2018-Q3,0,0,0
 Noa Ezra,2018-Q2,0,0,0
 Noa Ezra,2018-Q1,0,0,0
-Toon Verstraelen,2021-Q4,0,0,0
-Toon Verstraelen,2021-Q3,0,0,0
 Toon Verstraelen,2021-Q2,0,0,0
 Toon Verstraelen,2021-Q1,0,0,0
 Toon Verstraelen,2020-Q4,0,0,0
@@ -38431,8 +33627,6 @@ Toon Verstraelen,2018-Q4,0,0,0
 Toon Verstraelen,2018-Q3,0,0,0
 Toon Verstraelen,2018-Q2,0,0,0
 Toon Verstraelen,2018-Q1,0,0,0
-Yan Chen,2021-Q4,0,0,0
-Yan Chen,2021-Q3,0,0,0
 Yan Chen,2021-Q2,0,0,0
 Yan Chen,2021-Q1,0,0,0
 Yan Chen,2020-Q4,0,0,0
@@ -38447,8 +33641,6 @@ Yan Chen,2018-Q4,0,0,0
 Yan Chen,2018-Q3,0,0,0
 Yan Chen,2018-Q2,0,0,0
 Yan Chen,2018-Q1,0,0,0
-Yi Yang,2021-Q4,0,0,0
-Yi Yang,2021-Q3,0,0,0
 Yi Yang,2021-Q2,0,0,0
 Yi Yang,2021-Q1,0,0,0
 Yi Yang,2020-Q4,0,0,0
@@ -38463,8 +33655,6 @@ Yi Yang,2018-Q4,0,0,0
 Yi Yang,2018-Q3,0,0,0
 Yi Yang,2018-Q2,0,0,0
 Yi Yang,2018-Q1,0,0,0
-Qiao Longfei,2021-Q4,0,0,0
-Qiao Longfei,2021-Q3,0,0,0
 Qiao Longfei,2021-Q2,0,0,0
 Qiao Longfei,2021-Q1,0,0,0
 Qiao Longfei,2020-Q4,0,0,0
@@ -38479,8 +33669,6 @@ Qiao Longfei,2018-Q4,0,0,0
 Qiao Longfei,2018-Q3,0,0,0
 Qiao Longfei,2018-Q2,0,0,0
 Qiao Longfei,2018-Q1,0,0,0
-gunan,2021-Q4,0,0,0
-gunan,2021-Q3,0,0,0
 gunan,2021-Q2,0,0,0
 gunan,2021-Q1,0,0,0
 gunan,2020-Q4,0,0,0
@@ -38495,8 +33683,6 @@ gunan,2018-Q4,0,0,0
 gunan,2018-Q3,0,0,0
 gunan,2018-Q2,0,0,0
 gunan,2018-Q1,0,0,0
-miqlas,2021-Q4,0,0,0
-miqlas,2021-Q3,0,0,0
 miqlas,2021-Q2,0,0,0
 miqlas,2021-Q1,0,0,0
 miqlas,2020-Q4,0,0,0
@@ -38511,8 +33697,6 @@ miqlas,2018-Q4,0,0,0
 miqlas,2018-Q3,0,0,0
 miqlas,2018-Q2,0,0,0
 miqlas,2018-Q1,0,0,0
-opensourcemattress,2021-Q4,0,0,0
-opensourcemattress,2021-Q3,0,0,0
 opensourcemattress,2021-Q2,0,0,0
 opensourcemattress,2021-Q1,0,0,0
 opensourcemattress,2020-Q4,0,0,0
@@ -38527,8 +33711,6 @@ opensourcemattress,2018-Q4,0,0,0
 opensourcemattress,2018-Q3,0,0,0
 opensourcemattress,2018-Q2,0,0,0
 opensourcemattress,2018-Q1,0,0,0
-Eric Lv,2021-Q4,0,0,0
-Eric Lv,2021-Q3,0,0,0
 Eric Lv,2021-Q2,0,0,0
 Eric Lv,2021-Q1,0,0,0
 Eric Lv,2020-Q4,0,0,0
@@ -38543,8 +33725,6 @@ Eric Lv,2018-Q4,0,0,0
 Eric Lv,2018-Q3,0,0,0
 Eric Lv,2018-Q2,0,0,0
 Eric Lv,2018-Q1,0,0,0
-Steffen Schmitz,2021-Q4,0,0,0
-Steffen Schmitz,2021-Q3,0,0,0
 Steffen Schmitz,2021-Q2,0,0,0
 Steffen Schmitz,2021-Q1,0,0,0
 Steffen Schmitz,2020-Q4,0,0,0
@@ -38559,8 +33739,6 @@ Steffen Schmitz,2018-Q4,0,0,0
 Steffen Schmitz,2018-Q3,0,0,0
 Steffen Schmitz,2018-Q2,0,0,0
 Steffen Schmitz,2018-Q1,0,0,0
-Gaojin CAO,2021-Q4,0,0,0
-Gaojin CAO,2021-Q3,0,0,0
 Gaojin CAO,2021-Q2,0,0,0
 Gaojin CAO,2021-Q1,0,0,0
 Gaojin CAO,2020-Q4,0,0,0
@@ -38575,8 +33753,6 @@ Gaojin CAO,2018-Q4,0,0,0
 Gaojin CAO,2018-Q3,0,0,0
 Gaojin CAO,2018-Q2,0,0,0
 Gaojin CAO,2018-Q1,0,0,0
-qiao hai-jun,2021-Q4,0,0,0
-qiao hai-jun,2021-Q3,0,0,0
 qiao hai-jun,2021-Q2,0,0,0
 qiao hai-jun,2021-Q1,0,0,0
 qiao hai-jun,2020-Q4,0,0,0
@@ -38591,8 +33767,6 @@ qiao hai-jun,2018-Q4,0,0,0
 qiao hai-jun,2018-Q3,0,0,0
 qiao hai-jun,2018-Q2,0,0,0
 qiao hai-jun,2018-Q1,0,0,0
-Dmitry Trifonov,2021-Q4,0,0,0
-Dmitry Trifonov,2021-Q3,0,0,0
 Dmitry Trifonov,2021-Q2,0,0,0
 Dmitry Trifonov,2021-Q1,0,0,0
 Dmitry Trifonov,2020-Q4,0,0,0
@@ -38607,8 +33781,6 @@ Dmitry Trifonov,2018-Q4,0,0,0
 Dmitry Trifonov,2018-Q3,0,0,0
 Dmitry Trifonov,2018-Q2,0,0,0
 Dmitry Trifonov,2018-Q1,0,0,0
-Vish (Ishaya) Abrams,2021-Q4,0,0,0
-Vish (Ishaya) Abrams,2021-Q3,0,0,0
 Vish (Ishaya) Abrams,2021-Q2,0,0,0
 Vish (Ishaya) Abrams,2021-Q1,0,0,0
 Vish (Ishaya) Abrams,2020-Q4,0,0,0
@@ -38623,8 +33795,6 @@ Vish (Ishaya) Abrams,2018-Q4,0,0,0
 Vish (Ishaya) Abrams,2018-Q3,0,0,0
 Vish (Ishaya) Abrams,2018-Q2,0,0,0
 Vish (Ishaya) Abrams,2018-Q1,0,0,0
-Vijay Pai,2021-Q4,0,0,0
-Vijay Pai,2021-Q3,0,0,0
 Vijay Pai,2021-Q2,0,0,0
 Vijay Pai,2021-Q1,0,0,0
 Vijay Pai,2020-Q4,0,0,0
@@ -38639,8 +33809,6 @@ Vijay Pai,2018-Q4,0,0,0
 Vijay Pai,2018-Q3,0,0,0
 Vijay Pai,2018-Q2,0,0,0
 Vijay Pai,2018-Q1,0,0,0
-Bo Wang,2021-Q4,0,0,0
-Bo Wang,2021-Q3,0,0,0
 Bo Wang,2021-Q2,0,0,0
 Bo Wang,2021-Q1,0,0,0
 Bo Wang,2020-Q4,0,0,0
@@ -38655,8 +33823,6 @@ Bo Wang,2018-Q4,0,0,0
 Bo Wang,2018-Q3,0,0,0
 Bo Wang,2018-Q2,0,0,0
 Bo Wang,2018-Q1,0,0,0
-Matthew Daley,2021-Q4,0,0,0
-Matthew Daley,2021-Q3,0,0,0
 Matthew Daley,2021-Q2,0,0,0
 Matthew Daley,2021-Q1,0,0,0
 Matthew Daley,2020-Q4,0,0,0
@@ -38671,8 +33837,6 @@ Matthew Daley,2018-Q4,0,0,0
 Matthew Daley,2018-Q3,0,0,0
 Matthew Daley,2018-Q2,0,0,0
 Matthew Daley,2018-Q1,0,0,0
-Jinze Bai,2021-Q4,0,0,0
-Jinze Bai,2021-Q3,0,0,0
 Jinze Bai,2021-Q2,0,0,0
 Jinze Bai,2021-Q1,0,0,0
 Jinze Bai,2020-Q4,0,0,0
@@ -38687,8 +33851,6 @@ Jinze Bai,2018-Q4,0,0,0
 Jinze Bai,2018-Q3,0,0,0
 Jinze Bai,2018-Q2,0,0,0
 Jinze Bai,2018-Q1,0,0,0
-SaintNazaire,2021-Q4,0,0,0
-SaintNazaire,2021-Q3,0,0,0
 SaintNazaire,2021-Q2,0,0,0
 SaintNazaire,2021-Q1,0,0,0
 SaintNazaire,2020-Q4,0,0,0
@@ -38703,8 +33865,6 @@ SaintNazaire,2018-Q4,0,0,0
 SaintNazaire,2018-Q3,0,0,0
 SaintNazaire,2018-Q2,0,0,0
 SaintNazaire,2018-Q1,0,0,0
-Artëm Sobolev,2021-Q4,0,0,0
-Artëm Sobolev,2021-Q3,0,0,0
 Artëm Sobolev,2021-Q2,0,0,0
 Artëm Sobolev,2021-Q1,0,0,0
 Artëm Sobolev,2020-Q4,0,0,0
@@ -38719,8 +33879,6 @@ Artëm Sobolev,2018-Q4,0,0,0
 Artëm Sobolev,2018-Q3,0,0,0
 Artëm Sobolev,2018-Q2,0,0,0
 Artëm Sobolev,2018-Q1,0,0,0
-Urs Köster,2021-Q4,0,0,0
-Urs Köster,2021-Q3,0,0,0
 Urs Köster,2021-Q2,0,0,0
 Urs Köster,2021-Q1,0,0,0
 Urs Köster,2020-Q4,0,0,0
@@ -38735,8 +33893,6 @@ Urs Köster,2018-Q4,0,0,0
 Urs Köster,2018-Q3,0,0,0
 Urs Köster,2018-Q2,0,0,0
 Urs Köster,2018-Q1,0,0,0
-nolan liu,2021-Q4,0,0,0
-nolan liu,2021-Q3,0,0,0
 nolan liu,2021-Q2,0,0,0
 nolan liu,2021-Q1,0,0,0
 nolan liu,2020-Q4,0,0,0
@@ -38751,8 +33907,6 @@ nolan liu,2018-Q4,0,0,0
 nolan liu,2018-Q3,0,0,0
 nolan liu,2018-Q2,0,0,0
 nolan liu,2018-Q1,0,0,0
-Dhananjay Nakrani,2021-Q4,0,0,0
-Dhananjay Nakrani,2021-Q3,0,0,0
 Dhananjay Nakrani,2021-Q2,0,0,0
 Dhananjay Nakrani,2021-Q1,0,0,0
 Dhananjay Nakrani,2020-Q4,0,0,0
@@ -38767,8 +33921,6 @@ Dhananjay Nakrani,2018-Q4,0,0,0
 Dhananjay Nakrani,2018-Q3,0,0,0
 Dhananjay Nakrani,2018-Q2,0,0,0
 Dhananjay Nakrani,2018-Q1,0,0,0
-cglewis,2021-Q4,0,0,0
-cglewis,2021-Q3,0,0,0
 cglewis,2021-Q2,0,0,0
 cglewis,2021-Q1,0,0,0
 cglewis,2020-Q4,0,0,0
@@ -38783,8 +33935,6 @@ cglewis,2018-Q4,0,0,0
 cglewis,2018-Q3,0,0,0
 cglewis,2018-Q2,0,0,0
 cglewis,2018-Q1,0,0,0
-LevineHuang,2021-Q4,0,0,0
-LevineHuang,2021-Q3,0,0,0
 LevineHuang,2021-Q2,0,0,0
 LevineHuang,2021-Q1,0,0,0
 LevineHuang,2020-Q4,0,0,0
@@ -38799,8 +33949,6 @@ LevineHuang,2018-Q4,0,0,0
 LevineHuang,2018-Q3,0,0,0
 LevineHuang,2018-Q2,0,0,0
 LevineHuang,2018-Q1,0,0,0
-Rohan Varma,2021-Q4,0,0,0
-Rohan Varma,2021-Q3,0,0,0
 Rohan Varma,2021-Q2,0,0,0
 Rohan Varma,2021-Q1,0,0,0
 Rohan Varma,2020-Q4,0,0,0
@@ -38815,8 +33963,6 @@ Rohan Varma,2018-Q4,0,0,0
 Rohan Varma,2018-Q3,0,0,0
 Rohan Varma,2018-Q2,0,0,0
 Rohan Varma,2018-Q1,0,0,0
-Jeremy Sharpe,2021-Q4,0,0,0
-Jeremy Sharpe,2021-Q3,0,0,0
 Jeremy Sharpe,2021-Q2,0,0,0
 Jeremy Sharpe,2021-Q1,0,0,0
 Jeremy Sharpe,2020-Q4,0,0,0
@@ -38831,8 +33977,6 @@ Jeremy Sharpe,2018-Q4,0,0,0
 Jeremy Sharpe,2018-Q3,0,0,0
 Jeremy Sharpe,2018-Q2,0,0,0
 Jeremy Sharpe,2018-Q1,0,0,0
-Sarah Maddox,2021-Q4,0,0,0
-Sarah Maddox,2021-Q3,0,0,0
 Sarah Maddox,2021-Q2,0,0,0
 Sarah Maddox,2021-Q1,0,0,0
 Sarah Maddox,2020-Q4,0,0,0
@@ -38847,8 +33991,6 @@ Sarah Maddox,2018-Q4,0,0,0
 Sarah Maddox,2018-Q3,0,0,0
 Sarah Maddox,2018-Q2,0,0,0
 Sarah Maddox,2018-Q1,0,0,0
-Tim Harley,2021-Q4,0,0,0
-Tim Harley,2021-Q3,0,0,0
 Tim Harley,2021-Q2,0,0,0
 Tim Harley,2021-Q1,0,0,0
 Tim Harley,2020-Q4,0,0,0
@@ -38863,8 +34005,6 @@ Tim Harley,2018-Q4,0,0,0
 Tim Harley,2018-Q3,0,0,0
 Tim Harley,2018-Q2,0,0,0
 Tim Harley,2018-Q1,0,0,0
-ashankar,2021-Q4,0,0,0
-ashankar,2021-Q3,0,0,0
 ashankar,2021-Q2,0,0,0
 ashankar,2021-Q1,0,0,0
 ashankar,2020-Q4,0,0,0
@@ -38879,8 +34019,6 @@ ashankar,2018-Q4,0,0,0
 ashankar,2018-Q3,0,0,0
 ashankar,2018-Q2,0,0,0
 ashankar,2018-Q1,0,0,0
-Mahdi Abavisani,2021-Q4,0,0,0
-Mahdi Abavisani,2021-Q3,0,0,0
 Mahdi Abavisani,2021-Q2,0,0,0
 Mahdi Abavisani,2021-Q1,0,0,0
 Mahdi Abavisani,2020-Q4,0,0,0
@@ -38895,8 +34033,6 @@ Mahdi Abavisani,2018-Q4,0,0,0
 Mahdi Abavisani,2018-Q3,0,0,0
 Mahdi Abavisani,2018-Q2,0,0,0
 Mahdi Abavisani,2018-Q1,0,0,0
-chi-hung,2021-Q4,0,0,0
-chi-hung,2021-Q3,0,0,0
 chi-hung,2021-Q2,0,0,0
 chi-hung,2021-Q1,0,0,0
 chi-hung,2020-Q4,0,0,0
@@ -38911,8 +34047,6 @@ chi-hung,2018-Q4,0,0,0
 chi-hung,2018-Q3,0,0,0
 chi-hung,2018-Q2,0,0,0
 chi-hung,2018-Q1,0,0,0
-Christian Grail,2021-Q4,0,0,0
-Christian Grail,2021-Q3,0,0,0
 Christian Grail,2021-Q2,0,0,0
 Christian Grail,2021-Q1,0,0,0
 Christian Grail,2020-Q4,0,0,0
@@ -38927,8 +34061,6 @@ Christian Grail,2018-Q4,0,0,0
 Christian Grail,2018-Q3,0,0,0
 Christian Grail,2018-Q2,0,0,0
 Christian Grail,2018-Q1,0,0,0
-michelleirvine,2021-Q4,0,0,0
-michelleirvine,2021-Q3,0,0,0
 michelleirvine,2021-Q2,0,0,0
 michelleirvine,2021-Q1,0,0,0
 michelleirvine,2020-Q4,0,0,0
@@ -38943,8 +34075,6 @@ michelleirvine,2018-Q4,0,0,0
 michelleirvine,2018-Q3,0,0,0
 michelleirvine,2018-Q2,0,0,0
 michelleirvine,2018-Q1,0,0,0
-Se-won Kim,2021-Q4,0,0,0
-Se-won Kim,2021-Q3,0,0,0
 Se-won Kim,2021-Q2,0,0,0
 Se-won Kim,2021-Q1,0,0,0
 Se-won Kim,2020-Q4,0,0,0
@@ -38959,8 +34089,6 @@ Se-won Kim,2018-Q4,0,0,0
 Se-won Kim,2018-Q3,0,0,0
 Se-won Kim,2018-Q2,0,0,0
 Se-won Kim,2018-Q1,0,0,0
-Bill Prin,2021-Q4,0,0,0
-Bill Prin,2021-Q3,0,0,0
 Bill Prin,2021-Q2,0,0,0
 Bill Prin,2021-Q1,0,0,0
 Bill Prin,2020-Q4,0,0,0
@@ -38975,8 +34103,6 @@ Bill Prin,2018-Q4,0,0,0
 Bill Prin,2018-Q3,0,0,0
 Bill Prin,2018-Q2,0,0,0
 Bill Prin,2018-Q1,0,0,0
-Simon Perkins,2021-Q4,0,0,0
-Simon Perkins,2021-Q3,0,0,0
 Simon Perkins,2021-Q2,0,0,0
 Simon Perkins,2021-Q1,0,0,0
 Simon Perkins,2020-Q4,0,0,0
@@ -38991,8 +34117,6 @@ Simon Perkins,2018-Q4,0,0,0
 Simon Perkins,2018-Q3,0,0,0
 Simon Perkins,2018-Q2,0,0,0
 Simon Perkins,2018-Q1,0,0,0
-Ali Yahya,2021-Q4,0,0,0
-Ali Yahya,2021-Q3,0,0,0
 Ali Yahya,2021-Q2,0,0,0
 Ali Yahya,2021-Q1,0,0,0
 Ali Yahya,2020-Q4,0,0,0
@@ -39007,8 +34131,6 @@ Ali Yahya,2018-Q4,0,0,0
 Ali Yahya,2018-Q3,0,0,0
 Ali Yahya,2018-Q2,0,0,0
 Ali Yahya,2018-Q1,0,0,0
-Ryohei Kuroki,2021-Q4,0,0,0
-Ryohei Kuroki,2021-Q3,0,0,0
 Ryohei Kuroki,2021-Q2,0,0,0
 Ryohei Kuroki,2021-Q1,0,0,0
 Ryohei Kuroki,2020-Q4,0,0,0
@@ -39023,8 +34145,6 @@ Ryohei Kuroki,2018-Q4,0,0,0
 Ryohei Kuroki,2018-Q3,0,0,0
 Ryohei Kuroki,2018-Q2,0,0,0
 Ryohei Kuroki,2018-Q1,0,0,0
-Atlas7,2021-Q4,0,0,0
-Atlas7,2021-Q3,0,0,0
 Atlas7,2021-Q2,0,0,0
 Atlas7,2021-Q1,0,0,0
 Atlas7,2020-Q4,0,0,0
@@ -39039,8 +34159,6 @@ Atlas7,2018-Q4,0,0,0
 Atlas7,2018-Q3,0,0,0
 Atlas7,2018-Q2,0,0,0
 Atlas7,2018-Q1,0,0,0
-Sylvus,2021-Q4,0,0,0
-Sylvus,2021-Q3,0,0,0
 Sylvus,2021-Q2,0,0,0
 Sylvus,2021-Q1,0,0,0
 Sylvus,2020-Q4,0,0,0
@@ -39055,8 +34173,6 @@ Sylvus,2018-Q4,0,0,0
 Sylvus,2018-Q3,0,0,0
 Sylvus,2018-Q2,0,0,0
 Sylvus,2018-Q1,0,0,0
-Scott Mudge,2021-Q4,0,0,0
-Scott Mudge,2021-Q3,0,0,0
 Scott Mudge,2021-Q2,0,0,0
 Scott Mudge,2021-Q1,0,0,0
 Scott Mudge,2020-Q4,0,0,0
@@ -39071,8 +34187,6 @@ Scott Mudge,2018-Q4,0,0,0
 Scott Mudge,2018-Q3,0,0,0
 Scott Mudge,2018-Q2,0,0,0
 Scott Mudge,2018-Q1,0,0,0
-Armen Donigian,2021-Q4,0,0,0
-Armen Donigian,2021-Q3,0,0,0
 Armen Donigian,2021-Q2,0,0,0
 Armen Donigian,2021-Q1,0,0,0
 Armen Donigian,2020-Q4,0,0,0
@@ -39087,8 +34201,6 @@ Armen Donigian,2018-Q4,0,0,0
 Armen Donigian,2018-Q3,0,0,0
 Armen Donigian,2018-Q2,0,0,0
 Armen Donigian,2018-Q1,0,0,0
-Hanmin Qin,2021-Q4,0,0,0
-Hanmin Qin,2021-Q3,0,0,0
 Hanmin Qin,2021-Q2,0,0,0
 Hanmin Qin,2021-Q1,0,0,0
 Hanmin Qin,2020-Q4,0,0,0
@@ -39103,8 +34215,6 @@ Hanmin Qin,2018-Q4,0,0,0
 Hanmin Qin,2018-Q3,0,0,0
 Hanmin Qin,2018-Q2,0,0,0
 Hanmin Qin,2018-Q1,0,0,0
-melvyniandrag,2021-Q4,0,0,0
-melvyniandrag,2021-Q3,0,0,0
 melvyniandrag,2021-Q2,0,0,0
 melvyniandrag,2021-Q1,0,0,0
 melvyniandrag,2020-Q4,0,0,0
@@ -39119,8 +34229,6 @@ melvyniandrag,2018-Q4,0,0,0
 melvyniandrag,2018-Q3,0,0,0
 melvyniandrag,2018-Q2,0,0,0
 melvyniandrag,2018-Q1,0,0,0
-ZxYuan,2021-Q4,0,0,0
-ZxYuan,2021-Q3,0,0,0
 ZxYuan,2021-Q2,0,0,0
 ZxYuan,2021-Q1,0,0,0
 ZxYuan,2020-Q4,0,0,0
@@ -39135,8 +34243,6 @@ ZxYuan,2018-Q4,0,0,0
 ZxYuan,2018-Q3,0,0,0
 ZxYuan,2018-Q2,0,0,0
 ZxYuan,2018-Q1,0,0,0
-Jeff Carpenter,2021-Q4,0,0,0
-Jeff Carpenter,2021-Q3,0,0,0
 Jeff Carpenter,2021-Q2,0,0,0
 Jeff Carpenter,2021-Q1,0,0,0
 Jeff Carpenter,2020-Q4,0,0,0
@@ -39151,8 +34257,6 @@ Jeff Carpenter,2018-Q4,0,0,0
 Jeff Carpenter,2018-Q3,0,0,0
 Jeff Carpenter,2018-Q2,0,0,0
 Jeff Carpenter,2018-Q1,0,0,0
-Mike Case,2021-Q4,0,0,0
-Mike Case,2021-Q3,0,0,0
 Mike Case,2021-Q2,0,0,0
 Mike Case,2021-Q1,0,0,0
 Mike Case,2020-Q4,0,0,0
@@ -39167,8 +34271,6 @@ Mike Case,2018-Q4,0,0,0
 Mike Case,2018-Q3,0,0,0
 Mike Case,2018-Q2,0,0,0
 Mike Case,2018-Q1,0,0,0
-Scott Kirkland,2021-Q4,0,0,0
-Scott Kirkland,2021-Q3,0,0,0
 Scott Kirkland,2021-Q2,0,0,0
 Scott Kirkland,2021-Q1,0,0,0
 Scott Kirkland,2020-Q4,0,0,0
@@ -39183,8 +34285,6 @@ Scott Kirkland,2018-Q4,0,0,0
 Scott Kirkland,2018-Q3,0,0,0
 Scott Kirkland,2018-Q2,0,0,0
 Scott Kirkland,2018-Q1,0,0,0
-Fan Xia,2021-Q4,0,0,0
-Fan Xia,2021-Q3,0,0,0
 Fan Xia,2021-Q2,0,0,0
 Fan Xia,2021-Q1,0,0,0
 Fan Xia,2020-Q4,0,0,0
@@ -39199,8 +34299,6 @@ Fan Xia,2018-Q4,0,0,0
 Fan Xia,2018-Q3,0,0,0
 Fan Xia,2018-Q2,0,0,0
 Fan Xia,2018-Q1,0,0,0
-horance,2021-Q4,0,0,0
-horance,2021-Q3,0,0,0
 horance,2021-Q2,0,0,0
 horance,2021-Q1,0,0,0
 horance,2020-Q4,0,0,0
@@ -39215,8 +34313,6 @@ horance,2018-Q4,0,0,0
 horance,2018-Q3,0,0,0
 horance,2018-Q2,0,0,0
 horance,2018-Q1,0,0,0
-Andrew Myers,2021-Q4,0,0,0
-Andrew Myers,2021-Q3,0,0,0
 Andrew Myers,2021-Q2,0,0,0
 Andrew Myers,2021-Q1,0,0,0
 Andrew Myers,2020-Q4,0,0,0
@@ -39231,8 +34327,6 @@ Andrew Myers,2018-Q4,0,0,0
 Andrew Myers,2018-Q3,0,0,0
 Andrew Myers,2018-Q2,0,0,0
 Andrew Myers,2018-Q1,0,0,0
-Sean Vig,2021-Q4,0,0,0
-Sean Vig,2021-Q3,0,0,0
 Sean Vig,2021-Q2,0,0,0
 Sean Vig,2021-Q1,0,0,0
 Sean Vig,2020-Q4,0,0,0
@@ -39247,8 +34341,6 @@ Sean Vig,2018-Q4,0,0,0
 Sean Vig,2018-Q3,0,0,0
 Sean Vig,2018-Q2,0,0,0
 Sean Vig,2018-Q1,0,0,0
-Pavel Christof,2021-Q4,0,0,0
-Pavel Christof,2021-Q3,0,0,0
 Pavel Christof,2021-Q2,0,0,0
 Pavel Christof,2021-Q1,0,0,0
 Pavel Christof,2020-Q4,0,0,0
@@ -39263,8 +34355,6 @@ Pavel Christof,2018-Q4,0,0,0
 Pavel Christof,2018-Q3,0,0,0
 Pavel Christof,2018-Q2,0,0,0
 Pavel Christof,2018-Q1,0,0,0
-John Impallomeni,2021-Q4,0,0,0
-John Impallomeni,2021-Q3,0,0,0
 John Impallomeni,2021-Q2,0,0,0
 John Impallomeni,2021-Q1,0,0,0
 John Impallomeni,2020-Q4,0,0,0
@@ -39279,8 +34369,6 @@ John Impallomeni,2018-Q4,0,0,0
 John Impallomeni,2018-Q3,0,0,0
 John Impallomeni,2018-Q2,0,0,0
 John Impallomeni,2018-Q1,0,0,0
-m-smith,2021-Q4,0,0,0
-m-smith,2021-Q3,0,0,0
 m-smith,2021-Q2,0,0,0
 m-smith,2021-Q1,0,0,0
 m-smith,2020-Q4,0,0,0
@@ -39295,8 +34383,6 @@ m-smith,2018-Q4,0,0,0
 m-smith,2018-Q3,0,0,0
 m-smith,2018-Q2,0,0,0
 m-smith,2018-Q1,0,0,0
-Anastasios Doumoulakis,2021-Q4,0,0,0
-Anastasios Doumoulakis,2021-Q3,0,0,0
 Anastasios Doumoulakis,2021-Q2,0,0,0
 Anastasios Doumoulakis,2021-Q1,0,0,0
 Anastasios Doumoulakis,2020-Q4,0,0,0
@@ -39311,8 +34397,6 @@ Anastasios Doumoulakis,2018-Q4,0,0,0
 Anastasios Doumoulakis,2018-Q3,0,0,0
 Anastasios Doumoulakis,2018-Q2,0,0,0
 Anastasios Doumoulakis,2018-Q1,0,0,0
-lhlmgr,2021-Q4,0,0,0
-lhlmgr,2021-Q3,0,0,0
 lhlmgr,2021-Q2,0,0,0
 lhlmgr,2021-Q1,0,0,0
 lhlmgr,2020-Q4,0,0,0
@@ -39327,8 +34411,6 @@ lhlmgr,2018-Q4,0,0,0
 lhlmgr,2018-Q3,0,0,0
 lhlmgr,2018-Q2,0,0,0
 lhlmgr,2018-Q1,0,0,0
-Matt Smith,2021-Q4,0,0,0
-Matt Smith,2021-Q3,0,0,0
 Matt Smith,2021-Q2,0,0,0
 Matt Smith,2021-Q1,0,0,0
 Matt Smith,2020-Q4,0,0,0
@@ -39343,8 +34425,6 @@ Matt Smith,2018-Q4,0,0,0
 Matt Smith,2018-Q3,0,0,0
 Matt Smith,2018-Q2,0,0,0
 Matt Smith,2018-Q1,0,0,0
-Dorokhov,2021-Q4,0,0,0
-Dorokhov,2021-Q3,0,0,0
 Dorokhov,2021-Q2,0,0,0
 Dorokhov,2021-Q1,0,0,0
 Dorokhov,2020-Q4,0,0,0
@@ -39359,8 +34439,6 @@ Dorokhov,2018-Q4,0,0,0
 Dorokhov,2018-Q3,0,0,0
 Dorokhov,2018-Q2,0,0,0
 Dorokhov,2018-Q1,0,0,0
-Ash Hall,2021-Q4,0,0,0
-Ash Hall,2021-Q3,0,0,0
 Ash Hall,2021-Q2,0,0,0
 Ash Hall,2021-Q1,0,0,0
 Ash Hall,2020-Q4,0,0,0
@@ -39375,8 +34453,6 @@ Ash Hall,2018-Q4,0,0,0
 Ash Hall,2018-Q3,0,0,0
 Ash Hall,2018-Q2,0,0,0
 Ash Hall,2018-Q1,0,0,0
-Jett Jones,2021-Q4,0,0,0
-Jett Jones,2021-Q3,0,0,0
 Jett Jones,2021-Q2,0,0,0
 Jett Jones,2021-Q1,0,0,0
 Jett Jones,2020-Q4,0,0,0
@@ -39391,8 +34467,6 @@ Jett Jones,2018-Q4,0,0,0
 Jett Jones,2018-Q3,0,0,0
 Jett Jones,2018-Q2,0,0,0
 Jett Jones,2018-Q1,0,0,0
-EMCP,2021-Q4,0,0,0
-EMCP,2021-Q3,0,0,0
 EMCP,2021-Q2,0,0,0
 EMCP,2021-Q1,0,0,0
 EMCP,2020-Q4,0,0,0
@@ -39407,8 +34481,6 @@ EMCP,2018-Q4,0,0,0
 EMCP,2018-Q3,0,0,0
 EMCP,2018-Q2,0,0,0
 EMCP,2018-Q1,0,0,0
-Codrut,2021-Q4,0,0,0
-Codrut,2021-Q3,0,0,0
 Codrut,2021-Q2,0,0,0
 Codrut,2021-Q1,0,0,0
 Codrut,2020-Q4,0,0,0
@@ -39423,8 +34495,6 @@ Codrut,2018-Q4,0,0,0
 Codrut,2018-Q3,0,0,0
 Codrut,2018-Q2,0,0,0
 Codrut,2018-Q1,0,0,0
-Jean Wanka,2021-Q4,0,0,0
-Jean Wanka,2021-Q3,0,0,0
 Jean Wanka,2021-Q2,0,0,0
 Jean Wanka,2021-Q1,0,0,0
 Jean Wanka,2020-Q4,0,0,0
@@ -39439,8 +34509,6 @@ Jean Wanka,2018-Q4,0,0,0
 Jean Wanka,2018-Q3,0,0,0
 Jean Wanka,2018-Q2,0,0,0
 Jean Wanka,2018-Q1,0,0,0
-John B Nelson,2021-Q4,0,0,0
-John B Nelson,2021-Q3,0,0,0
 John B Nelson,2021-Q2,0,0,0
 John B Nelson,2021-Q1,0,0,0
 John B Nelson,2020-Q4,0,0,0
@@ -39455,8 +34523,6 @@ John B Nelson,2018-Q4,0,0,0
 John B Nelson,2018-Q3,0,0,0
 John B Nelson,2018-Q2,0,0,0
 John B Nelson,2018-Q1,0,0,0
-JKurland,2021-Q4,0,0,0
-JKurland,2021-Q3,0,0,0
 JKurland,2021-Q2,0,0,0
 JKurland,2021-Q1,0,0,0
 JKurland,2020-Q4,0,0,0
@@ -39471,8 +34537,6 @@ JKurland,2018-Q4,0,0,0
 JKurland,2018-Q3,0,0,0
 JKurland,2018-Q2,0,0,0
 JKurland,2018-Q1,0,0,0
-Michele Colombo,2021-Q4,0,0,0
-Michele Colombo,2021-Q3,0,0,0
 Michele Colombo,2021-Q2,0,0,0
 Michele Colombo,2021-Q1,0,0,0
 Michele Colombo,2020-Q4,0,0,0
@@ -39487,8 +34551,6 @@ Michele Colombo,2018-Q4,0,0,0
 Michele Colombo,2018-Q3,0,0,0
 Michele Colombo,2018-Q2,0,0,0
 Michele Colombo,2018-Q1,0,0,0
-Sven Mayer,2021-Q4,0,0,0
-Sven Mayer,2021-Q3,0,0,0
 Sven Mayer,2021-Q2,0,0,0
 Sven Mayer,2021-Q1,0,0,0
 Sven Mayer,2020-Q4,0,0,0
@@ -39503,8 +34565,6 @@ Sven Mayer,2018-Q4,0,0,0
 Sven Mayer,2018-Q3,0,0,0
 Sven Mayer,2018-Q2,0,0,0
 Sven Mayer,2018-Q1,0,0,0
-tetris,2021-Q4,0,0,0
-tetris,2021-Q3,0,0,0
 tetris,2021-Q2,0,0,0
 tetris,2021-Q1,0,0,0
 tetris,2020-Q4,0,0,0
@@ -39519,8 +34579,6 @@ tetris,2018-Q4,0,0,0
 tetris,2018-Q3,0,0,0
 tetris,2018-Q2,0,0,0
 tetris,2018-Q1,0,0,0
-Kai Sasaki,2021-Q4,0,0,0
-Kai Sasaki,2021-Q3,0,0,0
 Kai Sasaki,2021-Q2,0,0,0
 Kai Sasaki,2021-Q1,0,0,0
 Kai Sasaki,2020-Q4,0,0,0
@@ -39535,8 +34593,6 @@ Kai Sasaki,2018-Q4,0,0,0
 Kai Sasaki,2018-Q3,0,0,0
 Kai Sasaki,2018-Q2,0,0,0
 Kai Sasaki,2018-Q1,0,0,0
-Duncan Mac-Vicar P,2021-Q4,0,0,0
-Duncan Mac-Vicar P,2021-Q3,0,0,0
 Duncan Mac-Vicar P,2021-Q2,0,0,0
 Duncan Mac-Vicar P,2021-Q1,0,0,0
 Duncan Mac-Vicar P,2020-Q4,0,0,0
@@ -39551,8 +34607,6 @@ Duncan Mac-Vicar P,2018-Q4,0,0,0
 Duncan Mac-Vicar P,2018-Q3,0,0,0
 Duncan Mac-Vicar P,2018-Q2,0,0,0
 Duncan Mac-Vicar P,2018-Q1,0,0,0
-Aseem Raj Baranwal,2021-Q4,0,0,0
-Aseem Raj Baranwal,2021-Q3,0,0,0
 Aseem Raj Baranwal,2021-Q2,0,0,0
 Aseem Raj Baranwal,2021-Q1,0,0,0
 Aseem Raj Baranwal,2020-Q4,0,0,0
@@ -39567,8 +34621,6 @@ Aseem Raj Baranwal,2018-Q4,0,0,0
 Aseem Raj Baranwal,2018-Q3,0,0,0
 Aseem Raj Baranwal,2018-Q2,0,0,0
 Aseem Raj Baranwal,2018-Q1,0,0,0
-Patrik Erdes,2021-Q4,0,0,0
-Patrik Erdes,2021-Q3,0,0,0
 Patrik Erdes,2021-Q2,0,0,0
 Patrik Erdes,2021-Q1,0,0,0
 Patrik Erdes,2020-Q4,0,0,0
@@ -39583,8 +34635,6 @@ Patrik Erdes,2018-Q4,0,0,0
 Patrik Erdes,2018-Q3,0,0,0
 Patrik Erdes,2018-Q2,0,0,0
 Patrik Erdes,2018-Q1,0,0,0
-jinze1994,2021-Q4,0,0,0
-jinze1994,2021-Q3,0,0,0
 jinze1994,2021-Q2,0,0,0
 jinze1994,2021-Q1,0,0,0
 jinze1994,2020-Q4,0,0,0
@@ -39599,8 +34649,6 @@ jinze1994,2018-Q4,0,0,0
 jinze1994,2018-Q3,0,0,0
 jinze1994,2018-Q2,0,0,0
 jinze1994,2018-Q1,0,0,0
-Chris Oelmueller,2021-Q4,0,0,0
-Chris Oelmueller,2021-Q3,0,0,0
 Chris Oelmueller,2021-Q2,0,0,0
 Chris Oelmueller,2021-Q1,0,0,0
 Chris Oelmueller,2020-Q4,0,0,0
@@ -39615,8 +34663,6 @@ Chris Oelmueller,2018-Q4,0,0,0
 Chris Oelmueller,2018-Q3,0,0,0
 Chris Oelmueller,2018-Q2,0,0,0
 Chris Oelmueller,2018-Q1,0,0,0
-Vincent Vanhoucke,2021-Q4,0,0,0
-Vincent Vanhoucke,2021-Q3,0,0,0
 Vincent Vanhoucke,2021-Q2,0,0,0
 Vincent Vanhoucke,2021-Q1,0,0,0
 Vincent Vanhoucke,2020-Q4,0,0,0
@@ -39631,8 +34677,6 @@ Vincent Vanhoucke,2018-Q4,0,0,0
 Vincent Vanhoucke,2018-Q3,0,0,0
 Vincent Vanhoucke,2018-Q2,0,0,0
 Vincent Vanhoucke,2018-Q1,0,0,0
-Mark Aaron Shirley,2021-Q4,0,0,0
-Mark Aaron Shirley,2021-Q3,0,0,0
 Mark Aaron Shirley,2021-Q2,0,0,0
 Mark Aaron Shirley,2021-Q1,0,0,0
 Mark Aaron Shirley,2020-Q4,0,0,0
@@ -39647,8 +34691,6 @@ Mark Aaron Shirley,2018-Q4,0,0,0
 Mark Aaron Shirley,2018-Q3,0,0,0
 Mark Aaron Shirley,2018-Q2,0,0,0
 Mark Aaron Shirley,2018-Q1,0,0,0
-Stuart Berg,2021-Q4,0,0,0
-Stuart Berg,2021-Q3,0,0,0
 Stuart Berg,2021-Q2,0,0,0
 Stuart Berg,2021-Q1,0,0,0
 Stuart Berg,2020-Q4,0,0,0
@@ -39663,8 +34705,6 @@ Stuart Berg,2018-Q4,0,0,0
 Stuart Berg,2018-Q3,0,0,0
 Stuart Berg,2018-Q2,0,0,0
 Stuart Berg,2018-Q1,0,0,0
-Kevin Slagle,2021-Q4,0,0,0
-Kevin Slagle,2021-Q3,0,0,0
 Kevin Slagle,2021-Q2,0,0,0
 Kevin Slagle,2021-Q1,0,0,0
 Kevin Slagle,2020-Q4,0,0,0
@@ -39679,8 +34719,6 @@ Kevin Slagle,2018-Q4,0,0,0
 Kevin Slagle,2018-Q3,0,0,0
 Kevin Slagle,2018-Q2,0,0,0
 Kevin Slagle,2018-Q1,0,0,0
-Lyndon White,2021-Q4,0,0,0
-Lyndon White,2021-Q3,0,0,0
 Lyndon White,2021-Q2,0,0,0
 Lyndon White,2021-Q1,0,0,0
 Lyndon White,2020-Q4,0,0,0
@@ -39695,8 +34733,6 @@ Lyndon White,2018-Q4,0,0,0
 Lyndon White,2018-Q3,0,0,0
 Lyndon White,2018-Q2,0,0,0
 Lyndon White,2018-Q1,0,0,0
-postBG,2021-Q4,0,0,0
-postBG,2021-Q3,0,0,0
 postBG,2021-Q2,0,0,0
 postBG,2021-Q1,0,0,0
 postBG,2020-Q4,0,0,0
@@ -39711,8 +34747,6 @@ postBG,2018-Q4,0,0,0
 postBG,2018-Q3,0,0,0
 postBG,2018-Q2,0,0,0
 postBG,2018-Q1,0,0,0
-joshkyh,2021-Q4,0,0,0
-joshkyh,2021-Q3,0,0,0
 joshkyh,2021-Q2,0,0,0
 joshkyh,2021-Q1,0,0,0
 joshkyh,2020-Q4,0,0,0
@@ -39727,8 +34761,6 @@ joshkyh,2018-Q4,0,0,0
 joshkyh,2018-Q3,0,0,0
 joshkyh,2018-Q2,0,0,0
 joshkyh,2018-Q1,0,0,0
-Jonas,2021-Q4,0,0,0
-Jonas,2021-Q3,0,0,0
 Jonas,2021-Q2,0,0,0
 Jonas,2021-Q1,0,0,0
 Jonas,2020-Q4,0,0,0
@@ -39743,8 +34775,6 @@ Jonas,2018-Q4,0,0,0
 Jonas,2018-Q3,0,0,0
 Jonas,2018-Q2,0,0,0
 Jonas,2018-Q1,0,0,0
-Daniel Grazian,2021-Q4,0,0,0
-Daniel Grazian,2021-Q3,0,0,0
 Daniel Grazian,2021-Q2,0,0,0
 Daniel Grazian,2021-Q1,0,0,0
 Daniel Grazian,2020-Q4,0,0,0
@@ -39759,8 +34789,6 @@ Daniel Grazian,2018-Q4,0,0,0
 Daniel Grazian,2018-Q3,0,0,0
 Daniel Grazian,2018-Q2,0,0,0
 Daniel Grazian,2018-Q1,0,0,0
-Andrew Erlichson,2021-Q4,0,0,0
-Andrew Erlichson,2021-Q3,0,0,0
 Andrew Erlichson,2021-Q2,0,0,0
 Andrew Erlichson,2021-Q1,0,0,0
 Andrew Erlichson,2020-Q4,0,0,0
@@ -39775,8 +34803,6 @@ Andrew Erlichson,2018-Q4,0,0,0
 Andrew Erlichson,2018-Q3,0,0,0
 Andrew Erlichson,2018-Q2,0,0,0
 Andrew Erlichson,2018-Q1,0,0,0
-Rasmi,2021-Q4,0,0,0
-Rasmi,2021-Q3,0,0,0
 Rasmi,2021-Q2,0,0,0
 Rasmi,2021-Q1,0,0,0
 Rasmi,2020-Q4,0,0,0
@@ -39791,8 +34817,6 @@ Rasmi,2018-Q4,0,0,0
 Rasmi,2018-Q3,0,0,0
 Rasmi,2018-Q2,0,0,0
 Rasmi,2018-Q1,0,0,0
-David Röthlisberger,2021-Q4,0,0,0
-David Röthlisberger,2021-Q3,0,0,0
 David Röthlisberger,2021-Q2,0,0,0
 David Röthlisberger,2021-Q1,0,0,0
 David Röthlisberger,2020-Q4,0,0,0
@@ -39807,8 +34831,6 @@ David Röthlisberger,2018-Q4,0,0,0
 David Röthlisberger,2018-Q3,0,0,0
 David Röthlisberger,2018-Q2,0,0,0
 David Röthlisberger,2018-Q1,0,0,0
-Sebastian Weiss,2021-Q4,0,0,0
-Sebastian Weiss,2021-Q3,0,0,0
 Sebastian Weiss,2021-Q2,0,0,0
 Sebastian Weiss,2021-Q1,0,0,0
 Sebastian Weiss,2020-Q4,0,0,0
@@ -39823,8 +34845,6 @@ Sebastian Weiss,2018-Q4,0,0,0
 Sebastian Weiss,2018-Q3,0,0,0
 Sebastian Weiss,2018-Q2,0,0,0
 Sebastian Weiss,2018-Q1,0,0,0
-Artsiom Chapialiou,2021-Q4,0,0,0
-Artsiom Chapialiou,2021-Q3,0,0,0
 Artsiom Chapialiou,2021-Q2,0,0,0
 Artsiom Chapialiou,2021-Q1,0,0,0
 Artsiom Chapialiou,2020-Q4,0,0,0
@@ -39839,8 +34859,6 @@ Artsiom Chapialiou,2018-Q4,0,0,0
 Artsiom Chapialiou,2018-Q3,0,0,0
 Artsiom Chapialiou,2018-Q2,0,0,0
 Artsiom Chapialiou,2018-Q1,0,0,0
-jinghua2,2021-Q4,0,0,0
-jinghua2,2021-Q3,0,0,0
 jinghua2,2021-Q2,0,0,0
 jinghua2,2021-Q1,0,0,0
 jinghua2,2020-Q4,0,0,0
@@ -39855,8 +34873,6 @@ jinghua2,2018-Q4,0,0,0
 jinghua2,2018-Q3,0,0,0
 jinghua2,2018-Q2,0,0,0
 jinghua2,2018-Q1,0,0,0
-EdwardDixon,2021-Q4,0,0,0
-EdwardDixon,2021-Q3,0,0,0
 EdwardDixon,2021-Q2,0,0,0
 EdwardDixon,2021-Q1,0,0,0
 EdwardDixon,2020-Q4,0,0,0
@@ -39871,8 +34887,6 @@ EdwardDixon,2018-Q4,0,0,0
 EdwardDixon,2018-Q3,0,0,0
 EdwardDixon,2018-Q2,0,0,0
 EdwardDixon,2018-Q1,0,0,0
-Marcel Puyat,2021-Q4,0,0,0
-Marcel Puyat,2021-Q3,0,0,0
 Marcel Puyat,2021-Q2,0,0,0
 Marcel Puyat,2021-Q1,0,0,0
 Marcel Puyat,2020-Q4,0,0,0
@@ -39887,8 +34901,6 @@ Marcel Puyat,2018-Q4,0,0,0
 Marcel Puyat,2018-Q3,0,0,0
 Marcel Puyat,2018-Q2,0,0,0
 Marcel Puyat,2018-Q1,0,0,0
-Amit Kushwaha,2021-Q4,0,0,0
-Amit Kushwaha,2021-Q3,0,0,0
 Amit Kushwaha,2021-Q2,0,0,0
 Amit Kushwaha,2021-Q1,0,0,0
 Amit Kushwaha,2020-Q4,0,0,0
@@ -39903,8 +34915,6 @@ Amit Kushwaha,2018-Q4,0,0,0
 Amit Kushwaha,2018-Q3,0,0,0
 Amit Kushwaha,2018-Q2,0,0,0
 Amit Kushwaha,2018-Q1,0,0,0
-Kenichi Ueno,2021-Q4,0,0,0
-Kenichi Ueno,2021-Q3,0,0,0
 Kenichi Ueno,2021-Q2,0,0,0
 Kenichi Ueno,2021-Q1,0,0,0
 Kenichi Ueno,2020-Q4,0,0,0
@@ -39919,8 +34929,6 @@ Kenichi Ueno,2018-Q4,0,0,0
 Kenichi Ueno,2018-Q3,0,0,0
 Kenichi Ueno,2018-Q2,0,0,0
 Kenichi Ueno,2018-Q1,0,0,0
-Lin Min,2021-Q4,0,0,0
-Lin Min,2021-Q3,0,0,0
 Lin Min,2021-Q2,0,0,0
 Lin Min,2021-Q1,0,0,0
 Lin Min,2020-Q4,0,0,0
@@ -39935,8 +34943,6 @@ Lin Min,2018-Q4,0,0,0
 Lin Min,2018-Q3,0,0,0
 Lin Min,2018-Q2,0,0,0
 Lin Min,2018-Q1,0,0,0
-liu.guangcong,2021-Q4,0,0,0
-liu.guangcong,2021-Q3,0,0,0
 liu.guangcong,2021-Q2,0,0,0
 liu.guangcong,2021-Q1,0,0,0
 liu.guangcong,2020-Q4,0,0,0
@@ -39951,8 +34957,6 @@ liu.guangcong,2018-Q4,0,0,0
 liu.guangcong,2018-Q3,0,0,0
 liu.guangcong,2018-Q2,0,0,0
 liu.guangcong,2018-Q1,0,0,0
-niranjan.hasabnis,2021-Q4,0,0,0
-niranjan.hasabnis,2021-Q3,0,0,0
 niranjan.hasabnis,2021-Q2,0,0,0
 niranjan.hasabnis,2021-Q1,0,0,0
 niranjan.hasabnis,2020-Q4,0,0,0
@@ -39967,8 +34971,6 @@ niranjan.hasabnis,2018-Q4,0,0,0
 niranjan.hasabnis,2018-Q3,0,0,0
 niranjan.hasabnis,2018-Q2,0,0,0
 niranjan.hasabnis,2018-Q1,0,0,0
-ben,2021-Q4,0,0,0
-ben,2021-Q3,0,0,0
 ben,2021-Q2,0,0,0
 ben,2021-Q1,0,0,0
 ben,2020-Q4,0,0,0
@@ -39983,8 +34985,6 @@ ben,2018-Q4,0,0,0
 ben,2018-Q3,0,0,0
 ben,2018-Q2,0,0,0
 ben,2018-Q1,0,0,0
-Alexey Petrenko,2021-Q4,0,0,0
-Alexey Petrenko,2021-Q3,0,0,0
 Alexey Petrenko,2021-Q2,0,0,0
 Alexey Petrenko,2021-Q1,0,0,0
 Alexey Petrenko,2020-Q4,0,0,0
@@ -39999,8 +34999,6 @@ Alexey Petrenko,2018-Q4,0,0,0
 Alexey Petrenko,2018-Q3,0,0,0
 Alexey Petrenko,2018-Q2,0,0,0
 Alexey Petrenko,2018-Q1,0,0,0
-yanivbl6,2021-Q4,0,0,0
-yanivbl6,2021-Q3,0,0,0
 yanivbl6,2021-Q2,0,0,0
 yanivbl6,2021-Q1,0,0,0
 yanivbl6,2020-Q4,0,0,0
@@ -40015,8 +35013,6 @@ yanivbl6,2018-Q4,0,0,0
 yanivbl6,2018-Q3,0,0,0
 yanivbl6,2018-Q2,0,0,0
 yanivbl6,2018-Q1,0,0,0
-Anton Daitche,2021-Q4,0,0,0
-Anton Daitche,2021-Q3,0,0,0
 Anton Daitche,2021-Q2,0,0,0
 Anton Daitche,2021-Q1,0,0,0
 Anton Daitche,2020-Q4,0,0,0
@@ -40031,8 +35027,6 @@ Anton Daitche,2018-Q4,0,0,0
 Anton Daitche,2018-Q3,0,0,0
 Anton Daitche,2018-Q2,0,0,0
 Anton Daitche,2018-Q1,0,0,0
-MtDersvan,2021-Q4,0,0,0
-MtDersvan,2021-Q3,0,0,0
 MtDersvan,2021-Q2,0,0,0
 MtDersvan,2021-Q1,0,0,0
 MtDersvan,2020-Q4,0,0,0
@@ -40047,8 +35041,6 @@ MtDersvan,2018-Q4,0,0,0
 MtDersvan,2018-Q3,0,0,0
 MtDersvan,2018-Q2,0,0,0
 MtDersvan,2018-Q1,0,0,0
-Louie Helm,2021-Q4,0,0,0
-Louie Helm,2021-Q3,0,0,0
 Louie Helm,2021-Q2,0,0,0
 Louie Helm,2021-Q1,0,0,0
 Louie Helm,2020-Q4,0,0,0
@@ -40063,8 +35055,6 @@ Louie Helm,2018-Q4,0,0,0
 Louie Helm,2018-Q3,0,0,0
 Louie Helm,2018-Q2,0,0,0
 Louie Helm,2018-Q1,0,0,0
-Fritz Obermeyer,2021-Q4,0,0,0
-Fritz Obermeyer,2021-Q3,0,0,0
 Fritz Obermeyer,2021-Q2,0,0,0
 Fritz Obermeyer,2021-Q1,0,0,0
 Fritz Obermeyer,2020-Q4,0,0,0
@@ -40079,8 +35069,6 @@ Fritz Obermeyer,2018-Q4,0,0,0
 Fritz Obermeyer,2018-Q3,0,0,0
 Fritz Obermeyer,2018-Q2,0,0,0
 Fritz Obermeyer,2018-Q1,0,0,0
-Shivam Kotwalia,2021-Q4,0,0,0
-Shivam Kotwalia,2021-Q3,0,0,0
 Shivam Kotwalia,2021-Q2,0,0,0
 Shivam Kotwalia,2021-Q1,0,0,0
 Shivam Kotwalia,2020-Q4,0,0,0
@@ -40095,8 +35083,6 @@ Shivam Kotwalia,2018-Q4,0,0,0
 Shivam Kotwalia,2018-Q3,0,0,0
 Shivam Kotwalia,2018-Q2,0,0,0
 Shivam Kotwalia,2018-Q1,0,0,0
-Tiago Freitas Pereira,2021-Q4,0,0,0
-Tiago Freitas Pereira,2021-Q3,0,0,0
 Tiago Freitas Pereira,2021-Q2,0,0,0
 Tiago Freitas Pereira,2021-Q1,0,0,0
 Tiago Freitas Pereira,2020-Q4,0,0,0
@@ -40111,8 +35097,6 @@ Tiago Freitas Pereira,2018-Q4,0,0,0
 Tiago Freitas Pereira,2018-Q3,0,0,0
 Tiago Freitas Pereira,2018-Q2,0,0,0
 Tiago Freitas Pereira,2018-Q1,0,0,0
-Bill Piel,2021-Q4,0,0,0
-Bill Piel,2021-Q3,0,0,0
 Bill Piel,2021-Q2,0,0,0
 Bill Piel,2021-Q1,0,0,0
 Bill Piel,2020-Q4,0,0,0
@@ -40127,8 +35111,6 @@ Bill Piel,2018-Q4,0,0,0
 Bill Piel,2018-Q3,0,0,0
 Bill Piel,2018-Q2,0,0,0
 Bill Piel,2018-Q1,0,0,0
-Bart Kiers,2021-Q4,0,0,0
-Bart Kiers,2021-Q3,0,0,0
 Bart Kiers,2021-Q2,0,0,0
 Bart Kiers,2021-Q1,0,0,0
 Bart Kiers,2020-Q4,0,0,0
@@ -40143,8 +35125,6 @@ Bart Kiers,2018-Q4,0,0,0
 Bart Kiers,2018-Q3,0,0,0
 Bart Kiers,2018-Q2,0,0,0
 Bart Kiers,2018-Q1,0,0,0
-Raphael,2021-Q4,0,0,0
-Raphael,2021-Q3,0,0,0
 Raphael,2021-Q2,0,0,0
 Raphael,2021-Q1,0,0,0
 Raphael,2020-Q4,0,0,0
@@ -40159,8 +35139,6 @@ Raphael,2018-Q4,0,0,0
 Raphael,2018-Q3,0,0,0
 Raphael,2018-Q2,0,0,0
 Raphael,2018-Q1,0,0,0
-meijun,2021-Q4,0,0,0
-meijun,2021-Q3,0,0,0
 meijun,2021-Q2,0,0,0
 meijun,2021-Q1,0,0,0
 meijun,2020-Q4,0,0,0
@@ -40175,8 +35153,6 @@ meijun,2018-Q4,0,0,0
 meijun,2018-Q3,0,0,0
 meijun,2018-Q2,0,0,0
 meijun,2018-Q1,0,0,0
-Dhruv,2021-Q4,0,0,0
-Dhruv,2021-Q3,0,0,0
 Dhruv,2021-Q2,0,0,0
 Dhruv,2021-Q1,0,0,0
 Dhruv,2020-Q4,0,0,0
@@ -40191,8 +35167,6 @@ Dhruv,2018-Q4,0,0,0
 Dhruv,2018-Q3,0,0,0
 Dhruv,2018-Q2,0,0,0
 Dhruv,2018-Q1,0,0,0
-Hee Jung Ryu,2021-Q4,0,0,0
-Hee Jung Ryu,2021-Q3,0,0,0
 Hee Jung Ryu,2021-Q2,0,0,0
 Hee Jung Ryu,2021-Q1,0,0,0
 Hee Jung Ryu,2020-Q4,0,0,0
@@ -40207,8 +35181,6 @@ Hee Jung Ryu,2018-Q4,0,0,0
 Hee Jung Ryu,2018-Q3,0,0,0
 Hee Jung Ryu,2018-Q2,0,0,0
 Hee Jung Ryu,2018-Q1,0,0,0
-Hyungsuk Yoon,2021-Q4,0,0,0
-Hyungsuk Yoon,2021-Q3,0,0,0
 Hyungsuk Yoon,2021-Q2,0,0,0
 Hyungsuk Yoon,2021-Q1,0,0,0
 Hyungsuk Yoon,2020-Q4,0,0,0
@@ -40223,8 +35195,6 @@ Hyungsuk Yoon,2018-Q4,0,0,0
 Hyungsuk Yoon,2018-Q3,0,0,0
 Hyungsuk Yoon,2018-Q2,0,0,0
 Hyungsuk Yoon,2018-Q1,0,0,0
-vfdev,2021-Q4,0,0,0
-vfdev,2021-Q3,0,0,0
 vfdev,2021-Q2,0,0,0
 vfdev,2021-Q1,0,0,0
 vfdev,2020-Q4,0,0,0
@@ -40239,8 +35209,6 @@ vfdev,2018-Q4,0,0,0
 vfdev,2018-Q3,0,0,0
 vfdev,2018-Q2,0,0,0
 vfdev,2018-Q1,0,0,0
-Ti Zhou,2021-Q4,0,0,0
-Ti Zhou,2021-Q3,0,0,0
 Ti Zhou,2021-Q2,0,0,0
 Ti Zhou,2021-Q1,0,0,0
 Ti Zhou,2020-Q4,0,0,0
@@ -40255,8 +35223,6 @@ Ti Zhou,2018-Q4,0,0,0
 Ti Zhou,2018-Q3,0,0,0
 Ti Zhou,2018-Q2,0,0,0
 Ti Zhou,2018-Q1,0,0,0
-Nouce,2021-Q4,0,0,0
-Nouce,2021-Q3,0,0,0
 Nouce,2021-Q2,0,0,0
 Nouce,2021-Q1,0,0,0
 Nouce,2020-Q4,0,0,0
@@ -40271,8 +35237,6 @@ Nouce,2018-Q4,0,0,0
 Nouce,2018-Q3,0,0,0
 Nouce,2018-Q2,0,0,0
 Nouce,2018-Q1,0,0,0
-superzerg,2021-Q4,0,0,0
-superzerg,2021-Q3,0,0,0
 superzerg,2021-Q2,0,0,0
 superzerg,2021-Q1,0,0,0
 superzerg,2020-Q4,0,0,0
@@ -40287,8 +35251,6 @@ superzerg,2018-Q4,0,0,0
 superzerg,2018-Q3,0,0,0
 superzerg,2018-Q2,0,0,0
 superzerg,2018-Q1,0,0,0
-wangqr,2021-Q4,0,0,0
-wangqr,2021-Q3,0,0,0
 wangqr,2021-Q2,0,0,0
 wangqr,2021-Q1,0,0,0
 wangqr,2020-Q4,0,0,0
@@ -40303,8 +35265,6 @@ wangqr,2018-Q4,0,0,0
 wangqr,2018-Q3,0,0,0
 wangqr,2018-Q2,0,0,0
 wangqr,2018-Q1,0,0,0
-lucasmoura,2021-Q4,0,0,0
-lucasmoura,2021-Q3,0,0,0
 lucasmoura,2021-Q2,0,0,0
 lucasmoura,2021-Q1,0,0,0
 lucasmoura,2020-Q4,0,0,0
@@ -40319,8 +35279,6 @@ lucasmoura,2018-Q4,0,0,0
 lucasmoura,2018-Q3,0,0,0
 lucasmoura,2018-Q2,0,0,0
 lucasmoura,2018-Q1,0,0,0
-Weber Xie,2021-Q4,0,0,0
-Weber Xie,2021-Q3,0,0,0
 Weber Xie,2021-Q2,0,0,0
 Weber Xie,2021-Q1,0,0,0
 Weber Xie,2020-Q4,0,0,0
@@ -40335,8 +35293,6 @@ Weber Xie,2018-Q4,0,0,0
 Weber Xie,2018-Q3,0,0,0
 Weber Xie,2018-Q2,0,0,0
 Weber Xie,2018-Q1,0,0,0
-Yue Zhang,2021-Q4,0,0,0
-Yue Zhang,2021-Q3,0,0,0
 Yue Zhang,2021-Q2,0,0,0
 Yue Zhang,2021-Q1,0,0,0
 Yue Zhang,2020-Q4,0,0,0
@@ -40351,8 +35307,6 @@ Yue Zhang,2018-Q4,0,0,0
 Yue Zhang,2018-Q3,0,0,0
 Yue Zhang,2018-Q2,0,0,0
 Yue Zhang,2018-Q1,0,0,0
-youkaichao,2021-Q4,0,0,0
-youkaichao,2021-Q3,0,0,0
 youkaichao,2021-Q2,0,0,0
 youkaichao,2021-Q1,0,0,0
 youkaichao,2020-Q4,0,0,0
@@ -40367,8 +35321,6 @@ youkaichao,2018-Q4,0,0,0
 youkaichao,2018-Q3,0,0,0
 youkaichao,2018-Q2,0,0,0
 youkaichao,2018-Q1,0,0,0
-Sergey Kolesnikov,2021-Q4,0,0,0
-Sergey Kolesnikov,2021-Q3,0,0,0
 Sergey Kolesnikov,2021-Q2,0,0,0
 Sergey Kolesnikov,2021-Q1,0,0,0
 Sergey Kolesnikov,2020-Q4,0,0,0
@@ -40383,8 +35335,6 @@ Sergey Kolesnikov,2018-Q4,0,0,0
 Sergey Kolesnikov,2018-Q3,0,0,0
 Sergey Kolesnikov,2018-Q2,0,0,0
 Sergey Kolesnikov,2018-Q1,0,0,0
-Brian Williammee,2021-Q4,0,0,0
-Brian Williammee,2021-Q3,0,0,0
 Brian Williammee,2021-Q2,0,0,0
 Brian Williammee,2021-Q1,0,0,0
 Brian Williammee,2020-Q4,0,0,0
@@ -40399,8 +35349,6 @@ Brian Williammee,2018-Q4,0,0,0
 Brian Williammee,2018-Q3,0,0,0
 Brian Williammee,2018-Q2,0,0,0
 Brian Williammee,2018-Q1,0,0,0
-Rasmus Larsen,2021-Q4,0,0,0
-Rasmus Larsen,2021-Q3,0,0,0
 Rasmus Larsen,2021-Q2,0,0,0
 Rasmus Larsen,2021-Q1,0,0,0
 Rasmus Larsen,2020-Q4,0,0,0
@@ -40415,8 +35363,6 @@ Rasmus Larsen,2018-Q4,0,0,0
 Rasmus Larsen,2018-Q3,0,0,0
 Rasmus Larsen,2018-Q2,0,0,0
 Rasmus Larsen,2018-Q1,0,0,0
-Lakshay Garg,2021-Q4,0,0,0
-Lakshay Garg,2021-Q3,0,0,0
 Lakshay Garg,2021-Q2,0,0,0
 Lakshay Garg,2021-Q1,0,0,0
 Lakshay Garg,2020-Q4,0,0,0
@@ -40431,8 +35377,6 @@ Lakshay Garg,2018-Q4,0,0,0
 Lakshay Garg,2018-Q3,0,0,0
 Lakshay Garg,2018-Q2,0,0,0
 Lakshay Garg,2018-Q1,0,0,0
-raymondxyang,2021-Q4,0,0,0
-raymondxyang,2021-Q3,0,0,0
 raymondxyang,2021-Q2,0,0,0
 raymondxyang,2021-Q1,0,0,0
 raymondxyang,2020-Q4,0,0,0
@@ -40447,8 +35391,6 @@ raymondxyang,2018-Q4,0,0,0
 raymondxyang,2018-Q3,0,0,0
 raymondxyang,2018-Q2,0,0,0
 raymondxyang,2018-Q1,0,0,0
-Ruben Vereecken,2021-Q4,0,0,0
-Ruben Vereecken,2021-Q3,0,0,0
 Ruben Vereecken,2021-Q2,0,0,0
 Ruben Vereecken,2021-Q1,0,0,0
 Ruben Vereecken,2020-Q4,0,0,0
@@ -40463,8 +35405,6 @@ Ruben Vereecken,2018-Q4,0,0,0
 Ruben Vereecken,2018-Q3,0,0,0
 Ruben Vereecken,2018-Q2,0,0,0
 Ruben Vereecken,2018-Q1,0,0,0
-Ziming Dong,2021-Q4,0,0,0
-Ziming Dong,2021-Q3,0,0,0
 Ziming Dong,2021-Q2,0,0,0
 Ziming Dong,2021-Q1,0,0,0
 Ziming Dong,2020-Q4,0,0,0
@@ -40479,8 +35419,6 @@ Ziming Dong,2018-Q4,0,0,0
 Ziming Dong,2018-Q3,0,0,0
 Ziming Dong,2018-Q2,0,0,0
 Ziming Dong,2018-Q1,0,0,0
-Anish Shah,2021-Q4,0,0,0
-Anish Shah,2021-Q3,0,0,0
 Anish Shah,2021-Q2,0,0,0
 Anish Shah,2021-Q1,0,0,0
 Anish Shah,2020-Q4,0,0,0
@@ -40495,8 +35433,6 @@ Anish Shah,2018-Q4,0,0,0
 Anish Shah,2018-Q3,0,0,0
 Anish Shah,2018-Q2,0,0,0
 Anish Shah,2018-Q1,0,0,0
-luke iwanski,2021-Q4,0,0,0
-luke iwanski,2021-Q3,0,0,0
 luke iwanski,2021-Q2,0,0,0
 luke iwanski,2021-Q1,0,0,0
 luke iwanski,2020-Q4,0,0,0
@@ -40511,8 +35447,6 @@ luke iwanski,2018-Q4,0,0,0
 luke iwanski,2018-Q3,0,0,0
 luke iwanski,2018-Q2,0,0,0
 luke iwanski,2018-Q1,0,0,0
-Vaibhav Sood,2021-Q4,0,0,0
-Vaibhav Sood,2021-Q3,0,0,0
 Vaibhav Sood,2021-Q2,0,0,0
 Vaibhav Sood,2021-Q1,0,0,0
 Vaibhav Sood,2020-Q4,0,0,0
@@ -40527,8 +35461,6 @@ Vaibhav Sood,2018-Q4,0,0,0
 Vaibhav Sood,2018-Q3,0,0,0
 Vaibhav Sood,2018-Q2,0,0,0
 Vaibhav Sood,2018-Q1,0,0,0
-Renze Yu,2021-Q4,0,0,0
-Renze Yu,2021-Q3,0,0,0
 Renze Yu,2021-Q2,0,0,0
 Renze Yu,2021-Q1,0,0,0
 Renze Yu,2020-Q4,0,0,0
@@ -40543,8 +35475,6 @@ Renze Yu,2018-Q4,0,0,0
 Renze Yu,2018-Q3,0,0,0
 Renze Yu,2018-Q2,0,0,0
 Renze Yu,2018-Q1,0,0,0
-Jun MEI,2021-Q4,0,0,0
-Jun MEI,2021-Q3,0,0,0
 Jun MEI,2021-Q2,0,0,0
 Jun MEI,2021-Q1,0,0,0
 Jun MEI,2020-Q4,0,0,0
@@ -40559,8 +35489,6 @@ Jun MEI,2018-Q4,0,0,0
 Jun MEI,2018-Q3,0,0,0
 Jun MEI,2018-Q2,0,0,0
 Jun MEI,2018-Q1,0,0,0
-HectorSVC,2021-Q4,0,0,0
-HectorSVC,2021-Q3,0,0,0
 HectorSVC,2021-Q2,0,0,0
 HectorSVC,2021-Q1,0,0,0
 HectorSVC,2020-Q4,0,0,0
@@ -40575,8 +35503,6 @@ HectorSVC,2018-Q4,0,0,0
 HectorSVC,2018-Q3,0,0,0
 HectorSVC,2018-Q2,0,0,0
 HectorSVC,2018-Q1,0,0,0
-Darren Garvey,2021-Q4,0,0,0
-Darren Garvey,2021-Q3,0,0,0
 Darren Garvey,2021-Q2,0,0,0
 Darren Garvey,2021-Q1,0,0,0
 Darren Garvey,2020-Q4,0,0,0
@@ -40591,8 +35517,6 @@ Darren Garvey,2018-Q4,0,0,0
 Darren Garvey,2018-Q3,0,0,0
 Darren Garvey,2018-Q2,0,0,0
 Darren Garvey,2018-Q1,0,0,0
-asdf2014,2021-Q4,0,0,0
-asdf2014,2021-Q3,0,0,0
 asdf2014,2021-Q2,0,0,0
 asdf2014,2021-Q1,0,0,0
 asdf2014,2020-Q4,0,0,0
@@ -40607,8 +35531,6 @@ asdf2014,2018-Q4,0,0,0
 asdf2014,2018-Q3,0,0,0
 asdf2014,2018-Q2,0,0,0
 asdf2014,2018-Q1,0,0,0
-Oliver Hennigh,2021-Q4,0,0,0
-Oliver Hennigh,2021-Q3,0,0,0
 Oliver Hennigh,2021-Q2,0,0,0
 Oliver Hennigh,2021-Q1,0,0,0
 Oliver Hennigh,2020-Q4,0,0,0
@@ -40623,8 +35545,6 @@ Oliver Hennigh,2018-Q4,0,0,0
 Oliver Hennigh,2018-Q3,0,0,0
 Oliver Hennigh,2018-Q2,0,0,0
 Oliver Hennigh,2018-Q1,0,0,0
-Andrew Stepanov,2021-Q4,0,0,0
-Andrew Stepanov,2021-Q3,0,0,0
 Andrew Stepanov,2021-Q2,0,0,0
 Andrew Stepanov,2021-Q1,0,0,0
 Andrew Stepanov,2020-Q4,0,0,0
@@ -40639,8 +35559,6 @@ Andrew Stepanov,2018-Q4,0,0,0
 Andrew Stepanov,2018-Q3,0,0,0
 Andrew Stepanov,2018-Q2,0,0,0
 Andrew Stepanov,2018-Q1,0,0,0
-Francois Xavier,2021-Q4,0,0,0
-Francois Xavier,2021-Q3,0,0,0
 Francois Xavier,2021-Q2,0,0,0
 Francois Xavier,2021-Q1,0,0,0
 Francois Xavier,2020-Q4,0,0,0
@@ -40655,8 +35573,6 @@ Francois Xavier,2018-Q4,0,0,0
 Francois Xavier,2018-Q3,0,0,0
 Francois Xavier,2018-Q2,0,0,0
 Francois Xavier,2018-Q1,0,0,0
-jeremy rutman,2021-Q4,0,0,0
-jeremy rutman,2021-Q3,0,0,0
 jeremy rutman,2021-Q2,0,0,0
 jeremy rutman,2021-Q1,0,0,0
 jeremy rutman,2020-Q4,0,0,0
@@ -40671,8 +35587,6 @@ jeremy rutman,2018-Q4,0,0,0
 jeremy rutman,2018-Q3,0,0,0
 jeremy rutman,2018-Q2,0,0,0
 jeremy rutman,2018-Q1,0,0,0
-Yufeng,2021-Q4,0,0,0
-Yufeng,2021-Q3,0,0,0
 Yufeng,2021-Q2,0,0,0
 Yufeng,2021-Q1,0,0,0
 Yufeng,2020-Q4,0,0,0
@@ -40687,8 +35601,6 @@ Yufeng,2018-Q4,0,0,0
 Yufeng,2018-Q3,0,0,0
 Yufeng,2018-Q2,0,0,0
 Yufeng,2018-Q1,0,0,0
-Tomoaki Oiki,2021-Q4,0,0,0
-Tomoaki Oiki,2021-Q3,0,0,0
 Tomoaki Oiki,2021-Q2,0,0,0
 Tomoaki Oiki,2021-Q1,0,0,0
 Tomoaki Oiki,2020-Q4,0,0,0
@@ -40703,8 +35615,6 @@ Tomoaki Oiki,2018-Q4,0,0,0
 Tomoaki Oiki,2018-Q3,0,0,0
 Tomoaki Oiki,2018-Q2,0,0,0
 Tomoaki Oiki,2018-Q1,0,0,0
-James Pruegsanusak,2021-Q4,0,0,0
-James Pruegsanusak,2021-Q3,0,0,0
 James Pruegsanusak,2021-Q2,0,0,0
 James Pruegsanusak,2021-Q1,0,0,0
 James Pruegsanusak,2020-Q4,0,0,0
@@ -40719,8 +35629,6 @@ James Pruegsanusak,2018-Q4,0,0,0
 James Pruegsanusak,2018-Q3,0,0,0
 James Pruegsanusak,2018-Q2,0,0,0
 James Pruegsanusak,2018-Q1,0,0,0
-黄璞,2021-Q4,0,0,0
-黄璞,2021-Q3,0,0,0
 黄璞,2021-Q2,0,0,0
 黄璞,2021-Q1,0,0,0
 黄璞,2020-Q4,0,0,0
@@ -40735,8 +35643,6 @@ James Pruegsanusak,2018-Q1,0,0,0
 黄璞,2018-Q3,0,0,0
 黄璞,2018-Q2,0,0,0
 黄璞,2018-Q1,0,0,0
-Aditya Dhulipala,2021-Q4,0,0,0
-Aditya Dhulipala,2021-Q3,0,0,0
 Aditya Dhulipala,2021-Q2,0,0,0
 Aditya Dhulipala,2021-Q1,0,0,0
 Aditya Dhulipala,2020-Q4,0,0,0
@@ -40751,8 +35657,6 @@ Aditya Dhulipala,2018-Q4,0,0,0
 Aditya Dhulipala,2018-Q3,0,0,0
 Aditya Dhulipala,2018-Q2,0,0,0
 Aditya Dhulipala,2018-Q1,0,0,0
-Sumit Gouthaman,2021-Q4,0,0,0
-Sumit Gouthaman,2021-Q3,0,0,0
 Sumit Gouthaman,2021-Q2,0,0,0
 Sumit Gouthaman,2021-Q1,0,0,0
 Sumit Gouthaman,2020-Q4,0,0,0
@@ -40767,8 +35671,6 @@ Sumit Gouthaman,2018-Q4,0,0,0
 Sumit Gouthaman,2018-Q3,0,0,0
 Sumit Gouthaman,2018-Q2,0,0,0
 Sumit Gouthaman,2018-Q1,0,0,0
-Vahid Kazemi,2021-Q4,0,0,0
-Vahid Kazemi,2021-Q3,0,0,0
 Vahid Kazemi,2021-Q2,0,0,0
 Vahid Kazemi,2021-Q1,0,0,0
 Vahid Kazemi,2020-Q4,0,0,0
@@ -40783,8 +35685,6 @@ Vahid Kazemi,2018-Q4,0,0,0
 Vahid Kazemi,2018-Q3,0,0,0
 Vahid Kazemi,2018-Q2,0,0,0
 Vahid Kazemi,2018-Q1,0,0,0
-David Kristoffersson,2021-Q4,0,0,0
-David Kristoffersson,2021-Q3,0,0,0
 David Kristoffersson,2021-Q2,0,0,0
 David Kristoffersson,2021-Q1,0,0,0
 David Kristoffersson,2020-Q4,0,0,0
@@ -40799,8 +35699,6 @@ David Kristoffersson,2018-Q4,0,0,0
 David Kristoffersson,2018-Q3,0,0,0
 David Kristoffersson,2018-Q2,0,0,0
 David Kristoffersson,2018-Q1,0,0,0
-joetoth,2021-Q4,0,0,0
-joetoth,2021-Q3,0,0,0
 joetoth,2021-Q2,0,0,0
 joetoth,2021-Q1,0,0,0
 joetoth,2020-Q4,0,0,0
@@ -40815,8 +35713,6 @@ joetoth,2018-Q4,0,0,0
 joetoth,2018-Q3,0,0,0
 joetoth,2018-Q2,0,0,0
 joetoth,2018-Q1,0,0,0
-Abdullah Alrasheed,2021-Q4,0,0,0
-Abdullah Alrasheed,2021-Q3,0,0,0
 Abdullah Alrasheed,2021-Q2,0,0,0
 Abdullah Alrasheed,2021-Q1,0,0,0
 Abdullah Alrasheed,2020-Q4,0,0,0
@@ -40831,8 +35727,6 @@ Abdullah Alrasheed,2018-Q4,0,0,0
 Abdullah Alrasheed,2018-Q3,0,0,0
 Abdullah Alrasheed,2018-Q2,0,0,0
 Abdullah Alrasheed,2018-Q1,0,0,0
-Kongsea,2021-Q4,0,0,0
-Kongsea,2021-Q3,0,0,0
 Kongsea,2021-Q2,0,0,0
 Kongsea,2021-Q1,0,0,0
 Kongsea,2020-Q4,0,0,0
@@ -40847,8 +35741,6 @@ Kongsea,2018-Q4,0,0,0
 Kongsea,2018-Q3,0,0,0
 Kongsea,2018-Q2,0,0,0
 Kongsea,2018-Q1,0,0,0
-ebrevdo,2021-Q4,0,0,0
-ebrevdo,2021-Q3,0,0,0
 ebrevdo,2021-Q2,0,0,0
 ebrevdo,2021-Q1,0,0,0
 ebrevdo,2020-Q4,0,0,0
@@ -40863,8 +35755,6 @@ ebrevdo,2018-Q4,0,0,0
 ebrevdo,2018-Q3,0,0,0
 ebrevdo,2018-Q2,0,0,0
 ebrevdo,2018-Q1,0,0,0
-Adam Salvail,2021-Q4,0,0,0
-Adam Salvail,2021-Q3,0,0,0
 Adam Salvail,2021-Q2,0,0,0
 Adam Salvail,2021-Q1,0,0,0
 Adam Salvail,2020-Q4,0,0,0
@@ -40879,8 +35769,6 @@ Adam Salvail,2018-Q4,0,0,0
 Adam Salvail,2018-Q3,0,0,0
 Adam Salvail,2018-Q2,0,0,0
 Adam Salvail,2018-Q1,0,0,0
-Jun Luan,2021-Q4,0,0,0
-Jun Luan,2021-Q3,0,0,0
 Jun Luan,2021-Q2,0,0,0
 Jun Luan,2021-Q1,0,0,0
 Jun Luan,2020-Q4,0,0,0
@@ -40895,8 +35783,6 @@ Jun Luan,2018-Q4,0,0,0
 Jun Luan,2018-Q3,0,0,0
 Jun Luan,2018-Q2,0,0,0
 Jun Luan,2018-Q1,0,0,0
-AngryPowman,2021-Q4,0,0,0
-AngryPowman,2021-Q3,0,0,0
 AngryPowman,2021-Q2,0,0,0
 AngryPowman,2021-Q1,0,0,0
 AngryPowman,2020-Q4,0,0,0
@@ -40911,8 +35797,6 @@ AngryPowman,2018-Q4,0,0,0
 AngryPowman,2018-Q3,0,0,0
 AngryPowman,2018-Q2,0,0,0
 AngryPowman,2018-Q1,0,0,0
-DimanNe,2021-Q4,0,0,0
-DimanNe,2021-Q3,0,0,0
 DimanNe,2021-Q2,0,0,0
 DimanNe,2021-Q1,0,0,0
 DimanNe,2020-Q4,0,0,0
@@ -40927,8 +35811,6 @@ DimanNe,2018-Q4,0,0,0
 DimanNe,2018-Q3,0,0,0
 DimanNe,2018-Q2,0,0,0
 DimanNe,2018-Q1,0,0,0
-Sebastian Raschka,2021-Q4,0,0,0
-Sebastian Raschka,2021-Q3,0,0,0
 Sebastian Raschka,2021-Q2,0,0,0
 Sebastian Raschka,2021-Q1,0,0,0
 Sebastian Raschka,2020-Q4,0,0,0
@@ -40943,8 +35825,6 @@ Sebastian Raschka,2018-Q4,0,0,0
 Sebastian Raschka,2018-Q3,0,0,0
 Sebastian Raschka,2018-Q2,0,0,0
 Sebastian Raschka,2018-Q1,0,0,0
-Androbin,2021-Q4,0,0,0
-Androbin,2021-Q3,0,0,0
 Androbin,2021-Q2,0,0,0
 Androbin,2021-Q1,0,0,0
 Androbin,2020-Q4,0,0,0
@@ -40959,8 +35839,6 @@ Androbin,2018-Q4,0,0,0
 Androbin,2018-Q3,0,0,0
 Androbin,2018-Q2,0,0,0
 Androbin,2018-Q1,0,0,0
-Will Frey,2021-Q4,0,0,0
-Will Frey,2021-Q3,0,0,0
 Will Frey,2021-Q2,0,0,0
 Will Frey,2021-Q1,0,0,0
 Will Frey,2020-Q4,0,0,0
@@ -40975,8 +35853,6 @@ Will Frey,2018-Q4,0,0,0
 Will Frey,2018-Q3,0,0,0
 Will Frey,2018-Q2,0,0,0
 Will Frey,2018-Q1,0,0,0
-osdamv,2021-Q4,0,0,0
-osdamv,2021-Q3,0,0,0
 osdamv,2021-Q2,0,0,0
 osdamv,2021-Q1,0,0,0
 osdamv,2020-Q4,0,0,0
@@ -40991,8 +35867,6 @@ osdamv,2018-Q4,0,0,0
 osdamv,2018-Q3,0,0,0
 osdamv,2018-Q2,0,0,0
 osdamv,2018-Q1,0,0,0
-Roffel,2021-Q4,0,0,0
-Roffel,2021-Q3,0,0,0
 Roffel,2021-Q2,0,0,0
 Roffel,2021-Q1,0,0,0
 Roffel,2020-Q4,0,0,0
@@ -41007,8 +35881,6 @@ Roffel,2018-Q4,0,0,0
 Roffel,2018-Q3,0,0,0
 Roffel,2018-Q2,0,0,0
 Roffel,2018-Q1,0,0,0
-lewuathe,2021-Q4,0,0,0
-lewuathe,2021-Q3,0,0,0
 lewuathe,2021-Q2,0,0,0
 lewuathe,2021-Q1,0,0,0
 lewuathe,2020-Q4,0,0,0
@@ -41023,8 +35895,6 @@ lewuathe,2018-Q4,0,0,0
 lewuathe,2018-Q3,0,0,0
 lewuathe,2018-Q2,0,0,0
 lewuathe,2018-Q1,0,0,0
-Batchu Venkat Vishal,2021-Q4,0,0,0
-Batchu Venkat Vishal,2021-Q3,0,0,0
 Batchu Venkat Vishal,2021-Q2,0,0,0
 Batchu Venkat Vishal,2021-Q1,0,0,0
 Batchu Venkat Vishal,2020-Q4,0,0,0
@@ -41039,8 +35909,6 @@ Batchu Venkat Vishal,2018-Q4,0,0,0
 Batchu Venkat Vishal,2018-Q3,0,0,0
 Batchu Venkat Vishal,2018-Q2,0,0,0
 Batchu Venkat Vishal,2018-Q1,0,0,0
-Yixing Lao,2021-Q4,0,0,0
-Yixing Lao,2021-Q3,0,0,0
 Yixing Lao,2021-Q2,0,0,0
 Yixing Lao,2021-Q1,0,0,0
 Yixing Lao,2020-Q4,0,0,0
@@ -41055,8 +35923,6 @@ Yixing Lao,2018-Q4,0,0,0
 Yixing Lao,2018-Q3,0,0,0
 Yixing Lao,2018-Q2,0,0,0
 Yixing Lao,2018-Q1,0,0,0
-Manjunath Kudlur,2021-Q4,0,0,0
-Manjunath Kudlur,2021-Q3,0,0,0
 Manjunath Kudlur,2021-Q2,0,0,0
 Manjunath Kudlur,2021-Q1,0,0,0
 Manjunath Kudlur,2020-Q4,0,0,0
@@ -41071,8 +35937,6 @@ Manjunath Kudlur,2018-Q4,0,0,0
 Manjunath Kudlur,2018-Q3,0,0,0
 Manjunath Kudlur,2018-Q2,0,0,0
 Manjunath Kudlur,2018-Q1,0,0,0
-John Lawson,2021-Q4,0,0,0
-John Lawson,2021-Q3,0,0,0
 John Lawson,2021-Q2,0,0,0
 John Lawson,2021-Q1,0,0,0
 John Lawson,2020-Q4,0,0,0
@@ -41087,8 +35951,6 @@ John Lawson,2018-Q4,0,0,0
 John Lawson,2018-Q3,0,0,0
 John Lawson,2018-Q2,0,0,0
 John Lawson,2018-Q1,0,0,0
-Guo Yejun (郭叶军),2021-Q4,0,0,0
-Guo Yejun (郭叶军),2021-Q3,0,0,0
 Guo Yejun (郭叶军),2021-Q2,0,0,0
 Guo Yejun (郭叶军),2021-Q1,0,0,0
 Guo Yejun (郭叶军),2020-Q4,0,0,0
@@ -41103,8 +35965,6 @@ Guo Yejun (郭叶军),2018-Q4,0,0,0
 Guo Yejun (郭叶军),2018-Q3,0,0,0
 Guo Yejun (郭叶军),2018-Q2,0,0,0
 Guo Yejun (郭叶军),2018-Q1,0,0,0
-Catalin Voss,2021-Q4,0,0,0
-Catalin Voss,2021-Q3,0,0,0
 Catalin Voss,2021-Q2,0,0,0
 Catalin Voss,2021-Q1,0,0,0
 Catalin Voss,2020-Q4,0,0,0
@@ -41119,8 +35979,6 @@ Catalin Voss,2018-Q4,0,0,0
 Catalin Voss,2018-Q3,0,0,0
 Catalin Voss,2018-Q2,0,0,0
 Catalin Voss,2018-Q1,0,0,0
-Lef Ioannidis,2021-Q4,0,0,0
-Lef Ioannidis,2021-Q3,0,0,0
 Lef Ioannidis,2021-Q2,0,0,0
 Lef Ioannidis,2021-Q1,0,0,0
 Lef Ioannidis,2020-Q4,0,0,0
@@ -41135,8 +35993,6 @@ Lef Ioannidis,2018-Q4,0,0,0
 Lef Ioannidis,2018-Q3,0,0,0
 Lef Ioannidis,2018-Q2,0,0,0
 Lef Ioannidis,2018-Q1,0,0,0
-Arvinds-ds,2021-Q4,0,0,0
-Arvinds-ds,2021-Q3,0,0,0
 Arvinds-ds,2021-Q2,0,0,0
 Arvinds-ds,2021-Q1,0,0,0
 Arvinds-ds,2020-Q4,0,0,0
@@ -41151,8 +36007,6 @@ Arvinds-ds,2018-Q4,0,0,0
 Arvinds-ds,2018-Q3,0,0,0
 Arvinds-ds,2018-Q2,0,0,0
 Arvinds-ds,2018-Q1,0,0,0
-Shuolongbj,2021-Q4,0,0,0
-Shuolongbj,2021-Q3,0,0,0
 Shuolongbj,2021-Q2,0,0,0
 Shuolongbj,2021-Q1,0,0,0
 Shuolongbj,2020-Q4,0,0,0
@@ -41167,8 +36021,6 @@ Shuolongbj,2018-Q4,0,0,0
 Shuolongbj,2018-Q3,0,0,0
 Shuolongbj,2018-Q2,0,0,0
 Shuolongbj,2018-Q1,0,0,0
-vhasanov,2021-Q4,0,0,0
-vhasanov,2021-Q3,0,0,0
 vhasanov,2021-Q2,0,0,0
 vhasanov,2021-Q1,0,0,0
 vhasanov,2020-Q4,0,0,0
@@ -41183,8 +36035,6 @@ vhasanov,2018-Q4,0,0,0
 vhasanov,2018-Q3,0,0,0
 vhasanov,2018-Q2,0,0,0
 vhasanov,2018-Q1,0,0,0
-zhongzyd,2021-Q4,0,0,0
-zhongzyd,2021-Q3,0,0,0
 zhongzyd,2021-Q2,0,0,0
 zhongzyd,2021-Q1,0,0,0
 zhongzyd,2020-Q4,0,0,0
@@ -41199,8 +36049,6 @@ zhongzyd,2018-Q4,0,0,0
 zhongzyd,2018-Q3,0,0,0
 zhongzyd,2018-Q2,0,0,0
 zhongzyd,2018-Q1,0,0,0
-TJ Rana,2021-Q4,0,0,0
-TJ Rana,2021-Q3,0,0,0
 TJ Rana,2021-Q2,0,0,0
 TJ Rana,2021-Q1,0,0,0
 TJ Rana,2020-Q4,0,0,0
@@ -41215,8 +36063,6 @@ TJ Rana,2018-Q4,0,0,0
 TJ Rana,2018-Q3,0,0,0
 TJ Rana,2018-Q2,0,0,0
 TJ Rana,2018-Q1,0,0,0
-Yann Henon,2021-Q4,0,0,0
-Yann Henon,2021-Q3,0,0,0
 Yann Henon,2021-Q2,0,0,0
 Yann Henon,2021-Q1,0,0,0
 Yann Henon,2020-Q4,0,0,0
@@ -41231,8 +36077,6 @@ Yann Henon,2018-Q4,0,0,0
 Yann Henon,2018-Q3,0,0,0
 Yann Henon,2018-Q2,0,0,0
 Yann Henon,2018-Q1,0,0,0
-Chris Song,2021-Q4,0,0,0
-Chris Song,2021-Q3,0,0,0
 Chris Song,2021-Q2,0,0,0
 Chris Song,2021-Q1,0,0,0
 Chris Song,2020-Q4,0,0,0
@@ -41247,8 +36091,6 @@ Chris Song,2018-Q4,0,0,0
 Chris Song,2018-Q3,0,0,0
 Chris Song,2018-Q2,0,0,0
 Chris Song,2018-Q1,0,0,0
-Louis Tiao,2021-Q4,0,0,0
-Louis Tiao,2021-Q3,0,0,0
 Louis Tiao,2021-Q2,0,0,0
 Louis Tiao,2021-Q1,0,0,0
 Louis Tiao,2020-Q4,0,0,0
@@ -41263,8 +36105,6 @@ Louis Tiao,2018-Q4,0,0,0
 Louis Tiao,2018-Q3,0,0,0
 Louis Tiao,2018-Q2,0,0,0
 Louis Tiao,2018-Q1,0,0,0
-Bruno Rosa,2021-Q4,0,0,0
-Bruno Rosa,2021-Q3,0,0,0
 Bruno Rosa,2021-Q2,0,0,0
 Bruno Rosa,2021-Q1,0,0,0
 Bruno Rosa,2020-Q4,0,0,0
@@ -41279,8 +36119,6 @@ Bruno Rosa,2018-Q4,0,0,0
 Bruno Rosa,2018-Q3,0,0,0
 Bruno Rosa,2018-Q2,0,0,0
 Bruno Rosa,2018-Q1,0,0,0
-yorkie,2021-Q4,0,0,0
-yorkie,2021-Q3,0,0,0
 yorkie,2021-Q2,0,0,0
 yorkie,2021-Q1,0,0,0
 yorkie,2020-Q4,0,0,0
@@ -41295,8 +36133,6 @@ yorkie,2018-Q4,0,0,0
 yorkie,2018-Q3,0,0,0
 yorkie,2018-Q2,0,0,0
 yorkie,2018-Q1,0,0,0
-Julian Viereck,2021-Q4,0,0,0
-Julian Viereck,2021-Q3,0,0,0
 Julian Viereck,2021-Q2,0,0,0
 Julian Viereck,2021-Q1,0,0,0
 Julian Viereck,2020-Q4,0,0,0
@@ -41311,8 +36147,6 @@ Julian Viereck,2018-Q4,0,0,0
 Julian Viereck,2018-Q3,0,0,0
 Julian Viereck,2018-Q2,0,0,0
 Julian Viereck,2018-Q1,0,0,0
-Michaël Defferrard,2021-Q4,0,0,0
-Michaël Defferrard,2021-Q3,0,0,0
 Michaël Defferrard,2021-Q2,0,0,0
 Michaël Defferrard,2021-Q1,0,0,0
 Michaël Defferrard,2020-Q4,0,0,0
@@ -41327,8 +36161,6 @@ Michaël Defferrard,2018-Q4,0,0,0
 Michaël Defferrard,2018-Q3,0,0,0
 Michaël Defferrard,2018-Q2,0,0,0
 Michaël Defferrard,2018-Q1,0,0,0
-Melody Guan,2021-Q4,0,0,0
-Melody Guan,2021-Q3,0,0,0
 Melody Guan,2021-Q2,0,0,0
 Melody Guan,2021-Q1,0,0,0
 Melody Guan,2020-Q4,0,0,0
@@ -41343,8 +36175,6 @@ Melody Guan,2018-Q4,0,0,0
 Melody Guan,2018-Q3,0,0,0
 Melody Guan,2018-Q2,0,0,0
 Melody Guan,2018-Q1,0,0,0
-myPrecious,2021-Q4,0,0,0
-myPrecious,2021-Q3,0,0,0
 myPrecious,2021-Q2,0,0,0
 myPrecious,2021-Q1,0,0,0
 myPrecious,2020-Q4,0,0,0
@@ -41359,8 +36189,6 @@ myPrecious,2018-Q4,0,0,0
 myPrecious,2018-Q3,0,0,0
 myPrecious,2018-Q2,0,0,0
 myPrecious,2018-Q1,0,0,0
-Pankaj Gupta,2021-Q4,0,0,0
-Pankaj Gupta,2021-Q3,0,0,0
 Pankaj Gupta,2021-Q2,0,0,0
 Pankaj Gupta,2021-Q1,0,0,0
 Pankaj Gupta,2020-Q4,0,0,0
@@ -41375,8 +36203,6 @@ Pankaj Gupta,2018-Q4,0,0,0
 Pankaj Gupta,2018-Q3,0,0,0
 Pankaj Gupta,2018-Q2,0,0,0
 Pankaj Gupta,2018-Q1,0,0,0
-Wei Wu,2021-Q4,0,0,0
-Wei Wu,2021-Q3,0,0,0
 Wei Wu,2021-Q2,0,0,0
 Wei Wu,2021-Q1,0,0,0
 Wei Wu,2020-Q4,0,0,0
@@ -41391,8 +36217,6 @@ Wei Wu,2018-Q4,0,0,0
 Wei Wu,2018-Q3,0,0,0
 Wei Wu,2018-Q2,0,0,0
 Wei Wu,2018-Q1,0,0,0
-Chase Roberts,2021-Q4,0,0,0
-Chase Roberts,2021-Q3,0,0,0
 Chase Roberts,2021-Q2,0,0,0
 Chase Roberts,2021-Q1,0,0,0
 Chase Roberts,2020-Q4,0,0,0
@@ -41407,8 +36231,6 @@ Chase Roberts,2018-Q4,0,0,0
 Chase Roberts,2018-Q3,0,0,0
 Chase Roberts,2018-Q2,0,0,0
 Chase Roberts,2018-Q1,0,0,0
-davidpham87,2021-Q4,0,0,0
-davidpham87,2021-Q3,0,0,0
 davidpham87,2021-Q2,0,0,0
 davidpham87,2021-Q1,0,0,0
 davidpham87,2020-Q4,0,0,0
@@ -41423,8 +36245,6 @@ davidpham87,2018-Q4,0,0,0
 davidpham87,2018-Q3,0,0,0
 davidpham87,2018-Q2,0,0,0
 davidpham87,2018-Q1,0,0,0
-Alexey Surkov,2021-Q4,0,0,0
-Alexey Surkov,2021-Q3,0,0,0
 Alexey Surkov,2021-Q2,0,0,0
 Alexey Surkov,2021-Q1,0,0,0
 Alexey Surkov,2020-Q4,0,0,0
@@ -41439,8 +36259,6 @@ Alexey Surkov,2018-Q4,0,0,0
 Alexey Surkov,2018-Q3,0,0,0
 Alexey Surkov,2018-Q2,0,0,0
 Alexey Surkov,2018-Q1,0,0,0
-Kevin van der Burgt,2021-Q4,0,0,0
-Kevin van der Burgt,2021-Q3,0,0,0
 Kevin van der Burgt,2021-Q2,0,0,0
 Kevin van der Burgt,2021-Q1,0,0,0
 Kevin van der Burgt,2020-Q4,0,0,0
@@ -41455,8 +36273,6 @@ Kevin van der Burgt,2018-Q4,0,0,0
 Kevin van der Burgt,2018-Q3,0,0,0
 Kevin van der Burgt,2018-Q2,0,0,0
 Kevin van der Burgt,2018-Q1,0,0,0
-Baptiste Arnaud,2021-Q4,0,0,0
-Baptiste Arnaud,2021-Q3,0,0,0
 Baptiste Arnaud,2021-Q2,0,0,0
 Baptiste Arnaud,2021-Q1,0,0,0
 Baptiste Arnaud,2020-Q4,0,0,0
@@ -41471,8 +36287,6 @@ Baptiste Arnaud,2018-Q4,0,0,0
 Baptiste Arnaud,2018-Q3,0,0,0
 Baptiste Arnaud,2018-Q2,0,0,0
 Baptiste Arnaud,2018-Q1,0,0,0
-Tiago Morais Morgado,2021-Q4,0,0,0
-Tiago Morais Morgado,2021-Q3,0,0,0
 Tiago Morais Morgado,2021-Q2,0,0,0
 Tiago Morais Morgado,2021-Q1,0,0,0
 Tiago Morais Morgado,2020-Q4,0,0,0
@@ -41487,8 +36301,6 @@ Tiago Morais Morgado,2018-Q4,0,0,0
 Tiago Morais Morgado,2018-Q3,0,0,0
 Tiago Morais Morgado,2018-Q2,0,0,0
 Tiago Morais Morgado,2018-Q1,0,0,0
-Liangliang He,2021-Q4,0,0,0
-Liangliang He,2021-Q3,0,0,0
 Liangliang He,2021-Q2,0,0,0
 Liangliang He,2021-Q1,0,0,0
 Liangliang He,2020-Q4,0,0,0
@@ -41503,8 +36315,6 @@ Liangliang He,2018-Q4,0,0,0
 Liangliang He,2018-Q3,0,0,0
 Liangliang He,2018-Q2,0,0,0
 Liangliang He,2018-Q1,0,0,0
-Rockford Wei,2021-Q4,0,0,0
-Rockford Wei,2021-Q3,0,0,0
 Rockford Wei,2021-Q2,0,0,0
 Rockford Wei,2021-Q1,0,0,0
 Rockford Wei,2020-Q4,0,0,0
@@ -41519,8 +36329,6 @@ Rockford Wei,2018-Q4,0,0,0
 Rockford Wei,2018-Q3,0,0,0
 Rockford Wei,2018-Q2,0,0,0
 Rockford Wei,2018-Q1,0,0,0
-Jayeol Chun,2021-Q4,0,0,0
-Jayeol Chun,2021-Q3,0,0,0
 Jayeol Chun,2021-Q2,0,0,0
 Jayeol Chun,2021-Q1,0,0,0
 Jayeol Chun,2020-Q4,0,0,0
@@ -41535,8 +36343,6 @@ Jayeol Chun,2018-Q4,0,0,0
 Jayeol Chun,2018-Q3,0,0,0
 Jayeol Chun,2018-Q2,0,0,0
 Jayeol Chun,2018-Q1,0,0,0
-Mike Brodie,2021-Q4,0,0,0
-Mike Brodie,2021-Q3,0,0,0
 Mike Brodie,2021-Q2,0,0,0
 Mike Brodie,2021-Q1,0,0,0
 Mike Brodie,2020-Q4,0,0,0
@@ -41551,8 +36357,6 @@ Mike Brodie,2018-Q4,0,0,0
 Mike Brodie,2018-Q3,0,0,0
 Mike Brodie,2018-Q2,0,0,0
 Mike Brodie,2018-Q1,0,0,0
-Tapan Prakash,2021-Q4,0,0,0
-Tapan Prakash,2021-Q3,0,0,0
 Tapan Prakash,2021-Q2,0,0,0
 Tapan Prakash,2021-Q1,0,0,0
 Tapan Prakash,2020-Q4,0,0,0
@@ -41567,8 +36371,6 @@ Tapan Prakash,2018-Q4,0,0,0
 Tapan Prakash,2018-Q3,0,0,0
 Tapan Prakash,2018-Q2,0,0,0
 Tapan Prakash,2018-Q1,0,0,0
-Alex Lattas,2021-Q4,0,0,0
-Alex Lattas,2021-Q3,0,0,0
 Alex Lattas,2021-Q2,0,0,0
 Alex Lattas,2021-Q1,0,0,0
 Alex Lattas,2020-Q4,0,0,0
@@ -41583,8 +36385,6 @@ Alex Lattas,2018-Q4,0,0,0
 Alex Lattas,2018-Q3,0,0,0
 Alex Lattas,2018-Q2,0,0,0
 Alex Lattas,2018-Q1,0,0,0
-J Alammar,2021-Q4,0,0,0
-J Alammar,2021-Q3,0,0,0
 J Alammar,2021-Q2,0,0,0
 J Alammar,2021-Q1,0,0,0
 J Alammar,2020-Q4,0,0,0
@@ -41599,8 +36399,6 @@ J Alammar,2018-Q4,0,0,0
 J Alammar,2018-Q3,0,0,0
 J Alammar,2018-Q2,0,0,0
 J Alammar,2018-Q1,0,0,0
-Mosnoi Ion,2021-Q4,0,0,0
-Mosnoi Ion,2021-Q3,0,0,0
 Mosnoi Ion,2021-Q2,0,0,0
 Mosnoi Ion,2021-Q1,0,0,0
 Mosnoi Ion,2020-Q4,0,0,0
@@ -41615,8 +36413,6 @@ Mosnoi Ion,2018-Q4,0,0,0
 Mosnoi Ion,2018-Q3,0,0,0
 Mosnoi Ion,2018-Q2,0,0,0
 Mosnoi Ion,2018-Q1,0,0,0
-Ben Mabey,2021-Q4,0,0,0
-Ben Mabey,2021-Q3,0,0,0
 Ben Mabey,2021-Q2,0,0,0
 Ben Mabey,2021-Q1,0,0,0
 Ben Mabey,2020-Q4,0,0,0
@@ -41631,8 +36427,6 @@ Ben Mabey,2018-Q4,0,0,0
 Ben Mabey,2018-Q3,0,0,0
 Ben Mabey,2018-Q2,0,0,0
 Ben Mabey,2018-Q1,0,0,0
-raoqiyu,2021-Q4,0,0,0
-raoqiyu,2021-Q3,0,0,0
 raoqiyu,2021-Q2,0,0,0
 raoqiyu,2021-Q1,0,0,0
 raoqiyu,2020-Q4,0,0,0
@@ -41647,8 +36441,6 @@ raoqiyu,2018-Q4,0,0,0
 raoqiyu,2018-Q3,0,0,0
 raoqiyu,2018-Q2,0,0,0
 raoqiyu,2018-Q1,0,0,0
-Stephen Fox,2021-Q4,0,0,0
-Stephen Fox,2021-Q3,0,0,0
 Stephen Fox,2021-Q2,0,0,0
 Stephen Fox,2021-Q1,0,0,0
 Stephen Fox,2020-Q4,0,0,0
@@ -41663,8 +36455,6 @@ Stephen Fox,2018-Q4,0,0,0
 Stephen Fox,2018-Q3,0,0,0
 Stephen Fox,2018-Q2,0,0,0
 Stephen Fox,2018-Q1,0,0,0
-Siim Põder,2021-Q4,0,0,0
-Siim Põder,2021-Q3,0,0,0
 Siim Põder,2021-Q2,0,0,0
 Siim Põder,2021-Q1,0,0,0
 Siim Põder,2020-Q4,0,0,0
@@ -41679,8 +36469,6 @@ Siim Põder,2018-Q4,0,0,0
 Siim Põder,2018-Q3,0,0,0
 Siim Põder,2018-Q2,0,0,0
 Siim Põder,2018-Q1,0,0,0
-Boyuan Deng,2021-Q4,0,0,0
-Boyuan Deng,2021-Q3,0,0,0
 Boyuan Deng,2021-Q2,0,0,0
 Boyuan Deng,2021-Q1,0,0,0
 Boyuan Deng,2020-Q4,0,0,0
@@ -41695,8 +36483,6 @@ Boyuan Deng,2018-Q4,0,0,0
 Boyuan Deng,2018-Q3,0,0,0
 Boyuan Deng,2018-Q2,0,0,0
 Boyuan Deng,2018-Q1,0,0,0
-Maxwell Paul Brickner,2021-Q4,0,0,0
-Maxwell Paul Brickner,2021-Q3,0,0,0
 Maxwell Paul Brickner,2021-Q2,0,0,0
 Maxwell Paul Brickner,2021-Q1,0,0,0
 Maxwell Paul Brickner,2020-Q4,0,0,0
@@ -41711,8 +36497,6 @@ Maxwell Paul Brickner,2018-Q4,0,0,0
 Maxwell Paul Brickner,2018-Q3,0,0,0
 Maxwell Paul Brickner,2018-Q2,0,0,0
 Maxwell Paul Brickner,2018-Q1,0,0,0
-superryanguo,2021-Q4,0,0,0
-superryanguo,2021-Q3,0,0,0
 superryanguo,2021-Q2,0,0,0
 superryanguo,2021-Q1,0,0,0
 superryanguo,2020-Q4,0,0,0
@@ -41727,8 +36511,6 @@ superryanguo,2018-Q4,0,0,0
 superryanguo,2018-Q3,0,0,0
 superryanguo,2018-Q2,0,0,0
 superryanguo,2018-Q1,0,0,0
-Rishabh Patel,2021-Q4,0,0,0
-Rishabh Patel,2021-Q3,0,0,0
 Rishabh Patel,2021-Q2,0,0,0
 Rishabh Patel,2021-Q1,0,0,0
 Rishabh Patel,2020-Q4,0,0,0
@@ -41743,8 +36525,6 @@ Rishabh Patel,2018-Q4,0,0,0
 Rishabh Patel,2018-Q3,0,0,0
 Rishabh Patel,2018-Q2,0,0,0
 Rishabh Patel,2018-Q1,0,0,0
-Dumitru Erhan,2021-Q4,0,0,0
-Dumitru Erhan,2021-Q3,0,0,0
 Dumitru Erhan,2021-Q2,0,0,0
 Dumitru Erhan,2021-Q1,0,0,0
 Dumitru Erhan,2020-Q4,0,0,0
@@ -41759,8 +36539,6 @@ Dumitru Erhan,2018-Q4,0,0,0
 Dumitru Erhan,2018-Q3,0,0,0
 Dumitru Erhan,2018-Q2,0,0,0
 Dumitru Erhan,2018-Q1,0,0,0
-Mark Neumann,2021-Q4,0,0,0
-Mark Neumann,2021-Q3,0,0,0
 Mark Neumann,2021-Q2,0,0,0
 Mark Neumann,2021-Q1,0,0,0
 Mark Neumann,2020-Q4,0,0,0
@@ -41775,8 +36553,6 @@ Mark Neumann,2018-Q4,0,0,0
 Mark Neumann,2018-Q3,0,0,0
 Mark Neumann,2018-Q2,0,0,0
 Mark Neumann,2018-Q1,0,0,0
-sj6077,2021-Q4,0,0,0
-sj6077,2021-Q3,0,0,0
 sj6077,2021-Q2,0,0,0
 sj6077,2021-Q1,0,0,0
 sj6077,2020-Q4,0,0,0
@@ -41791,8 +36567,6 @@ sj6077,2018-Q4,0,0,0
 sj6077,2018-Q3,0,0,0
 sj6077,2018-Q2,0,0,0
 sj6077,2018-Q1,0,0,0
-mdymczyk,2021-Q4,0,0,0
-mdymczyk,2021-Q3,0,0,0
 mdymczyk,2021-Q2,0,0,0
 mdymczyk,2021-Q1,0,0,0
 mdymczyk,2020-Q4,0,0,0
@@ -41807,8 +36581,6 @@ mdymczyk,2018-Q4,0,0,0
 mdymczyk,2018-Q3,0,0,0
 mdymczyk,2018-Q2,0,0,0
 mdymczyk,2018-Q1,0,0,0
-ribx,2021-Q4,0,0,0
-ribx,2021-Q3,0,0,0
 ribx,2021-Q2,0,0,0
 ribx,2021-Q1,0,0,0
 ribx,2020-Q4,0,0,0
@@ -41823,8 +36595,6 @@ ribx,2018-Q4,0,0,0
 ribx,2018-Q3,0,0,0
 ribx,2018-Q2,0,0,0
 ribx,2018-Q1,0,0,0
-Hauke Brammer,2021-Q4,0,0,0
-Hauke Brammer,2021-Q3,0,0,0
 Hauke Brammer,2021-Q2,0,0,0
 Hauke Brammer,2021-Q1,0,0,0
 Hauke Brammer,2020-Q4,0,0,0
@@ -41839,8 +36609,6 @@ Hauke Brammer,2018-Q4,0,0,0
 Hauke Brammer,2018-Q3,0,0,0
 Hauke Brammer,2018-Q2,0,0,0
 Hauke Brammer,2018-Q1,0,0,0
-Pierre,2021-Q4,0,0,0
-Pierre,2021-Q3,0,0,0
 Pierre,2021-Q2,0,0,0
 Pierre,2021-Q1,0,0,0
 Pierre,2020-Q4,0,0,0
@@ -41855,8 +36623,6 @@ Pierre,2018-Q4,0,0,0
 Pierre,2018-Q3,0,0,0
 Pierre,2018-Q2,0,0,0
 Pierre,2018-Q1,0,0,0
-Chirag Bhatia,2021-Q4,0,0,0
-Chirag Bhatia,2021-Q3,0,0,0
 Chirag Bhatia,2021-Q2,0,0,0
 Chirag Bhatia,2021-Q1,0,0,0
 Chirag Bhatia,2020-Q4,0,0,0
@@ -41871,8 +36637,6 @@ Chirag Bhatia,2018-Q4,0,0,0
 Chirag Bhatia,2018-Q3,0,0,0
 Chirag Bhatia,2018-Q2,0,0,0
 Chirag Bhatia,2018-Q1,0,0,0
-Sahil Dua,2021-Q4,0,0,0
-Sahil Dua,2021-Q3,0,0,0
 Sahil Dua,2021-Q2,0,0,0
 Sahil Dua,2021-Q1,0,0,0
 Sahil Dua,2020-Q4,0,0,0
@@ -41887,8 +36651,6 @@ Sahil Dua,2018-Q4,0,0,0
 Sahil Dua,2018-Q3,0,0,0
 Sahil Dua,2018-Q2,0,0,0
 Sahil Dua,2018-Q1,0,0,0
-Adriano Carmezim,2021-Q4,0,0,0
-Adriano Carmezim,2021-Q3,0,0,0
 Adriano Carmezim,2021-Q2,0,0,0
 Adriano Carmezim,2021-Q1,0,0,0
 Adriano Carmezim,2020-Q4,0,0,0
@@ -41903,8 +36665,6 @@ Adriano Carmezim,2018-Q4,0,0,0
 Adriano Carmezim,2018-Q3,0,0,0
 Adriano Carmezim,2018-Q2,0,0,0
 Adriano Carmezim,2018-Q1,0,0,0
-Kaarthik Sivashanmugam,2021-Q4,0,0,0
-Kaarthik Sivashanmugam,2021-Q3,0,0,0
 Kaarthik Sivashanmugam,2021-Q2,0,0,0
 Kaarthik Sivashanmugam,2021-Q1,0,0,0
 Kaarthik Sivashanmugam,2020-Q4,0,0,0
@@ -41919,8 +36679,6 @@ Kaarthik Sivashanmugam,2018-Q4,0,0,0
 Kaarthik Sivashanmugam,2018-Q3,0,0,0
 Kaarthik Sivashanmugam,2018-Q2,0,0,0
 Kaarthik Sivashanmugam,2018-Q1,0,0,0
-windead,2021-Q4,0,0,0
-windead,2021-Q3,0,0,0
 windead,2021-Q2,0,0,0
 windead,2021-Q1,0,0,0
 windead,2020-Q4,0,0,0
@@ -41935,8 +36693,6 @@ windead,2018-Q4,0,0,0
 windead,2018-Q3,0,0,0
 windead,2018-Q2,0,0,0
 windead,2018-Q1,0,0,0
-Andrew Hundt,2021-Q4,0,0,0
-Andrew Hundt,2021-Q3,0,0,0
 Andrew Hundt,2021-Q2,0,0,0
 Andrew Hundt,2021-Q1,0,0,0
 Andrew Hundt,2020-Q4,0,0,0
@@ -41951,8 +36707,6 @@ Andrew Hundt,2018-Q4,0,0,0
 Andrew Hundt,2018-Q3,0,0,0
 Andrew Hundt,2018-Q2,0,0,0
 Andrew Hundt,2018-Q1,0,0,0
-Alexandr Baranezky,2021-Q4,0,0,0
-Alexandr Baranezky,2021-Q3,0,0,0
 Alexandr Baranezky,2021-Q2,0,0,0
 Alexandr Baranezky,2021-Q1,0,0,0
 Alexandr Baranezky,2020-Q4,0,0,0
@@ -41967,8 +36721,6 @@ Alexandr Baranezky,2018-Q4,0,0,0
 Alexandr Baranezky,2018-Q3,0,0,0
 Alexandr Baranezky,2018-Q2,0,0,0
 Alexandr Baranezky,2018-Q1,0,0,0
-Alex Baranezky,2021-Q4,0,0,0
-Alex Baranezky,2021-Q3,0,0,0
 Alex Baranezky,2021-Q2,0,0,0
 Alex Baranezky,2021-Q1,0,0,0
 Alex Baranezky,2020-Q4,0,0,0
@@ -41983,8 +36735,6 @@ Alex Baranezky,2018-Q4,0,0,0
 Alex Baranezky,2018-Q3,0,0,0
 Alex Baranezky,2018-Q2,0,0,0
 Alex Baranezky,2018-Q1,0,0,0
-Yi Wang,2021-Q4,0,0,0
-Yi Wang,2021-Q3,0,0,0
 Yi Wang,2021-Q2,0,0,0
 Yi Wang,2021-Q1,0,0,0
 Yi Wang,2020-Q4,0,0,0
@@ -41999,8 +36749,6 @@ Yi Wang,2018-Q4,0,0,0
 Yi Wang,2018-Q3,0,0,0
 Yi Wang,2018-Q2,0,0,0
 Yi Wang,2018-Q1,0,0,0
-Gyu-Ho Lee,2021-Q4,0,0,0
-Gyu-Ho Lee,2021-Q3,0,0,0
 Gyu-Ho Lee,2021-Q2,0,0,0
 Gyu-Ho Lee,2021-Q1,0,0,0
 Gyu-Ho Lee,2020-Q4,0,0,0
@@ -42015,8 +36763,6 @@ Gyu-Ho Lee,2018-Q4,0,0,0
 Gyu-Ho Lee,2018-Q3,0,0,0
 Gyu-Ho Lee,2018-Q2,0,0,0
 Gyu-Ho Lee,2018-Q1,0,0,0
-Richard S. Imaoka,2021-Q4,0,0,0
-Richard S. Imaoka,2021-Q3,0,0,0
 Richard S. Imaoka,2021-Q2,0,0,0
 Richard S. Imaoka,2021-Q1,0,0,0
 Richard S. Imaoka,2020-Q4,0,0,0
@@ -42031,8 +36777,6 @@ Richard S. Imaoka,2018-Q4,0,0,0
 Richard S. Imaoka,2018-Q3,0,0,0
 Richard S. Imaoka,2018-Q2,0,0,0
 Richard S. Imaoka,2018-Q1,0,0,0
-Humanity123,2021-Q4,0,0,0
-Humanity123,2021-Q3,0,0,0
 Humanity123,2021-Q2,0,0,0
 Humanity123,2021-Q1,0,0,0
 Humanity123,2020-Q4,0,0,0
@@ -42047,8 +36791,6 @@ Humanity123,2018-Q4,0,0,0
 Humanity123,2018-Q3,0,0,0
 Humanity123,2018-Q2,0,0,0
 Humanity123,2018-Q1,0,0,0
-Jing Jun Yin,2021-Q4,0,0,0
-Jing Jun Yin,2021-Q3,0,0,0
 Jing Jun Yin,2021-Q2,0,0,0
 Jing Jun Yin,2021-Q1,0,0,0
 Jing Jun Yin,2020-Q4,0,0,0
@@ -42063,8 +36805,6 @@ Jing Jun Yin,2018-Q4,0,0,0
 Jing Jun Yin,2018-Q3,0,0,0
 Jing Jun Yin,2018-Q2,0,0,0
 Jing Jun Yin,2018-Q1,0,0,0
-Zongheng Yang,2021-Q4,0,0,0
-Zongheng Yang,2021-Q3,0,0,0
 Zongheng Yang,2021-Q2,0,0,0
 Zongheng Yang,2021-Q1,0,0,0
 Zongheng Yang,2020-Q4,0,0,0
@@ -42079,8 +36819,6 @@ Zongheng Yang,2018-Q4,0,0,0
 Zongheng Yang,2018-Q3,0,0,0
 Zongheng Yang,2018-Q2,0,0,0
 Zongheng Yang,2018-Q1,0,0,0
-Daniel Cardenas,2021-Q4,0,0,0
-Daniel Cardenas,2021-Q3,0,0,0
 Daniel Cardenas,2021-Q2,0,0,0
 Daniel Cardenas,2021-Q1,0,0,0
 Daniel Cardenas,2020-Q4,0,0,0
@@ -42095,8 +36833,6 @@ Daniel Cardenas,2018-Q4,0,0,0
 Daniel Cardenas,2018-Q3,0,0,0
 Daniel Cardenas,2018-Q2,0,0,0
 Daniel Cardenas,2018-Q1,0,0,0
-preciousdp11,2021-Q4,0,0,0
-preciousdp11,2021-Q3,0,0,0
 preciousdp11,2021-Q2,0,0,0
 preciousdp11,2021-Q1,0,0,0
 preciousdp11,2020-Q4,0,0,0
@@ -42111,8 +36847,6 @@ preciousdp11,2018-Q4,0,0,0
 preciousdp11,2018-Q3,0,0,0
 preciousdp11,2018-Q2,0,0,0
 preciousdp11,2018-Q1,0,0,0
-magixsno,2021-Q4,0,0,0
-magixsno,2021-Q3,0,0,0
 magixsno,2021-Q2,0,0,0
 magixsno,2021-Q1,0,0,0
 magixsno,2020-Q4,0,0,0
@@ -42127,8 +36861,6 @@ magixsno,2018-Q4,0,0,0
 magixsno,2018-Q3,0,0,0
 magixsno,2018-Q2,0,0,0
 magixsno,2018-Q1,0,0,0
-Spotlight0xff,2021-Q4,0,0,0
-Spotlight0xff,2021-Q3,0,0,0
 Spotlight0xff,2021-Q2,0,0,0
 Spotlight0xff,2021-Q1,0,0,0
 Spotlight0xff,2020-Q4,0,0,0
@@ -42143,8 +36875,6 @@ Spotlight0xff,2018-Q4,0,0,0
 Spotlight0xff,2018-Q3,0,0,0
 Spotlight0xff,2018-Q2,0,0,0
 Spotlight0xff,2018-Q1,0,0,0
-Jianfei Wang,2021-Q4,0,0,0
-Jianfei Wang,2021-Q3,0,0,0
 Jianfei Wang,2021-Q2,0,0,0
 Jianfei Wang,2021-Q1,0,0,0
 Jianfei Wang,2020-Q4,0,0,0
@@ -42159,8 +36889,6 @@ Jianfei Wang,2018-Q4,0,0,0
 Jianfei Wang,2018-Q3,0,0,0
 Jianfei Wang,2018-Q2,0,0,0
 Jianfei Wang,2018-Q1,0,0,0
-ksellesk,2021-Q4,0,0,0
-ksellesk,2021-Q3,0,0,0
 ksellesk,2021-Q2,0,0,0
 ksellesk,2021-Q1,0,0,0
 ksellesk,2020-Q4,0,0,0
@@ -42175,8 +36903,6 @@ ksellesk,2018-Q4,0,0,0
 ksellesk,2018-Q3,0,0,0
 ksellesk,2018-Q2,0,0,0
 ksellesk,2018-Q1,0,0,0
-Yan (Asta) Li,2021-Q4,0,0,0
-Yan (Asta) Li,2021-Q3,0,0,0
 Yan (Asta) Li,2021-Q2,0,0,0
 Yan (Asta) Li,2021-Q1,0,0,0
 Yan (Asta) Li,2020-Q4,0,0,0
@@ -42191,8 +36917,6 @@ Yan (Asta) Li,2018-Q4,0,0,0
 Yan (Asta) Li,2018-Q3,0,0,0
 Yan (Asta) Li,2018-Q2,0,0,0
 Yan (Asta) Li,2018-Q1,0,0,0
-orome,2021-Q4,0,0,0
-orome,2021-Q3,0,0,0
 orome,2021-Q2,0,0,0
 orome,2021-Q1,0,0,0
 orome,2020-Q4,0,0,0
@@ -42207,8 +36931,6 @@ orome,2018-Q4,0,0,0
 orome,2018-Q3,0,0,0
 orome,2018-Q2,0,0,0
 orome,2018-Q1,0,0,0
-Wei Ho,2021-Q4,0,0,0
-Wei Ho,2021-Q3,0,0,0
 Wei Ho,2021-Q2,0,0,0
 Wei Ho,2021-Q1,0,0,0
 Wei Ho,2020-Q4,0,0,0
@@ -42223,8 +36945,6 @@ Wei Ho,2018-Q4,0,0,0
 Wei Ho,2018-Q3,0,0,0
 Wei Ho,2018-Q2,0,0,0
 Wei Ho,2018-Q1,0,0,0
-Joan Puigcerver,2021-Q4,0,0,0
-Joan Puigcerver,2021-Q3,0,0,0
 Joan Puigcerver,2021-Q2,0,0,0
 Joan Puigcerver,2021-Q1,0,0,0
 Joan Puigcerver,2020-Q4,0,0,0
@@ -42239,8 +36959,6 @@ Joan Puigcerver,2018-Q4,0,0,0
 Joan Puigcerver,2018-Q3,0,0,0
 Joan Puigcerver,2018-Q2,0,0,0
 Joan Puigcerver,2018-Q1,0,0,0
-Beomsu Kim,2021-Q4,0,0,0
-Beomsu Kim,2021-Q3,0,0,0
 Beomsu Kim,2021-Q2,0,0,0
 Beomsu Kim,2021-Q1,0,0,0
 Beomsu Kim,2020-Q4,0,0,0
@@ -42255,8 +36973,6 @@ Beomsu Kim,2018-Q4,0,0,0
 Beomsu Kim,2018-Q3,0,0,0
 Beomsu Kim,2018-Q2,0,0,0
 Beomsu Kim,2018-Q1,0,0,0
-Michał Jastrzębski,2021-Q4,0,0,0
-Michał Jastrzębski,2021-Q3,0,0,0
 Michał Jastrzębski,2021-Q2,0,0,0
 Michał Jastrzębski,2021-Q1,0,0,0
 Michał Jastrzębski,2020-Q4,0,0,0
@@ -42271,8 +36987,6 @@ Michał Jastrzębski,2018-Q4,0,0,0
 Michał Jastrzębski,2018-Q3,0,0,0
 Michał Jastrzębski,2018-Q2,0,0,0
 Michał Jastrzębski,2018-Q1,0,0,0
-Earthson Lu,2021-Q4,0,0,0
-Earthson Lu,2021-Q3,0,0,0
 Earthson Lu,2021-Q2,0,0,0
 Earthson Lu,2021-Q1,0,0,0
 Earthson Lu,2020-Q4,0,0,0
@@ -42287,8 +37001,6 @@ Earthson Lu,2018-Q4,0,0,0
 Earthson Lu,2018-Q3,0,0,0
 Earthson Lu,2018-Q2,0,0,0
 Earthson Lu,2018-Q1,0,0,0
-Christos Nikolaou,2021-Q4,0,0,0
-Christos Nikolaou,2021-Q3,0,0,0
 Christos Nikolaou,2021-Q2,0,0,0
 Christos Nikolaou,2021-Q1,0,0,0
 Christos Nikolaou,2020-Q4,0,0,0
@@ -42303,8 +37015,6 @@ Christos Nikolaou,2018-Q4,0,0,0
 Christos Nikolaou,2018-Q3,0,0,0
 Christos Nikolaou,2018-Q2,0,0,0
 Christos Nikolaou,2018-Q1,0,0,0
-Jon Malmaud,2021-Q4,0,0,0
-Jon Malmaud,2021-Q3,0,0,0
 Jon Malmaud,2021-Q2,0,0,0
 Jon Malmaud,2021-Q1,0,0,0
 Jon Malmaud,2020-Q4,0,0,0
@@ -42319,8 +37029,6 @@ Jon Malmaud,2018-Q4,0,0,0
 Jon Malmaud,2018-Q3,0,0,0
 Jon Malmaud,2018-Q2,0,0,0
 Jon Malmaud,2018-Q1,0,0,0
-Drew Hintz,2021-Q4,0,0,0
-Drew Hintz,2021-Q3,0,0,0
 Drew Hintz,2021-Q2,0,0,0
 Drew Hintz,2021-Q1,0,0,0
 Drew Hintz,2020-Q4,0,0,0
@@ -42335,8 +37043,6 @@ Drew Hintz,2018-Q4,0,0,0
 Drew Hintz,2018-Q3,0,0,0
 Drew Hintz,2018-Q2,0,0,0
 Drew Hintz,2018-Q1,0,0,0
-cxx,2021-Q4,0,0,0
-cxx,2021-Q3,0,0,0
 cxx,2021-Q2,0,0,0
 cxx,2021-Q1,0,0,0
 cxx,2020-Q4,0,0,0
@@ -42351,8 +37057,6 @@ cxx,2018-Q4,0,0,0
 cxx,2018-Q3,0,0,0
 cxx,2018-Q2,0,0,0
 cxx,2018-Q1,0,0,0
-Yuan Yu,2021-Q4,0,0,0
-Yuan Yu,2021-Q3,0,0,0
 Yuan Yu,2021-Q2,0,0,0
 Yuan Yu,2021-Q1,0,0,0
 Yuan Yu,2020-Q4,0,0,0
@@ -42367,8 +37071,6 @@ Yuan Yu,2018-Q4,0,0,0
 Yuan Yu,2018-Q3,0,0,0
 Yuan Yu,2018-Q2,0,0,0
 Yuan Yu,2018-Q1,0,0,0
-My name is,2021-Q4,0,0,0
-My name is,2021-Q3,0,0,0
 My name is,2021-Q2,0,0,0
 My name is,2021-Q1,0,0,0
 My name is,2020-Q4,0,0,0
@@ -42383,8 +37085,6 @@ My name is,2018-Q4,0,0,0
 My name is,2018-Q3,0,0,0
 My name is,2018-Q2,0,0,0
 My name is,2018-Q1,0,0,0
-ddurham2,2021-Q4,0,0,0
-ddurham2,2021-Q3,0,0,0
 ddurham2,2021-Q2,0,0,0
 ddurham2,2021-Q1,0,0,0
 ddurham2,2020-Q4,0,0,0
@@ -42399,8 +37099,6 @@ ddurham2,2018-Q4,0,0,0
 ddurham2,2018-Q3,0,0,0
 ddurham2,2018-Q2,0,0,0
 ddurham2,2018-Q1,0,0,0
-Croath Liu,2021-Q4,0,0,0
-Croath Liu,2021-Q3,0,0,0
 Croath Liu,2021-Q2,0,0,0
 Croath Liu,2021-Q1,0,0,0
 Croath Liu,2020-Q4,0,0,0
@@ -42415,8 +37113,6 @@ Croath Liu,2018-Q4,0,0,0
 Croath Liu,2018-Q3,0,0,0
 Croath Liu,2018-Q2,0,0,0
 Croath Liu,2018-Q1,0,0,0
-Xiang Gao,2021-Q4,0,0,0
-Xiang Gao,2021-Q3,0,0,0
 Xiang Gao,2021-Q2,0,0,0
 Xiang Gao,2021-Q1,0,0,0
 Xiang Gao,2020-Q4,0,0,0
@@ -42431,8 +37127,6 @@ Xiang Gao,2018-Q4,0,0,0
 Xiang Gao,2018-Q3,0,0,0
 Xiang Gao,2018-Q2,0,0,0
 Xiang Gao,2018-Q1,0,0,0
-Shitian Ni,2021-Q4,0,0,0
-Shitian Ni,2021-Q3,0,0,0
 Shitian Ni,2021-Q2,0,0,0
 Shitian Ni,2021-Q1,0,0,0
 Shitian Ni,2020-Q4,0,0,0
@@ -42447,8 +37141,6 @@ Shitian Ni,2018-Q4,0,0,0
 Shitian Ni,2018-Q3,0,0,0
 Shitian Ni,2018-Q2,0,0,0
 Shitian Ni,2018-Q1,0,0,0
-Ryan Kung,2021-Q4,0,0,0
-Ryan Kung,2021-Q3,0,0,0
 Ryan Kung,2021-Q2,0,0,0
 Ryan Kung,2021-Q1,0,0,0
 Ryan Kung,2020-Q4,0,0,0
@@ -42463,8 +37155,6 @@ Ryan Kung,2018-Q4,0,0,0
 Ryan Kung,2018-Q3,0,0,0
 Ryan Kung,2018-Q2,0,0,0
 Ryan Kung,2018-Q1,0,0,0
-Maciek Chociej,2021-Q4,0,0,0
-Maciek Chociej,2021-Q3,0,0,0
 Maciek Chociej,2021-Q2,0,0,0
 Maciek Chociej,2021-Q1,0,0,0
 Maciek Chociej,2020-Q4,0,0,0
@@ -42479,8 +37169,6 @@ Maciek Chociej,2018-Q4,0,0,0
 Maciek Chociej,2018-Q3,0,0,0
 Maciek Chociej,2018-Q2,0,0,0
 Maciek Chociej,2018-Q1,0,0,0
-Benedikt Linse,2021-Q4,0,0,0
-Benedikt Linse,2021-Q3,0,0,0
 Benedikt Linse,2021-Q2,0,0,0
 Benedikt Linse,2021-Q1,0,0,0
 Benedikt Linse,2020-Q4,0,0,0
@@ -42495,8 +37183,6 @@ Benedikt Linse,2018-Q4,0,0,0
 Benedikt Linse,2018-Q3,0,0,0
 Benedikt Linse,2018-Q2,0,0,0
 Benedikt Linse,2018-Q1,0,0,0
-sgt101,2021-Q4,0,0,0
-sgt101,2021-Q3,0,0,0
 sgt101,2021-Q2,0,0,0
 sgt101,2021-Q1,0,0,0
 sgt101,2020-Q4,0,0,0
@@ -42511,8 +37197,6 @@ sgt101,2018-Q4,0,0,0
 sgt101,2018-Q3,0,0,0
 sgt101,2018-Q2,0,0,0
 sgt101,2018-Q1,0,0,0
-Fabian Winnen,2021-Q4,0,0,0
-Fabian Winnen,2021-Q3,0,0,0
 Fabian Winnen,2021-Q2,0,0,0
 Fabian Winnen,2021-Q1,0,0,0
 Fabian Winnen,2020-Q4,0,0,0
@@ -42527,8 +37211,6 @@ Fabian Winnen,2018-Q4,0,0,0
 Fabian Winnen,2018-Q3,0,0,0
 Fabian Winnen,2018-Q2,0,0,0
 Fabian Winnen,2018-Q1,0,0,0
-b1rd,2021-Q4,0,0,0
-b1rd,2021-Q3,0,0,0
 b1rd,2021-Q2,0,0,0
 b1rd,2021-Q1,0,0,0
 b1rd,2020-Q4,0,0,0
@@ -42543,8 +37225,6 @@ b1rd,2018-Q4,0,0,0
 b1rd,2018-Q3,0,0,0
 b1rd,2018-Q2,0,0,0
 b1rd,2018-Q1,0,0,0
-Nelson Liu,2021-Q4,0,0,0
-Nelson Liu,2021-Q3,0,0,0
 Nelson Liu,2021-Q2,0,0,0
 Nelson Liu,2021-Q1,0,0,0
 Nelson Liu,2020-Q4,0,0,0
@@ -42559,8 +37239,6 @@ Nelson Liu,2018-Q4,0,0,0
 Nelson Liu,2018-Q3,0,0,0
 Nelson Liu,2018-Q2,0,0,0
 Nelson Liu,2018-Q1,0,0,0
-Czxck001,2021-Q4,0,0,0
-Czxck001,2021-Q3,0,0,0
 Czxck001,2021-Q2,0,0,0
 Czxck001,2021-Q1,0,0,0
 Czxck001,2020-Q4,0,0,0
@@ -42575,8 +37253,6 @@ Czxck001,2018-Q4,0,0,0
 Czxck001,2018-Q3,0,0,0
 Czxck001,2018-Q2,0,0,0
 Czxck001,2018-Q1,0,0,0
-David Brailovsky,2021-Q4,0,0,0
-David Brailovsky,2021-Q3,0,0,0
 David Brailovsky,2021-Q2,0,0,0
 David Brailovsky,2021-Q1,0,0,0
 David Brailovsky,2020-Q4,0,0,0
@@ -42591,8 +37267,6 @@ David Brailovsky,2018-Q4,0,0,0
 David Brailovsky,2018-Q3,0,0,0
 David Brailovsky,2018-Q2,0,0,0
 David Brailovsky,2018-Q1,0,0,0
-zhengjiajin,2021-Q4,0,0,0
-zhengjiajin,2021-Q3,0,0,0
 zhengjiajin,2021-Q2,0,0,0
 zhengjiajin,2021-Q1,0,0,0
 zhengjiajin,2020-Q4,0,0,0
@@ -42607,8 +37281,6 @@ zhengjiajin,2018-Q4,0,0,0
 zhengjiajin,2018-Q3,0,0,0
 zhengjiajin,2018-Q2,0,0,0
 zhengjiajin,2018-Q1,0,0,0
-ethiraj,2021-Q4,0,0,0
-ethiraj,2021-Q3,0,0,0
 ethiraj,2021-Q2,0,0,0
 ethiraj,2021-Q1,0,0,0
 ethiraj,2020-Q4,0,0,0
@@ -42623,8 +37295,6 @@ ethiraj,2018-Q4,0,0,0
 ethiraj,2018-Q3,0,0,0
 ethiraj,2018-Q2,0,0,0
 ethiraj,2018-Q1,0,0,0
-Steffen Eberbach,2021-Q4,0,0,0
-Steffen Eberbach,2021-Q3,0,0,0
 Steffen Eberbach,2021-Q2,0,0,0
 Steffen Eberbach,2021-Q1,0,0,0
 Steffen Eberbach,2020-Q4,0,0,0
@@ -42639,8 +37309,6 @@ Steffen Eberbach,2018-Q4,0,0,0
 Steffen Eberbach,2018-Q3,0,0,0
 Steffen Eberbach,2018-Q2,0,0,0
 Steffen Eberbach,2018-Q1,0,0,0
-mouradmourafiq,2021-Q4,0,0,0
-mouradmourafiq,2021-Q3,0,0,0
 mouradmourafiq,2021-Q2,0,0,0
 mouradmourafiq,2021-Q1,0,0,0
 mouradmourafiq,2020-Q4,0,0,0
@@ -42655,8 +37323,6 @@ mouradmourafiq,2018-Q4,0,0,0
 mouradmourafiq,2018-Q3,0,0,0
 mouradmourafiq,2018-Q2,0,0,0
 mouradmourafiq,2018-Q1,0,0,0
-SOLARIS,2021-Q4,0,0,0
-SOLARIS,2021-Q3,0,0,0
 SOLARIS,2021-Q2,0,0,0
 SOLARIS,2021-Q1,0,0,0
 SOLARIS,2020-Q4,0,0,0
@@ -42671,8 +37337,6 @@ SOLARIS,2018-Q4,0,0,0
 SOLARIS,2018-Q3,0,0,0
 SOLARIS,2018-Q2,0,0,0
 SOLARIS,2018-Q1,0,0,0
-Ali Siddiqui,2021-Q4,0,0,0
-Ali Siddiqui,2021-Q3,0,0,0
 Ali Siddiqui,2021-Q2,0,0,0
 Ali Siddiqui,2021-Q1,0,0,0
 Ali Siddiqui,2020-Q4,0,0,0
@@ -42687,8 +37351,6 @@ Ali Siddiqui,2018-Q4,0,0,0
 Ali Siddiqui,2018-Q3,0,0,0
 Ali Siddiqui,2018-Q2,0,0,0
 Ali Siddiqui,2018-Q1,0,0,0
-Andreas Solleder,2021-Q4,0,0,0
-Andreas Solleder,2021-Q3,0,0,0
 Andreas Solleder,2021-Q2,0,0,0
 Andreas Solleder,2021-Q1,0,0,0
 Andreas Solleder,2020-Q4,0,0,0
@@ -42703,8 +37365,6 @@ Andreas Solleder,2018-Q4,0,0,0
 Andreas Solleder,2018-Q3,0,0,0
 Andreas Solleder,2018-Q2,0,0,0
 Andreas Solleder,2018-Q1,0,0,0
-4F2E4A2E,2021-Q4,0,0,0
-4F2E4A2E,2021-Q3,0,0,0
 4F2E4A2E,2021-Q2,0,0,0
 4F2E4A2E,2021-Q1,0,0,0
 4F2E4A2E,2020-Q4,0,0,0
@@ -42719,8 +37379,6 @@ Andreas Solleder,2018-Q1,0,0,0
 4F2E4A2E,2018-Q3,0,0,0
 4F2E4A2E,2018-Q2,0,0,0
 4F2E4A2E,2018-Q1,0,0,0
-peeyush18,2021-Q4,0,0,0
-peeyush18,2021-Q3,0,0,0
 peeyush18,2021-Q2,0,0,0
 peeyush18,2021-Q1,0,0,0
 peeyush18,2020-Q4,0,0,0
@@ -42735,8 +37393,6 @@ peeyush18,2018-Q4,0,0,0
 peeyush18,2018-Q3,0,0,0
 peeyush18,2018-Q2,0,0,0
 peeyush18,2018-Q1,0,0,0
-ispirmustafa,2021-Q4,0,0,0
-ispirmustafa,2021-Q3,0,0,0
 ispirmustafa,2021-Q2,0,0,0
 ispirmustafa,2021-Q1,0,0,0
 ispirmustafa,2020-Q4,0,0,0
@@ -42751,8 +37407,6 @@ ispirmustafa,2018-Q4,0,0,0
 ispirmustafa,2018-Q3,0,0,0
 ispirmustafa,2018-Q2,0,0,0
 ispirmustafa,2018-Q1,0,0,0
-Kevin Carbone,2021-Q4,0,0,0
-Kevin Carbone,2021-Q3,0,0,0
 Kevin Carbone,2021-Q2,0,0,0
 Kevin Carbone,2021-Q1,0,0,0
 Kevin Carbone,2020-Q4,0,0,0
@@ -42767,8 +37421,6 @@ Kevin Carbone,2018-Q4,0,0,0
 Kevin Carbone,2018-Q3,0,0,0
 Kevin Carbone,2018-Q2,0,0,0
 Kevin Carbone,2018-Q1,0,0,0
-Neeraj Kashyap,2021-Q4,0,0,0
-Neeraj Kashyap,2021-Q3,0,0,0
 Neeraj Kashyap,2021-Q2,0,0,0
 Neeraj Kashyap,2021-Q1,0,0,0
 Neeraj Kashyap,2020-Q4,0,0,0
@@ -42783,8 +37435,6 @@ Neeraj Kashyap,2018-Q4,0,0,0
 Neeraj Kashyap,2018-Q3,0,0,0
 Neeraj Kashyap,2018-Q2,0,0,0
 Neeraj Kashyap,2018-Q1,0,0,0
-Adrià Arrufat,2021-Q4,0,0,0
-Adrià Arrufat,2021-Q3,0,0,0
 Adrià Arrufat,2021-Q2,0,0,0
 Adrià Arrufat,2021-Q1,0,0,0
 Adrià Arrufat,2020-Q4,0,0,0
@@ -42799,8 +37449,6 @@ Adrià Arrufat,2018-Q4,0,0,0
 Adrià Arrufat,2018-Q3,0,0,0
 Adrià Arrufat,2018-Q2,0,0,0
 Adrià Arrufat,2018-Q1,0,0,0
-Robert Walecki,2021-Q4,0,0,0
-Robert Walecki,2021-Q3,0,0,0
 Robert Walecki,2021-Q2,0,0,0
 Robert Walecki,2021-Q1,0,0,0
 Robert Walecki,2020-Q4,0,0,0
@@ -42815,8 +37463,6 @@ Robert Walecki,2018-Q4,0,0,0
 Robert Walecki,2018-Q3,0,0,0
 Robert Walecki,2018-Q2,0,0,0
 Robert Walecki,2018-Q1,0,0,0
-Johannes Mayer,2021-Q4,0,0,0
-Johannes Mayer,2021-Q3,0,0,0
 Johannes Mayer,2021-Q2,0,0,0
 Johannes Mayer,2021-Q1,0,0,0
 Johannes Mayer,2020-Q4,0,0,0
@@ -42831,8 +37477,6 @@ Johannes Mayer,2018-Q4,0,0,0
 Johannes Mayer,2018-Q3,0,0,0
 Johannes Mayer,2018-Q2,0,0,0
 Johannes Mayer,2018-Q1,0,0,0
-Jonathan Alvarez-Gutierrez,2021-Q4,0,0,0
-Jonathan Alvarez-Gutierrez,2021-Q3,0,0,0
 Jonathan Alvarez-Gutierrez,2021-Q2,0,0,0
 Jonathan Alvarez-Gutierrez,2021-Q1,0,0,0
 Jonathan Alvarez-Gutierrez,2020-Q4,0,0,0
@@ -42847,8 +37491,6 @@ Jonathan Alvarez-Gutierrez,2018-Q4,0,0,0
 Jonathan Alvarez-Gutierrez,2018-Q3,0,0,0
 Jonathan Alvarez-Gutierrez,2018-Q2,0,0,0
 Jonathan Alvarez-Gutierrez,2018-Q1,0,0,0
-Corey Wharton,2021-Q4,0,0,0
-Corey Wharton,2021-Q3,0,0,0
 Corey Wharton,2021-Q2,0,0,0
 Corey Wharton,2021-Q1,0,0,0
 Corey Wharton,2020-Q4,0,0,0
@@ -42863,8 +37505,6 @@ Corey Wharton,2018-Q4,0,0,0
 Corey Wharton,2018-Q3,0,0,0
 Corey Wharton,2018-Q2,0,0,0
 Corey Wharton,2018-Q1,0,0,0
-krivard,2021-Q4,0,0,0
-krivard,2021-Q3,0,0,0
 krivard,2021-Q2,0,0,0
 krivard,2021-Q1,0,0,0
 krivard,2020-Q4,0,0,0
@@ -42879,8 +37519,6 @@ krivard,2018-Q4,0,0,0
 krivard,2018-Q3,0,0,0
 krivard,2018-Q2,0,0,0
 krivard,2018-Q1,0,0,0
-Mathew Wicks,2021-Q4,0,0,0
-Mathew Wicks,2021-Q3,0,0,0
 Mathew Wicks,2021-Q2,0,0,0
 Mathew Wicks,2021-Q1,0,0,0
 Mathew Wicks,2020-Q4,0,0,0
@@ -42895,8 +37533,6 @@ Mathew Wicks,2018-Q4,0,0,0
 Mathew Wicks,2018-Q3,0,0,0
 Mathew Wicks,2018-Q2,0,0,0
 Mathew Wicks,2018-Q1,0,0,0
-Ikaro Silva,2021-Q4,0,0,0
-Ikaro Silva,2021-Q3,0,0,0
 Ikaro Silva,2021-Q2,0,0,0
 Ikaro Silva,2021-Q1,0,0,0
 Ikaro Silva,2020-Q4,0,0,0
@@ -42911,8 +37547,6 @@ Ikaro Silva,2018-Q4,0,0,0
 Ikaro Silva,2018-Q3,0,0,0
 Ikaro Silva,2018-Q2,0,0,0
 Ikaro Silva,2018-Q1,0,0,0
-Leandro Gracia Gil,2021-Q4,0,0,0
-Leandro Gracia Gil,2021-Q3,0,0,0
 Leandro Gracia Gil,2021-Q2,0,0,0
 Leandro Gracia Gil,2021-Q1,0,0,0
 Leandro Gracia Gil,2020-Q4,0,0,0
@@ -42927,8 +37561,6 @@ Leandro Gracia Gil,2018-Q4,0,0,0
 Leandro Gracia Gil,2018-Q3,0,0,0
 Leandro Gracia Gil,2018-Q2,0,0,0
 Leandro Gracia Gil,2018-Q1,0,0,0
-Raingo,2021-Q4,0,0,0
-Raingo,2021-Q3,0,0,0
 Raingo,2021-Q2,0,0,0
 Raingo,2021-Q1,0,0,0
 Raingo,2020-Q4,0,0,0
@@ -42943,8 +37575,6 @@ Raingo,2018-Q4,0,0,0
 Raingo,2018-Q3,0,0,0
 Raingo,2018-Q2,0,0,0
 Raingo,2018-Q1,0,0,0
-Mark Wong,2021-Q4,0,0,0
-Mark Wong,2021-Q3,0,0,0
 Mark Wong,2021-Q2,0,0,0
 Mark Wong,2021-Q1,0,0,0
 Mark Wong,2020-Q4,0,0,0
@@ -42959,8 +37589,6 @@ Mark Wong,2018-Q4,0,0,0
 Mark Wong,2018-Q3,0,0,0
 Mark Wong,2018-Q2,0,0,0
 Mark Wong,2018-Q1,0,0,0
-Scott Sievert,2021-Q4,0,0,0
-Scott Sievert,2021-Q3,0,0,0
 Scott Sievert,2021-Q2,0,0,0
 Scott Sievert,2021-Q1,0,0,0
 Scott Sievert,2020-Q4,0,0,0
@@ -42975,8 +37603,6 @@ Scott Sievert,2018-Q4,0,0,0
 Scott Sievert,2018-Q3,0,0,0
 Scott Sievert,2018-Q2,0,0,0
 Scott Sievert,2018-Q1,0,0,0
-Ido Shamay,2021-Q4,0,0,0
-Ido Shamay,2021-Q3,0,0,0
 Ido Shamay,2021-Q2,0,0,0
 Ido Shamay,2021-Q1,0,0,0
 Ido Shamay,2020-Q4,0,0,0
@@ -42991,8 +37617,6 @@ Ido Shamay,2018-Q4,0,0,0
 Ido Shamay,2018-Q3,0,0,0
 Ido Shamay,2018-Q2,0,0,0
 Ido Shamay,2018-Q1,0,0,0
-Piyush Chaudhary,2021-Q4,0,0,0
-Piyush Chaudhary,2021-Q3,0,0,0
 Piyush Chaudhary,2021-Q2,0,0,0
 Piyush Chaudhary,2021-Q1,0,0,0
 Piyush Chaudhary,2020-Q4,0,0,0
@@ -43007,8 +37631,6 @@ Piyush Chaudhary,2018-Q4,0,0,0
 Piyush Chaudhary,2018-Q3,0,0,0
 Piyush Chaudhary,2018-Q2,0,0,0
 Piyush Chaudhary,2018-Q1,0,0,0
-Junwei Pan,2021-Q4,0,0,0
-Junwei Pan,2021-Q3,0,0,0
 Junwei Pan,2021-Q2,0,0,0
 Junwei Pan,2021-Q1,0,0,0
 Junwei Pan,2020-Q4,0,0,0
@@ -43023,8 +37645,6 @@ Junwei Pan,2018-Q4,0,0,0
 Junwei Pan,2018-Q3,0,0,0
 Junwei Pan,2018-Q2,0,0,0
 Junwei Pan,2018-Q1,0,0,0
-Elliot Saba,2021-Q4,0,0,0
-Elliot Saba,2021-Q3,0,0,0
 Elliot Saba,2021-Q2,0,0,0
 Elliot Saba,2021-Q1,0,0,0
 Elliot Saba,2020-Q4,0,0,0
@@ -43039,8 +37659,6 @@ Elliot Saba,2018-Q4,0,0,0
 Elliot Saba,2018-Q3,0,0,0
 Elliot Saba,2018-Q2,0,0,0
 Elliot Saba,2018-Q1,0,0,0
-Xiaolin Lin,2021-Q4,0,0,0
-Xiaolin Lin,2021-Q3,0,0,0
 Xiaolin Lin,2021-Q2,0,0,0
 Xiaolin Lin,2021-Q1,0,0,0
 Xiaolin Lin,2020-Q4,0,0,0
@@ -43055,8 +37673,6 @@ Xiaolin Lin,2018-Q4,0,0,0
 Xiaolin Lin,2018-Q3,0,0,0
 Xiaolin Lin,2018-Q2,0,0,0
 Xiaolin Lin,2018-Q1,0,0,0
-Mortada Mehyar,2021-Q4,0,0,0
-Mortada Mehyar,2021-Q3,0,0,0
 Mortada Mehyar,2021-Q2,0,0,0
 Mortada Mehyar,2021-Q1,0,0,0
 Mortada Mehyar,2020-Q4,0,0,0
@@ -43071,8 +37687,6 @@ Mortada Mehyar,2018-Q4,0,0,0
 Mortada Mehyar,2018-Q3,0,0,0
 Mortada Mehyar,2018-Q2,0,0,0
 Mortada Mehyar,2018-Q1,0,0,0
-Sanders Kleinfeld,2021-Q4,0,0,0
-Sanders Kleinfeld,2021-Q3,0,0,0
 Sanders Kleinfeld,2021-Q2,0,0,0
 Sanders Kleinfeld,2021-Q1,0,0,0
 Sanders Kleinfeld,2020-Q4,0,0,0
@@ -43087,8 +37701,6 @@ Sanders Kleinfeld,2018-Q4,0,0,0
 Sanders Kleinfeld,2018-Q3,0,0,0
 Sanders Kleinfeld,2018-Q2,0,0,0
 Sanders Kleinfeld,2018-Q1,0,0,0
-Chris,2021-Q4,0,0,0
-Chris,2021-Q3,0,0,0
 Chris,2021-Q2,0,0,0
 Chris,2021-Q1,0,0,0
 Chris,2020-Q4,0,0,0
@@ -43103,8 +37715,6 @@ Chris,2018-Q4,0,0,0
 Chris,2018-Q3,0,0,0
 Chris,2018-Q2,0,0,0
 Chris,2018-Q1,0,0,0
-Zader Zheng,2021-Q4,0,0,0
-Zader Zheng,2021-Q3,0,0,0
 Zader Zheng,2021-Q2,0,0,0
 Zader Zheng,2021-Q1,0,0,0
 Zader Zheng,2020-Q4,0,0,0
@@ -43119,8 +37729,6 @@ Zader Zheng,2018-Q4,0,0,0
 Zader Zheng,2018-Q3,0,0,0
 Zader Zheng,2018-Q2,0,0,0
 Zader Zheng,2018-Q1,0,0,0
-Jonghoon Jin,2021-Q4,0,0,0
-Jonghoon Jin,2021-Q3,0,0,0
 Jonghoon Jin,2021-Q2,0,0,0
 Jonghoon Jin,2021-Q1,0,0,0
 Jonghoon Jin,2020-Q4,0,0,0
@@ -43135,8 +37743,6 @@ Jonghoon Jin,2018-Q4,0,0,0
 Jonghoon Jin,2018-Q3,0,0,0
 Jonghoon Jin,2018-Q2,0,0,0
 Jonghoon Jin,2018-Q1,0,0,0
-Kwotsin,2021-Q4,0,0,0
-Kwotsin,2021-Q3,0,0,0
 Kwotsin,2021-Q2,0,0,0
 Kwotsin,2021-Q1,0,0,0
 Kwotsin,2020-Q4,0,0,0
@@ -43151,8 +37757,6 @@ Kwotsin,2018-Q4,0,0,0
 Kwotsin,2018-Q3,0,0,0
 Kwotsin,2018-Q2,0,0,0
 Kwotsin,2018-Q1,0,0,0
-Oleksii Kuchaiev,2021-Q4,0,0,0
-Oleksii Kuchaiev,2021-Q3,0,0,0
 Oleksii Kuchaiev,2021-Q2,0,0,0
 Oleksii Kuchaiev,2021-Q1,0,0,0
 Oleksii Kuchaiev,2020-Q4,0,0,0
@@ -43167,8 +37771,6 @@ Oleksii Kuchaiev,2018-Q4,0,0,0
 Oleksii Kuchaiev,2018-Q3,0,0,0
 Oleksii Kuchaiev,2018-Q2,0,0,0
 Oleksii Kuchaiev,2018-Q1,0,0,0
-wuhaixutab,2021-Q4,0,0,0
-wuhaixutab,2021-Q3,0,0,0
 wuhaixutab,2021-Q2,0,0,0
 wuhaixutab,2021-Q1,0,0,0
 wuhaixutab,2020-Q4,0,0,0
@@ -43183,8 +37785,6 @@ wuhaixutab,2018-Q4,0,0,0
 wuhaixutab,2018-Q3,0,0,0
 wuhaixutab,2018-Q2,0,0,0
 wuhaixutab,2018-Q1,0,0,0
-Shane,2021-Q4,0,0,0
-Shane,2021-Q3,0,0,0
 Shane,2021-Q2,0,0,0
 Shane,2021-Q1,0,0,0
 Shane,2020-Q4,0,0,0
@@ -43199,8 +37799,6 @@ Shane,2018-Q4,0,0,0
 Shane,2018-Q3,0,0,0
 Shane,2018-Q2,0,0,0
 Shane,2018-Q1,0,0,0
-Aaron Schumacher,2021-Q4,0,0,0
-Aaron Schumacher,2021-Q3,0,0,0
 Aaron Schumacher,2021-Q2,0,0,0
 Aaron Schumacher,2021-Q1,0,0,0
 Aaron Schumacher,2020-Q4,0,0,0
@@ -43215,8 +37813,6 @@ Aaron Schumacher,2018-Q4,0,0,0
 Aaron Schumacher,2018-Q3,0,0,0
 Aaron Schumacher,2018-Q2,0,0,0
 Aaron Schumacher,2018-Q1,0,0,0
-Alex Egg,2021-Q4,0,0,0
-Alex Egg,2021-Q3,0,0,0
 Alex Egg,2021-Q2,0,0,0
 Alex Egg,2021-Q1,0,0,0
 Alex Egg,2020-Q4,0,0,0
@@ -43231,8 +37827,6 @@ Alex Egg,2018-Q4,0,0,0
 Alex Egg,2018-Q3,0,0,0
 Alex Egg,2018-Q2,0,0,0
 Alex Egg,2018-Q1,0,0,0
-Sam Abrahams,2021-Q4,0,0,0
-Sam Abrahams,2021-Q3,0,0,0
 Sam Abrahams,2021-Q2,0,0,0
 Sam Abrahams,2021-Q1,0,0,0
 Sam Abrahams,2020-Q4,0,0,0
@@ -43247,8 +37841,6 @@ Sam Abrahams,2018-Q4,0,0,0
 Sam Abrahams,2018-Q3,0,0,0
 Sam Abrahams,2018-Q2,0,0,0
 Sam Abrahams,2018-Q1,0,0,0
-weipingpku,2021-Q4,0,0,0
-weipingpku,2021-Q3,0,0,0
 weipingpku,2021-Q2,0,0,0
 weipingpku,2021-Q1,0,0,0
 weipingpku,2020-Q4,0,0,0
@@ -43263,8 +37855,6 @@ weipingpku,2018-Q4,0,0,0
 weipingpku,2018-Q3,0,0,0
 weipingpku,2018-Q2,0,0,0
 weipingpku,2018-Q1,0,0,0
-Arno Leist,2021-Q4,0,0,0
-Arno Leist,2021-Q3,0,0,0
 Arno Leist,2021-Q2,0,0,0
 Arno Leist,2021-Q1,0,0,0
 Arno Leist,2020-Q4,0,0,0
@@ -43279,8 +37869,6 @@ Arno Leist,2018-Q4,0,0,0
 Arno Leist,2018-Q3,0,0,0
 Arno Leist,2018-Q2,0,0,0
 Arno Leist,2018-Q1,0,0,0
-Dalei Li,2021-Q4,0,0,0
-Dalei Li,2021-Q3,0,0,0
 Dalei Li,2021-Q2,0,0,0
 Dalei Li,2021-Q1,0,0,0
 Dalei Li,2020-Q4,0,0,0
@@ -43295,8 +37883,6 @@ Dalei Li,2018-Q4,0,0,0
 Dalei Li,2018-Q3,0,0,0
 Dalei Li,2018-Q2,0,0,0
 Dalei Li,2018-Q1,0,0,0
-Cassandra Xia,2021-Q4,0,0,0
-Cassandra Xia,2021-Q3,0,0,0
 Cassandra Xia,2021-Q2,0,0,0
 Cassandra Xia,2021-Q1,0,0,0
 Cassandra Xia,2020-Q4,0,0,0
@@ -43311,8 +37897,6 @@ Cassandra Xia,2018-Q4,0,0,0
 Cassandra Xia,2018-Q3,0,0,0
 Cassandra Xia,2018-Q2,0,0,0
 Cassandra Xia,2018-Q1,0,0,0
-Julian Villella,2021-Q4,0,0,0
-Julian Villella,2021-Q3,0,0,0
 Julian Villella,2021-Q2,0,0,0
 Julian Villella,2021-Q1,0,0,0
 Julian Villella,2020-Q4,0,0,0
@@ -43327,8 +37911,6 @@ Julian Villella,2018-Q4,0,0,0
 Julian Villella,2018-Q3,0,0,0
 Julian Villella,2018-Q2,0,0,0
 Julian Villella,2018-Q1,0,0,0
-Jun Kim,2021-Q4,0,0,0
-Jun Kim,2021-Q3,0,0,0
 Jun Kim,2021-Q2,0,0,0
 Jun Kim,2021-Q1,0,0,0
 Jun Kim,2020-Q4,0,0,0
@@ -43343,8 +37925,6 @@ Jun Kim,2018-Q4,0,0,0
 Jun Kim,2018-Q3,0,0,0
 Jun Kim,2018-Q2,0,0,0
 Jun Kim,2018-Q1,0,0,0
-Michael Hofmann,2021-Q4,0,0,0
-Michael Hofmann,2021-Q3,0,0,0
 Michael Hofmann,2021-Q2,0,0,0
 Michael Hofmann,2021-Q1,0,0,0
 Michael Hofmann,2020-Q4,0,0,0
@@ -43359,8 +37939,6 @@ Michael Hofmann,2018-Q4,0,0,0
 Michael Hofmann,2018-Q3,0,0,0
 Michael Hofmann,2018-Q2,0,0,0
 Michael Hofmann,2018-Q1,0,0,0
-Falcon Dai,2021-Q4,0,0,0
-Falcon Dai,2021-Q3,0,0,0
 Falcon Dai,2021-Q2,0,0,0
 Falcon Dai,2021-Q1,0,0,0
 Falcon Dai,2020-Q4,0,0,0
@@ -43375,8 +37953,6 @@ Falcon Dai,2018-Q4,0,0,0
 Falcon Dai,2018-Q3,0,0,0
 Falcon Dai,2018-Q2,0,0,0
 Falcon Dai,2018-Q1,0,0,0
-Neven Miculinic,2021-Q4,0,0,0
-Neven Miculinic,2021-Q3,0,0,0
 Neven Miculinic,2021-Q2,0,0,0
 Neven Miculinic,2021-Q1,0,0,0
 Neven Miculinic,2020-Q4,0,0,0
@@ -43391,8 +37967,6 @@ Neven Miculinic,2018-Q4,0,0,0
 Neven Miculinic,2018-Q3,0,0,0
 Neven Miculinic,2018-Q2,0,0,0
 Neven Miculinic,2018-Q1,0,0,0
-Jamie Cooke,2021-Q4,0,0,0
-Jamie Cooke,2021-Q3,0,0,0
 Jamie Cooke,2021-Q2,0,0,0
 Jamie Cooke,2021-Q1,0,0,0
 Jamie Cooke,2020-Q4,0,0,0
@@ -43407,8 +37981,6 @@ Jamie Cooke,2018-Q4,0,0,0
 Jamie Cooke,2018-Q3,0,0,0
 Jamie Cooke,2018-Q2,0,0,0
 Jamie Cooke,2018-Q1,0,0,0
-Sebastian Schlecht,2021-Q4,0,0,0
-Sebastian Schlecht,2021-Q3,0,0,0
 Sebastian Schlecht,2021-Q2,0,0,0
 Sebastian Schlecht,2021-Q1,0,0,0
 Sebastian Schlecht,2020-Q4,0,0,0
@@ -43423,8 +37995,6 @@ Sebastian Schlecht,2018-Q4,0,0,0
 Sebastian Schlecht,2018-Q3,0,0,0
 Sebastian Schlecht,2018-Q2,0,0,0
 Sebastian Schlecht,2018-Q1,0,0,0
-Nghia Tran,2021-Q4,0,0,0
-Nghia Tran,2021-Q3,0,0,0
 Nghia Tran,2021-Q2,0,0,0
 Nghia Tran,2021-Q1,0,0,0
 Nghia Tran,2020-Q4,0,0,0
@@ -43439,8 +38009,6 @@ Nghia Tran,2018-Q4,0,0,0
 Nghia Tran,2018-Q3,0,0,0
 Nghia Tran,2018-Q2,0,0,0
 Nghia Tran,2018-Q1,0,0,0
-Li Chen,2021-Q4,0,0,0
-Li Chen,2021-Q3,0,0,0
 Li Chen,2021-Q2,0,0,0
 Li Chen,2021-Q1,0,0,0
 Li Chen,2020-Q4,0,0,0
@@ -43455,8 +38023,6 @@ Li Chen,2018-Q4,0,0,0
 Li Chen,2018-Q3,0,0,0
 Li Chen,2018-Q2,0,0,0
 Li Chen,2018-Q1,0,0,0
-Zakaria Haque,2021-Q4,0,0,0
-Zakaria Haque,2021-Q3,0,0,0
 Zakaria Haque,2021-Q2,0,0,0
 Zakaria Haque,2021-Q1,0,0,0
 Zakaria Haque,2020-Q4,0,0,0
@@ -43471,8 +38037,6 @@ Zakaria Haque,2018-Q4,0,0,0
 Zakaria Haque,2018-Q3,0,0,0
 Zakaria Haque,2018-Q2,0,0,0
 Zakaria Haque,2018-Q1,0,0,0
-Miguel Flores Ruiz de Eguino,2021-Q4,0,0,0
-Miguel Flores Ruiz de Eguino,2021-Q3,0,0,0
 Miguel Flores Ruiz de Eguino,2021-Q2,0,0,0
 Miguel Flores Ruiz de Eguino,2021-Q1,0,0,0
 Miguel Flores Ruiz de Eguino,2020-Q4,0,0,0
@@ -43487,8 +38051,6 @@ Miguel Flores Ruiz de Eguino,2018-Q4,0,0,0
 Miguel Flores Ruiz de Eguino,2018-Q3,0,0,0
 Miguel Flores Ruiz de Eguino,2018-Q2,0,0,0
 Miguel Flores Ruiz de Eguino,2018-Q1,0,0,0
-Darío Hereñú,2021-Q4,0,0,0
-Darío Hereñú,2021-Q3,0,0,0
 Darío Hereñú,2021-Q2,0,0,0
 Darío Hereñú,2021-Q1,0,0,0
 Darío Hereñú,2020-Q4,0,0,0
@@ -43503,8 +38065,6 @@ Darío Hereñú,2018-Q4,0,0,0
 Darío Hereñú,2018-Q3,0,0,0
 Darío Hereñú,2018-Q2,0,0,0
 Darío Hereñú,2018-Q1,0,0,0
-GBLin5566,2021-Q4,0,0,0
-GBLin5566,2021-Q3,0,0,0
 GBLin5566,2021-Q2,0,0,0
 GBLin5566,2021-Q1,0,0,0
 GBLin5566,2020-Q4,0,0,0
@@ -43519,8 +38079,6 @@ GBLin5566,2018-Q4,0,0,0
 GBLin5566,2018-Q3,0,0,0
 GBLin5566,2018-Q2,0,0,0
 GBLin5566,2018-Q1,0,0,0
-David Eng,2021-Q4,0,0,0
-David Eng,2021-Q3,0,0,0
 David Eng,2021-Q2,0,0,0
 David Eng,2021-Q1,0,0,0
 David Eng,2020-Q4,0,0,0
@@ -43535,8 +38093,6 @@ David Eng,2018-Q4,0,0,0
 David Eng,2018-Q3,0,0,0
 David Eng,2018-Q2,0,0,0
 David Eng,2018-Q1,0,0,0
-Ruizhe Zhao (Vincent),2021-Q4,0,0,0
-Ruizhe Zhao (Vincent),2021-Q3,0,0,0
 Ruizhe Zhao (Vincent),2021-Q2,0,0,0
 Ruizhe Zhao (Vincent),2021-Q1,0,0,0
 Ruizhe Zhao (Vincent),2020-Q4,0,0,0
@@ -43551,8 +38107,6 @@ Ruizhe Zhao (Vincent),2018-Q4,0,0,0
 Ruizhe Zhao (Vincent),2018-Q3,0,0,0
 Ruizhe Zhao (Vincent),2018-Q2,0,0,0
 Ruizhe Zhao (Vincent),2018-Q1,0,0,0
-Yi Liu,2021-Q4,0,0,0
-Yi Liu,2021-Q3,0,0,0
 Yi Liu,2021-Q2,0,0,0
 Yi Liu,2021-Q1,0,0,0
 Yi Liu,2020-Q4,0,0,0
@@ -43567,8 +38121,6 @@ Yi Liu,2018-Q4,0,0,0
 Yi Liu,2018-Q3,0,0,0
 Yi Liu,2018-Q2,0,0,0
 Yi Liu,2018-Q1,0,0,0
-admcrae,2021-Q4,0,0,0
-admcrae,2021-Q3,0,0,0
 admcrae,2021-Q2,0,0,0
 admcrae,2021-Q1,0,0,0
 admcrae,2020-Q4,0,0,0
@@ -43583,8 +38135,6 @@ admcrae,2018-Q4,0,0,0
 admcrae,2018-Q3,0,0,0
 admcrae,2018-Q2,0,0,0
 admcrae,2018-Q1,0,0,0
-Vu Pham,2021-Q4,0,0,0
-Vu Pham,2021-Q3,0,0,0
 Vu Pham,2021-Q2,0,0,0
 Vu Pham,2021-Q1,0,0,0
 Vu Pham,2020-Q4,0,0,0
@@ -43599,8 +38149,6 @@ Vu Pham,2018-Q4,0,0,0
 Vu Pham,2018-Q3,0,0,0
 Vu Pham,2018-Q2,0,0,0
 Vu Pham,2018-Q1,0,0,0
-Karan Desai,2021-Q4,0,0,0
-Karan Desai,2021-Q3,0,0,0
 Karan Desai,2021-Q2,0,0,0
 Karan Desai,2021-Q1,0,0,0
 Karan Desai,2020-Q4,0,0,0
@@ -43615,8 +38163,6 @@ Karan Desai,2018-Q4,0,0,0
 Karan Desai,2018-Q3,0,0,0
 Karan Desai,2018-Q2,0,0,0
 Karan Desai,2018-Q1,0,0,0
-Alexandre Caulier,2021-Q4,0,0,0
-Alexandre Caulier,2021-Q3,0,0,0
 Alexandre Caulier,2021-Q2,0,0,0
 Alexandre Caulier,2021-Q1,0,0,0
 Alexandre Caulier,2020-Q4,0,0,0
@@ -43631,8 +38177,6 @@ Alexandre Caulier,2018-Q4,0,0,0
 Alexandre Caulier,2018-Q3,0,0,0
 Alexandre Caulier,2018-Q2,0,0,0
 Alexandre Caulier,2018-Q1,0,0,0
-David Y. Zhang,2021-Q4,0,0,0
-David Y. Zhang,2021-Q3,0,0,0
 David Y. Zhang,2021-Q2,0,0,0
 David Y. Zhang,2021-Q1,0,0,0
 David Y. Zhang,2020-Q4,0,0,0
@@ -43647,8 +38191,6 @@ David Y. Zhang,2018-Q4,0,0,0
 David Y. Zhang,2018-Q3,0,0,0
 David Y. Zhang,2018-Q2,0,0,0
 David Y. Zhang,2018-Q1,0,0,0
-Charles Nicholson,2021-Q4,0,0,0
-Charles Nicholson,2021-Q3,0,0,0
 Charles Nicholson,2021-Q2,0,0,0
 Charles Nicholson,2021-Q1,0,0,0
 Charles Nicholson,2020-Q4,0,0,0
@@ -43663,8 +38205,6 @@ Charles Nicholson,2018-Q4,0,0,0
 Charles Nicholson,2018-Q3,0,0,0
 Charles Nicholson,2018-Q2,0,0,0
 Charles Nicholson,2018-Q1,0,0,0
-Nikhil Thorat,2021-Q4,0,0,0
-Nikhil Thorat,2021-Q3,0,0,0
 Nikhil Thorat,2021-Q2,0,0,0
 Nikhil Thorat,2021-Q1,0,0,0
 Nikhil Thorat,2020-Q4,0,0,0
@@ -43679,8 +38219,6 @@ Nikhil Thorat,2018-Q4,0,0,0
 Nikhil Thorat,2018-Q3,0,0,0
 Nikhil Thorat,2018-Q2,0,0,0
 Nikhil Thorat,2018-Q1,0,0,0
-wydwww,2021-Q4,0,0,0
-wydwww,2021-Q3,0,0,0
 wydwww,2021-Q2,0,0,0
 wydwww,2021-Q1,0,0,0
 wydwww,2020-Q4,0,0,0
@@ -43695,8 +38233,6 @@ wydwww,2018-Q4,0,0,0
 wydwww,2018-Q3,0,0,0
 wydwww,2018-Q2,0,0,0
 wydwww,2018-Q1,0,0,0
-ZhipengShen,2021-Q4,0,0,0
-ZhipengShen,2021-Q3,0,0,0
 ZhipengShen,2021-Q2,0,0,0
 ZhipengShen,2021-Q1,0,0,0
 ZhipengShen,2020-Q4,0,0,0
@@ -43711,8 +38247,6 @@ ZhipengShen,2018-Q4,0,0,0
 ZhipengShen,2018-Q3,0,0,0
 ZhipengShen,2018-Q2,0,0,0
 ZhipengShen,2018-Q1,0,0,0
-Daniel Mané,2021-Q4,0,0,0
-Daniel Mané,2021-Q3,0,0,0
 Daniel Mané,2021-Q2,0,0,0
 Daniel Mané,2021-Q1,0,0,0
 Daniel Mané,2020-Q4,0,0,0
@@ -43727,8 +38261,6 @@ Daniel Mané,2018-Q4,0,0,0
 Daniel Mané,2018-Q3,0,0,0
 Daniel Mané,2018-Q2,0,0,0
 Daniel Mané,2018-Q1,0,0,0
-Yuming Wang,2021-Q4,0,0,0
-Yuming Wang,2021-Q3,0,0,0
 Yuming Wang,2021-Q2,0,0,0
 Yuming Wang,2021-Q1,0,0,0
 Yuming Wang,2020-Q4,0,0,0
@@ -43743,8 +38275,6 @@ Yuming Wang,2018-Q4,0,0,0
 Yuming Wang,2018-Q3,0,0,0
 Yuming Wang,2018-Q2,0,0,0
 Yuming Wang,2018-Q1,0,0,0
-Harun Gunaydin,2021-Q4,0,0,0
-Harun Gunaydin,2021-Q3,0,0,0
 Harun Gunaydin,2021-Q2,0,0,0
 Harun Gunaydin,2021-Q1,0,0,0
 Harun Gunaydin,2020-Q4,0,0,0
@@ -43759,8 +38289,6 @@ Harun Gunaydin,2018-Q4,0,0,0
 Harun Gunaydin,2018-Q3,0,0,0
 Harun Gunaydin,2018-Q2,0,0,0
 Harun Gunaydin,2018-Q1,0,0,0
-Dominic Rossi,2021-Q4,0,0,0
-Dominic Rossi,2021-Q3,0,0,0
 Dominic Rossi,2021-Q2,0,0,0
 Dominic Rossi,2021-Q1,0,0,0
 Dominic Rossi,2020-Q4,0,0,0
@@ -43775,8 +38303,6 @@ Dominic Rossi,2018-Q4,0,0,0
 Dominic Rossi,2018-Q3,0,0,0
 Dominic Rossi,2018-Q2,0,0,0
 Dominic Rossi,2018-Q1,0,0,0
-Fei Gao,2021-Q4,0,0,0
-Fei Gao,2021-Q3,0,0,0
 Fei Gao,2021-Q2,0,0,0
 Fei Gao,2021-Q1,0,0,0
 Fei Gao,2020-Q4,0,0,0
@@ -43791,8 +38317,6 @@ Fei Gao,2018-Q4,0,0,0
 Fei Gao,2018-Q3,0,0,0
 Fei Gao,2018-Q2,0,0,0
 Fei Gao,2018-Q1,0,0,0
-Jun Shi,2021-Q4,0,0,0
-Jun Shi,2021-Q3,0,0,0
 Jun Shi,2021-Q2,0,0,0
 Jun Shi,2021-Q1,0,0,0
 Jun Shi,2020-Q4,0,0,0
@@ -43807,8 +38331,6 @@ Jun Shi,2018-Q4,0,0,0
 Jun Shi,2018-Q3,0,0,0
 Jun Shi,2018-Q2,0,0,0
 Jun Shi,2018-Q1,0,0,0
-poohzrn,2021-Q4,0,0,0
-poohzrn,2021-Q3,0,0,0
 poohzrn,2021-Q2,0,0,0
 poohzrn,2021-Q1,0,0,0
 poohzrn,2020-Q4,0,0,0
@@ -43823,8 +38345,6 @@ poohzrn,2018-Q4,0,0,0
 poohzrn,2018-Q3,0,0,0
 poohzrn,2018-Q2,0,0,0
 poohzrn,2018-Q1,0,0,0
-t13m,2021-Q4,0,0,0
-t13m,2021-Q3,0,0,0
 t13m,2021-Q2,0,0,0
 t13m,2021-Q1,0,0,0
 t13m,2020-Q4,0,0,0
@@ -43839,8 +38359,6 @@ t13m,2018-Q4,0,0,0
 t13m,2018-Q3,0,0,0
 t13m,2018-Q2,0,0,0
 t13m,2018-Q1,0,0,0
-Richard Davies,2021-Q4,0,0,0
-Richard Davies,2021-Q3,0,0,0
 Richard Davies,2021-Q2,0,0,0
 Richard Davies,2021-Q1,0,0,0
 Richard Davies,2020-Q4,0,0,0
@@ -43855,8 +38373,6 @@ Richard Davies,2018-Q4,0,0,0
 Richard Davies,2018-Q3,0,0,0
 Richard Davies,2018-Q2,0,0,0
 Richard Davies,2018-Q1,0,0,0
-Umang Mehta,2021-Q4,0,0,0
-Umang Mehta,2021-Q3,0,0,0
 Umang Mehta,2021-Q2,0,0,0
 Umang Mehta,2021-Q1,0,0,0
 Umang Mehta,2020-Q4,0,0,0
@@ -43871,8 +38387,6 @@ Umang Mehta,2018-Q4,0,0,0
 Umang Mehta,2018-Q3,0,0,0
 Umang Mehta,2018-Q2,0,0,0
 Umang Mehta,2018-Q1,0,0,0
-Thomas H. P. Andersen,2021-Q4,0,0,0
-Thomas H. P. Andersen,2021-Q3,0,0,0
 Thomas H. P. Andersen,2021-Q2,0,0,0
 Thomas H. P. Andersen,2021-Q1,0,0,0
 Thomas H. P. Andersen,2020-Q4,0,0,0
@@ -43887,8 +38401,6 @@ Thomas H. P. Andersen,2018-Q4,0,0,0
 Thomas H. P. Andersen,2018-Q3,0,0,0
 Thomas H. P. Andersen,2018-Q2,0,0,0
 Thomas H. P. Andersen,2018-Q1,0,0,0
-td2014,2021-Q4,0,0,0
-td2014,2021-Q3,0,0,0
 td2014,2021-Q2,0,0,0
 td2014,2021-Q1,0,0,0
 td2014,2020-Q4,0,0,0
@@ -43903,8 +38415,6 @@ td2014,2018-Q4,0,0,0
 td2014,2018-Q3,0,0,0
 td2014,2018-Q2,0,0,0
 td2014,2018-Q1,0,0,0
-Namnamseo,2021-Q4,0,0,0
-Namnamseo,2021-Q3,0,0,0
 Namnamseo,2021-Q2,0,0,0
 Namnamseo,2021-Q1,0,0,0
 Namnamseo,2020-Q4,0,0,0
@@ -43919,8 +38429,6 @@ Namnamseo,2018-Q4,0,0,0
 Namnamseo,2018-Q3,0,0,0
 Namnamseo,2018-Q2,0,0,0
 Namnamseo,2018-Q1,0,0,0
-Egil Martinsson,2021-Q4,0,0,0
-Egil Martinsson,2021-Q3,0,0,0
 Egil Martinsson,2021-Q2,0,0,0
 Egil Martinsson,2021-Q1,0,0,0
 Egil Martinsson,2020-Q4,0,0,0
@@ -43935,8 +38443,6 @@ Egil Martinsson,2018-Q4,0,0,0
 Egil Martinsson,2018-Q3,0,0,0
 Egil Martinsson,2018-Q2,0,0,0
 Egil Martinsson,2018-Q1,0,0,0
-Evan Klitzke,2021-Q4,0,0,0
-Evan Klitzke,2021-Q3,0,0,0
 Evan Klitzke,2021-Q2,0,0,0
 Evan Klitzke,2021-Q1,0,0,0
 Evan Klitzke,2020-Q4,0,0,0
@@ -43951,8 +38457,6 @@ Evan Klitzke,2018-Q4,0,0,0
 Evan Klitzke,2018-Q3,0,0,0
 Evan Klitzke,2018-Q2,0,0,0
 Evan Klitzke,2018-Q1,0,0,0
-Luiz Henrique Soares,2021-Q4,0,0,0
-Luiz Henrique Soares,2021-Q3,0,0,0
 Luiz Henrique Soares,2021-Q2,0,0,0
 Luiz Henrique Soares,2021-Q1,0,0,0
 Luiz Henrique Soares,2020-Q4,0,0,0
@@ -43967,8 +38471,6 @@ Luiz Henrique Soares,2018-Q4,0,0,0
 Luiz Henrique Soares,2018-Q3,0,0,0
 Luiz Henrique Soares,2018-Q2,0,0,0
 Luiz Henrique Soares,2018-Q1,0,0,0
-zjj2wry,2021-Q4,0,0,0
-zjj2wry,2021-Q3,0,0,0
 zjj2wry,2021-Q2,0,0,0
 zjj2wry,2021-Q1,0,0,0
 zjj2wry,2020-Q4,0,0,0
@@ -43983,8 +38485,6 @@ zjj2wry,2018-Q4,0,0,0
 zjj2wry,2018-Q3,0,0,0
 zjj2wry,2018-Q2,0,0,0
 zjj2wry,2018-Q1,0,0,0
-wannabesrevenge,2021-Q4,0,0,0
-wannabesrevenge,2021-Q3,0,0,0
 wannabesrevenge,2021-Q2,0,0,0
 wannabesrevenge,2021-Q1,0,0,0
 wannabesrevenge,2020-Q4,0,0,0
@@ -43999,8 +38499,6 @@ wannabesrevenge,2018-Q4,0,0,0
 wannabesrevenge,2018-Q3,0,0,0
 wannabesrevenge,2018-Q2,0,0,0
 wannabesrevenge,2018-Q1,0,0,0
-cfperez,2021-Q4,0,0,0
-cfperez,2021-Q3,0,0,0
 cfperez,2021-Q2,0,0,0
 cfperez,2021-Q1,0,0,0
 cfperez,2020-Q4,0,0,0
@@ -44015,8 +38513,6 @@ cfperez,2018-Q4,0,0,0
 cfperez,2018-Q3,0,0,0
 cfperez,2018-Q2,0,0,0
 cfperez,2018-Q1,0,0,0
-FloopCZ,2021-Q4,0,0,0
-FloopCZ,2021-Q3,0,0,0
 FloopCZ,2021-Q2,0,0,0
 FloopCZ,2021-Q1,0,0,0
 FloopCZ,2020-Q4,0,0,0
@@ -44031,8 +38527,6 @@ FloopCZ,2018-Q4,0,0,0
 FloopCZ,2018-Q3,0,0,0
 FloopCZ,2018-Q2,0,0,0
 FloopCZ,2018-Q1,0,0,0
-Zhaojun Zhang,2021-Q4,0,0,0
-Zhaojun Zhang,2021-Q3,0,0,0
 Zhaojun Zhang,2021-Q2,0,0,0
 Zhaojun Zhang,2021-Q1,0,0,0
 Zhaojun Zhang,2020-Q4,0,0,0
@@ -44047,8 +38541,6 @@ Zhaojun Zhang,2018-Q4,0,0,0
 Zhaojun Zhang,2018-Q3,0,0,0
 Zhaojun Zhang,2018-Q2,0,0,0
 Zhaojun Zhang,2018-Q1,0,0,0
-Vit Stepanovs,2021-Q4,0,0,0
-Vit Stepanovs,2021-Q3,0,0,0
 Vit Stepanovs,2021-Q2,0,0,0
 Vit Stepanovs,2021-Q1,0,0,0
 Vit Stepanovs,2020-Q4,0,0,0
@@ -44063,8 +38555,6 @@ Vit Stepanovs,2018-Q4,0,0,0
 Vit Stepanovs,2018-Q3,0,0,0
 Vit Stepanovs,2018-Q2,0,0,0
 Vit Stepanovs,2018-Q1,0,0,0
-Vincent Zhao,2021-Q4,0,0,0
-Vincent Zhao,2021-Q3,0,0,0
 Vincent Zhao,2021-Q2,0,0,0
 Vincent Zhao,2021-Q1,0,0,0
 Vincent Zhao,2020-Q4,0,0,0
@@ -44079,8 +38569,6 @@ Vincent Zhao,2018-Q4,0,0,0
 Vincent Zhao,2018-Q3,0,0,0
 Vincent Zhao,2018-Q2,0,0,0
 Vincent Zhao,2018-Q1,0,0,0
-Eduardo Pinho,2021-Q4,0,0,0
-Eduardo Pinho,2021-Q3,0,0,0
 Eduardo Pinho,2021-Q2,0,0,0
 Eduardo Pinho,2021-Q1,0,0,0
 Eduardo Pinho,2020-Q4,0,0,0
@@ -44095,8 +38583,6 @@ Eduardo Pinho,2018-Q4,0,0,0
 Eduardo Pinho,2018-Q3,0,0,0
 Eduardo Pinho,2018-Q2,0,0,0
 Eduardo Pinho,2018-Q1,0,0,0
-agramesh1,2021-Q4,0,0,0
-agramesh1,2021-Q3,0,0,0
 agramesh1,2021-Q2,0,0,0
 agramesh1,2021-Q1,0,0,0
 agramesh1,2020-Q4,0,0,0
@@ -44111,8 +38597,6 @@ agramesh1,2018-Q4,0,0,0
 agramesh1,2018-Q3,0,0,0
 agramesh1,2018-Q2,0,0,0
 agramesh1,2018-Q1,0,0,0
-Matthew Rahtz,2021-Q4,0,0,0
-Matthew Rahtz,2021-Q3,0,0,0
 Matthew Rahtz,2021-Q2,0,0,0
 Matthew Rahtz,2021-Q1,0,0,0
 Matthew Rahtz,2020-Q4,0,0,0
@@ -44127,8 +38611,6 @@ Matthew Rahtz,2018-Q4,0,0,0
 Matthew Rahtz,2018-Q3,0,0,0
 Matthew Rahtz,2018-Q2,0,0,0
 Matthew Rahtz,2018-Q1,0,0,0
-Alan Mosca,2021-Q4,0,0,0
-Alan Mosca,2021-Q3,0,0,0
 Alan Mosca,2021-Q2,0,0,0
 Alan Mosca,2021-Q1,0,0,0
 Alan Mosca,2020-Q4,0,0,0
@@ -44143,8 +38625,6 @@ Alan Mosca,2018-Q4,0,0,0
 Alan Mosca,2018-Q3,0,0,0
 Alan Mosca,2018-Q2,0,0,0
 Alan Mosca,2018-Q1,0,0,0
-Arron Cao,2021-Q4,0,0,0
-Arron Cao,2021-Q3,0,0,0
 Arron Cao,2021-Q2,0,0,0
 Arron Cao,2021-Q1,0,0,0
 Arron Cao,2020-Q4,0,0,0
@@ -44159,8 +38639,6 @@ Arron Cao,2018-Q4,0,0,0
 Arron Cao,2018-Q3,0,0,0
 Arron Cao,2018-Q2,0,0,0
 Arron Cao,2018-Q1,0,0,0
-MikeTam1021,2021-Q4,0,0,0
-MikeTam1021,2021-Q3,0,0,0
 MikeTam1021,2021-Q2,0,0,0
 MikeTam1021,2021-Q1,0,0,0
 MikeTam1021,2020-Q4,0,0,0
@@ -44175,8 +38653,6 @@ MikeTam1021,2018-Q4,0,0,0
 MikeTam1021,2018-Q3,0,0,0
 MikeTam1021,2018-Q2,0,0,0
 MikeTam1021,2018-Q1,0,0,0
-KhabarlakKonstantin,2021-Q4,0,0,0
-KhabarlakKonstantin,2021-Q3,0,0,0
 KhabarlakKonstantin,2021-Q2,0,0,0
 KhabarlakKonstantin,2021-Q1,0,0,0
 KhabarlakKonstantin,2020-Q4,0,0,0
@@ -44191,8 +38667,6 @@ KhabarlakKonstantin,2018-Q4,0,0,0
 KhabarlakKonstantin,2018-Q3,0,0,0
 KhabarlakKonstantin,2018-Q2,0,0,0
 KhabarlakKonstantin,2018-Q1,0,0,0
-John Maidens,2021-Q4,0,0,0
-John Maidens,2021-Q3,0,0,0
 John Maidens,2021-Q2,0,0,0
 John Maidens,2021-Q1,0,0,0
 John Maidens,2020-Q4,0,0,0
@@ -44207,8 +38681,6 @@ John Maidens,2018-Q4,0,0,0
 John Maidens,2018-Q3,0,0,0
 John Maidens,2018-Q2,0,0,0
 John Maidens,2018-Q1,0,0,0
-Abhi Agg,2021-Q4,0,0,0
-Abhi Agg,2021-Q3,0,0,0
 Abhi Agg,2021-Q2,0,0,0
 Abhi Agg,2021-Q1,0,0,0
 Abhi Agg,2020-Q4,0,0,0
@@ -44223,8 +38695,6 @@ Abhi Agg,2018-Q4,0,0,0
 Abhi Agg,2018-Q3,0,0,0
 Abhi Agg,2018-Q2,0,0,0
 Abhi Agg,2018-Q1,0,0,0
-NORTHAMERICA\vistepan,2021-Q4,0,0,0
-NORTHAMERICA\vistepan,2021-Q3,0,0,0
 NORTHAMERICA\vistepan,2021-Q2,0,0,0
 NORTHAMERICA\vistepan,2021-Q1,0,0,0
 NORTHAMERICA\vistepan,2020-Q4,0,0,0
@@ -44239,8 +38709,6 @@ NORTHAMERICA\vistepan,2018-Q4,0,0,0
 NORTHAMERICA\vistepan,2018-Q3,0,0,0
 NORTHAMERICA\vistepan,2018-Q2,0,0,0
 NORTHAMERICA\vistepan,2018-Q1,0,0,0
-Damien Martin-Guillerez,2021-Q4,0,0,0
-Damien Martin-Guillerez,2021-Q3,0,0,0
 Damien Martin-Guillerez,2021-Q2,0,0,0
 Damien Martin-Guillerez,2021-Q1,0,0,0
 Damien Martin-Guillerez,2020-Q4,0,0,0
@@ -44255,8 +38723,6 @@ Damien Martin-Guillerez,2018-Q4,0,0,0
 Damien Martin-Guillerez,2018-Q3,0,0,0
 Damien Martin-Guillerez,2018-Q2,0,0,0
 Damien Martin-Guillerez,2018-Q1,0,0,0
-Anand Venkat,2021-Q4,0,0,0
-Anand Venkat,2021-Q3,0,0,0
 Anand Venkat,2021-Q2,0,0,0
 Anand Venkat,2021-Q1,0,0,0
 Anand Venkat,2020-Q4,0,0,0
@@ -44271,8 +38737,6 @@ Anand Venkat,2018-Q4,0,0,0
 Anand Venkat,2018-Q3,0,0,0
 Anand Venkat,2018-Q2,0,0,0
 Anand Venkat,2018-Q1,0,0,0
-Alexander Heinecke,2021-Q4,0,0,0
-Alexander Heinecke,2021-Q3,0,0,0
 Alexander Heinecke,2021-Q2,0,0,0
 Alexander Heinecke,2021-Q1,0,0,0
 Alexander Heinecke,2020-Q4,0,0,0
@@ -44287,8 +38751,6 @@ Alexander Heinecke,2018-Q4,0,0,0
 Alexander Heinecke,2018-Q3,0,0,0
 Alexander Heinecke,2018-Q2,0,0,0
 Alexander Heinecke,2018-Q1,0,0,0
-Oyesh Mann Singh,2021-Q4,0,0,0
-Oyesh Mann Singh,2021-Q3,0,0,0
 Oyesh Mann Singh,2021-Q2,0,0,0
 Oyesh Mann Singh,2021-Q1,0,0,0
 Oyesh Mann Singh,2020-Q4,0,0,0
@@ -44303,8 +38765,6 @@ Oyesh Mann Singh,2018-Q4,0,0,0
 Oyesh Mann Singh,2018-Q3,0,0,0
 Oyesh Mann Singh,2018-Q2,0,0,0
 Oyesh Mann Singh,2018-Q1,0,0,0
-jubjamie,2021-Q4,0,0,0
-jubjamie,2021-Q3,0,0,0
 jubjamie,2021-Q2,0,0,0
 jubjamie,2021-Q1,0,0,0
 jubjamie,2020-Q4,0,0,0
@@ -44319,8 +38779,6 @@ jubjamie,2018-Q4,0,0,0
 jubjamie,2018-Q3,0,0,0
 jubjamie,2018-Q2,0,0,0
 jubjamie,2018-Q1,0,0,0
-Eric Bigelow,2021-Q4,0,0,0
-Eric Bigelow,2021-Q3,0,0,0
 Eric Bigelow,2021-Q2,0,0,0
 Eric Bigelow,2021-Q1,0,0,0
 Eric Bigelow,2020-Q4,0,0,0
@@ -44335,8 +38793,6 @@ Eric Bigelow,2018-Q4,0,0,0
 Eric Bigelow,2018-Q3,0,0,0
 Eric Bigelow,2018-Q2,0,0,0
 Eric Bigelow,2018-Q1,0,0,0
-Shubhankar Deshpande,2021-Q4,0,0,0
-Shubhankar Deshpande,2021-Q3,0,0,0
 Shubhankar Deshpande,2021-Q2,0,0,0
 Shubhankar Deshpande,2021-Q1,0,0,0
 Shubhankar Deshpande,2020-Q4,0,0,0
@@ -44351,8 +38807,6 @@ Shubhankar Deshpande,2018-Q4,0,0,0
 Shubhankar Deshpande,2018-Q3,0,0,0
 Shubhankar Deshpande,2018-Q2,0,0,0
 Shubhankar Deshpande,2018-Q1,0,0,0
-Toby Petty,2021-Q4,0,0,0
-Toby Petty,2021-Q3,0,0,0
 Toby Petty,2021-Q2,0,0,0
 Toby Petty,2021-Q1,0,0,0
 Toby Petty,2020-Q4,0,0,0
@@ -44367,8 +38821,6 @@ Toby Petty,2018-Q4,0,0,0
 Toby Petty,2018-Q3,0,0,0
 Toby Petty,2018-Q2,0,0,0
 Toby Petty,2018-Q1,0,0,0
-Alexander Matyasko,2021-Q4,0,0,0
-Alexander Matyasko,2021-Q3,0,0,0
 Alexander Matyasko,2021-Q2,0,0,0
 Alexander Matyasko,2021-Q1,0,0,0
 Alexander Matyasko,2020-Q4,0,0,0
@@ -44383,8 +38835,6 @@ Alexander Matyasko,2018-Q4,0,0,0
 Alexander Matyasko,2018-Q3,0,0,0
 Alexander Matyasko,2018-Q2,0,0,0
 Alexander Matyasko,2018-Q1,0,0,0
-jyegerlehner,2021-Q4,0,0,0
-jyegerlehner,2021-Q3,0,0,0
 jyegerlehner,2021-Q2,0,0,0
 jyegerlehner,2021-Q1,0,0,0
 jyegerlehner,2020-Q4,0,0,0
@@ -44399,8 +38849,6 @@ jyegerlehner,2018-Q4,0,0,0
 jyegerlehner,2018-Q3,0,0,0
 jyegerlehner,2018-Q2,0,0,0
 jyegerlehner,2018-Q1,0,0,0
-Immexxx,2021-Q4,0,0,0
-Immexxx,2021-Q3,0,0,0
 Immexxx,2021-Q2,0,0,0
 Immexxx,2021-Q1,0,0,0
 Immexxx,2020-Q4,0,0,0
@@ -44415,8 +38863,6 @@ Immexxx,2018-Q4,0,0,0
 Immexxx,2018-Q3,0,0,0
 Immexxx,2018-Q2,0,0,0
 Immexxx,2018-Q1,0,0,0
-Dmytro Kyrychuk,2021-Q4,0,0,0
-Dmytro Kyrychuk,2021-Q3,0,0,0
 Dmytro Kyrychuk,2021-Q2,0,0,0
 Dmytro Kyrychuk,2021-Q1,0,0,0
 Dmytro Kyrychuk,2020-Q4,0,0,0
@@ -44431,8 +38877,6 @@ Dmytro Kyrychuk,2018-Q4,0,0,0
 Dmytro Kyrychuk,2018-Q3,0,0,0
 Dmytro Kyrychuk,2018-Q2,0,0,0
 Dmytro Kyrychuk,2018-Q1,0,0,0
-James Mishra,2021-Q4,0,0,0
-James Mishra,2021-Q3,0,0,0
 James Mishra,2021-Q2,0,0,0
 James Mishra,2021-Q1,0,0,0
 James Mishra,2020-Q4,0,0,0
@@ -44447,8 +38891,6 @@ James Mishra,2018-Q4,0,0,0
 James Mishra,2018-Q3,0,0,0
 James Mishra,2018-Q2,0,0,0
 James Mishra,2018-Q1,0,0,0
-Fung LAM,2021-Q4,0,0,0
-Fung LAM,2021-Q3,0,0,0
 Fung LAM,2021-Q2,0,0,0
 Fung LAM,2021-Q1,0,0,0
 Fung LAM,2020-Q4,0,0,0
@@ -44463,8 +38905,6 @@ Fung LAM,2018-Q4,0,0,0
 Fung LAM,2018-Q3,0,0,0
 Fung LAM,2018-Q2,0,0,0
 Fung LAM,2018-Q1,0,0,0
-akimitsu seo,2021-Q4,0,0,0
-akimitsu seo,2021-Q3,0,0,0
 akimitsu seo,2021-Q2,0,0,0
 akimitsu seo,2021-Q1,0,0,0
 akimitsu seo,2020-Q4,0,0,0
@@ -44479,8 +38919,6 @@ akimitsu seo,2018-Q4,0,0,0
 akimitsu seo,2018-Q3,0,0,0
 akimitsu seo,2018-Q2,0,0,0
 akimitsu seo,2018-Q1,0,0,0
-Fabrizio Milo,2021-Q4,0,0,0
-Fabrizio Milo,2021-Q3,0,0,0
 Fabrizio Milo,2021-Q2,0,0,0
 Fabrizio Milo,2021-Q1,0,0,0
 Fabrizio Milo,2020-Q4,0,0,0
@@ -44495,8 +38933,6 @@ Fabrizio Milo,2018-Q4,0,0,0
 Fabrizio Milo,2018-Q3,0,0,0
 Fabrizio Milo,2018-Q2,0,0,0
 Fabrizio Milo,2018-Q1,0,0,0
-Sean O'Keefe,2021-Q4,0,0,0
-Sean O'Keefe,2021-Q3,0,0,0
 Sean O'Keefe,2021-Q2,0,0,0
 Sean O'Keefe,2021-Q1,0,0,0
 Sean O'Keefe,2020-Q4,0,0,0
@@ -44511,8 +38947,6 @@ Sean O'Keefe,2018-Q4,0,0,0
 Sean O'Keefe,2018-Q3,0,0,0
 Sean O'Keefe,2018-Q2,0,0,0
 Sean O'Keefe,2018-Q1,0,0,0
-Sahit Chintalapudi,2021-Q4,0,0,0
-Sahit Chintalapudi,2021-Q3,0,0,0
 Sahit Chintalapudi,2021-Q2,0,0,0
 Sahit Chintalapudi,2021-Q1,0,0,0
 Sahit Chintalapudi,2020-Q4,0,0,0
@@ -44527,8 +38961,6 @@ Sahit Chintalapudi,2018-Q4,0,0,0
 Sahit Chintalapudi,2018-Q3,0,0,0
 Sahit Chintalapudi,2018-Q2,0,0,0
 Sahit Chintalapudi,2018-Q1,0,0,0
-Quim Llimona,2021-Q4,0,0,0
-Quim Llimona,2021-Q3,0,0,0
 Quim Llimona,2021-Q2,0,0,0
 Quim Llimona,2021-Q1,0,0,0
 Quim Llimona,2020-Q4,0,0,0
@@ -44543,8 +38975,6 @@ Quim Llimona,2018-Q4,0,0,0
 Quim Llimona,2018-Q3,0,0,0
 Quim Llimona,2018-Q2,0,0,0
 Quim Llimona,2018-Q1,0,0,0
-Gu Wang,2021-Q4,0,0,0
-Gu Wang,2021-Q3,0,0,0
 Gu Wang,2021-Q2,0,0,0
 Gu Wang,2021-Q1,0,0,0
 Gu Wang,2020-Q4,0,0,0
@@ -44559,8 +38989,6 @@ Gu Wang,2018-Q4,0,0,0
 Gu Wang,2018-Q3,0,0,0
 Gu Wang,2018-Q2,0,0,0
 Gu Wang,2018-Q1,0,0,0
-Yoshihiro Sugi,2021-Q4,0,0,0
-Yoshihiro Sugi,2021-Q3,0,0,0
 Yoshihiro Sugi,2021-Q2,0,0,0
 Yoshihiro Sugi,2021-Q1,0,0,0
 Yoshihiro Sugi,2020-Q4,0,0,0
@@ -44575,8 +39003,6 @@ Yoshihiro Sugi,2018-Q4,0,0,0
 Yoshihiro Sugi,2018-Q3,0,0,0
 Yoshihiro Sugi,2018-Q2,0,0,0
 Yoshihiro Sugi,2018-Q1,0,0,0
-Nate Harada,2021-Q4,0,0,0
-Nate Harada,2021-Q3,0,0,0
 Nate Harada,2021-Q2,0,0,0
 Nate Harada,2021-Q1,0,0,0
 Nate Harada,2020-Q4,0,0,0
@@ -44591,8 +39017,6 @@ Nate Harada,2018-Q4,0,0,0
 Nate Harada,2018-Q3,0,0,0
 Nate Harada,2018-Q2,0,0,0
 Nate Harada,2018-Q1,0,0,0
-John Bates,2021-Q4,0,0,0
-John Bates,2021-Q3,0,0,0
 John Bates,2021-Q2,0,0,0
 John Bates,2021-Q1,0,0,0
 John Bates,2020-Q4,0,0,0
@@ -44607,8 +39031,6 @@ John Bates,2018-Q4,0,0,0
 John Bates,2018-Q3,0,0,0
 John Bates,2018-Q2,0,0,0
 John Bates,2018-Q1,0,0,0
-Deepak Subburam,2021-Q4,0,0,0
-Deepak Subburam,2021-Q3,0,0,0
 Deepak Subburam,2021-Q2,0,0,0
 Deepak Subburam,2021-Q1,0,0,0
 Deepak Subburam,2020-Q4,0,0,0
@@ -44623,8 +39045,6 @@ Deepak Subburam,2018-Q4,0,0,0
 Deepak Subburam,2018-Q3,0,0,0
 Deepak Subburam,2018-Q2,0,0,0
 Deepak Subburam,2018-Q1,0,0,0
-Anmol Sharma,2021-Q4,0,0,0
-Anmol Sharma,2021-Q3,0,0,0
 Anmol Sharma,2021-Q2,0,0,0
 Anmol Sharma,2021-Q1,0,0,0
 Anmol Sharma,2020-Q4,0,0,0
@@ -44639,8 +39059,6 @@ Anmol Sharma,2018-Q4,0,0,0
 Anmol Sharma,2018-Q3,0,0,0
 Anmol Sharma,2018-Q2,0,0,0
 Anmol Sharma,2018-Q1,0,0,0
-guschmue,2021-Q4,0,0,0
-guschmue,2021-Q3,0,0,0
 guschmue,2021-Q2,0,0,0
 guschmue,2021-Q1,0,0,0
 guschmue,2020-Q4,0,0,0
@@ -44655,8 +39073,6 @@ guschmue,2018-Q4,0,0,0
 guschmue,2018-Q3,0,0,0
 guschmue,2018-Q2,0,0,0
 guschmue,2018-Q1,0,0,0
-critiqjo,2021-Q4,0,0,0
-critiqjo,2021-Q3,0,0,0
 critiqjo,2021-Q2,0,0,0
 critiqjo,2021-Q1,0,0,0
 critiqjo,2020-Q4,0,0,0
@@ -44671,8 +39087,6 @@ critiqjo,2018-Q4,0,0,0
 critiqjo,2018-Q3,0,0,0
 critiqjo,2018-Q2,0,0,0
 critiqjo,2018-Q1,0,0,0
-Karel van de Plassche,2021-Q4,0,0,0
-Karel van de Plassche,2021-Q3,0,0,0
 Karel van de Plassche,2021-Q2,0,0,0
 Karel van de Plassche,2021-Q1,0,0,0
 Karel van de Plassche,2020-Q4,0,0,0
@@ -44687,8 +39101,6 @@ Karel van de Plassche,2018-Q4,0,0,0
 Karel van de Plassche,2018-Q3,0,0,0
 Karel van de Plassche,2018-Q2,0,0,0
 Karel van de Plassche,2018-Q1,0,0,0
-Mycosynth,2021-Q4,0,0,0
-Mycosynth,2021-Q3,0,0,0
 Mycosynth,2021-Q2,0,0,0
 Mycosynth,2021-Q1,0,0,0
 Mycosynth,2020-Q4,0,0,0
@@ -44703,8 +39115,6 @@ Mycosynth,2018-Q4,0,0,0
 Mycosynth,2018-Q3,0,0,0
 Mycosynth,2018-Q2,0,0,0
 Mycosynth,2018-Q1,0,0,0
-Panmari,2021-Q4,0,0,0
-Panmari,2021-Q3,0,0,0
 Panmari,2021-Q2,0,0,0
 Panmari,2021-Q1,0,0,0
 Panmari,2020-Q4,0,0,0
@@ -44719,8 +39129,6 @@ Panmari,2018-Q4,0,0,0
 Panmari,2018-Q3,0,0,0
 Panmari,2018-Q2,0,0,0
 Panmari,2018-Q1,0,0,0
-Valentin Iovene,2021-Q4,0,0,0
-Valentin Iovene,2021-Q3,0,0,0
 Valentin Iovene,2021-Q2,0,0,0
 Valentin Iovene,2021-Q1,0,0,0
 Valentin Iovene,2020-Q4,0,0,0
@@ -44735,8 +39143,6 @@ Valentin Iovene,2018-Q4,0,0,0
 Valentin Iovene,2018-Q3,0,0,0
 Valentin Iovene,2018-Q2,0,0,0
 Valentin Iovene,2018-Q1,0,0,0
-Nick Lyu,2021-Q4,0,0,0
-Nick Lyu,2021-Q3,0,0,0
 Nick Lyu,2021-Q2,0,0,0
 Nick Lyu,2021-Q1,0,0,0
 Nick Lyu,2020-Q4,0,0,0
@@ -44751,8 +39157,6 @@ Nick Lyu,2018-Q4,0,0,0
 Nick Lyu,2018-Q3,0,0,0
 Nick Lyu,2018-Q2,0,0,0
 Nick Lyu,2018-Q1,0,0,0
-Arie,2021-Q4,0,0,0
-Arie,2021-Q3,0,0,0
 Arie,2021-Q2,0,0,0
 Arie,2021-Q1,0,0,0
 Arie,2020-Q4,0,0,0
@@ -44767,8 +39171,6 @@ Arie,2018-Q4,0,0,0
 Arie,2018-Q3,0,0,0
 Arie,2018-Q2,0,0,0
 Arie,2018-Q1,0,0,0
-Davy Song,2021-Q4,0,0,0
-Davy Song,2021-Q3,0,0,0
 Davy Song,2021-Q2,0,0,0
 Davy Song,2021-Q1,0,0,0
 Davy Song,2020-Q4,0,0,0
@@ -44783,8 +39185,6 @@ Davy Song,2018-Q4,0,0,0
 Davy Song,2018-Q3,0,0,0
 Davy Song,2018-Q2,0,0,0
 Davy Song,2018-Q1,0,0,0
-SunYeop Lee,2021-Q4,0,0,0
-SunYeop Lee,2021-Q3,0,0,0
 SunYeop Lee,2021-Q2,0,0,0
 SunYeop Lee,2021-Q1,0,0,0
 SunYeop Lee,2020-Q4,0,0,0
@@ -44799,8 +39199,6 @@ SunYeop Lee,2018-Q4,0,0,0
 SunYeop Lee,2018-Q3,0,0,0
 SunYeop Lee,2018-Q2,0,0,0
 SunYeop Lee,2018-Q1,0,0,0
-Patrick,2021-Q4,0,0,0
-Patrick,2021-Q3,0,0,0
 Patrick,2021-Q2,0,0,0
 Patrick,2021-Q1,0,0,0
 Patrick,2020-Q4,0,0,0
@@ -44815,8 +39213,6 @@ Patrick,2018-Q4,0,0,0
 Patrick,2018-Q3,0,0,0
 Patrick,2018-Q2,0,0,0
 Patrick,2018-Q1,0,0,0
-Sean Papay,2021-Q4,0,0,0
-Sean Papay,2021-Q3,0,0,0
 Sean Papay,2021-Q2,0,0,0
 Sean Papay,2021-Q1,0,0,0
 Sean Papay,2020-Q4,0,0,0
@@ -44831,8 +39227,6 @@ Sean Papay,2018-Q4,0,0,0
 Sean Papay,2018-Q3,0,0,0
 Sean Papay,2018-Q2,0,0,0
 Sean Papay,2018-Q1,0,0,0
-A. Besir Kurtulmus,2021-Q4,0,0,0
-A. Besir Kurtulmus,2021-Q3,0,0,0
 A. Besir Kurtulmus,2021-Q2,0,0,0
 A. Besir Kurtulmus,2021-Q1,0,0,0
 A. Besir Kurtulmus,2020-Q4,0,0,0
@@ -44847,8 +39241,6 @@ A. Besir Kurtulmus,2018-Q4,0,0,0
 A. Besir Kurtulmus,2018-Q3,0,0,0
 A. Besir Kurtulmus,2018-Q2,0,0,0
 A. Besir Kurtulmus,2018-Q1,0,0,0
-Joey Meyer,2021-Q4,0,0,0
-Joey Meyer,2021-Q3,0,0,0
 Joey Meyer,2021-Q2,0,0,0
 Joey Meyer,2021-Q1,0,0,0
 Joey Meyer,2020-Q4,0,0,0
@@ -44863,8 +39255,6 @@ Joey Meyer,2018-Q4,0,0,0
 Joey Meyer,2018-Q3,0,0,0
 Joey Meyer,2018-Q2,0,0,0
 Joey Meyer,2018-Q1,0,0,0
-Aravind,2021-Q4,0,0,0
-Aravind,2021-Q3,0,0,0
 Aravind,2021-Q2,0,0,0
 Aravind,2021-Q1,0,0,0
 Aravind,2020-Q4,0,0,0
@@ -44879,8 +39269,6 @@ Aravind,2018-Q4,0,0,0
 Aravind,2018-Q3,0,0,0
 Aravind,2018-Q2,0,0,0
 Aravind,2018-Q1,0,0,0
-Mark Szepieniec,2021-Q4,0,0,0
-Mark Szepieniec,2021-Q3,0,0,0
 Mark Szepieniec,2021-Q2,0,0,0
 Mark Szepieniec,2021-Q1,0,0,0
 Mark Szepieniec,2020-Q4,0,0,0
@@ -44895,8 +39283,6 @@ Mark Szepieniec,2018-Q4,0,0,0
 Mark Szepieniec,2018-Q3,0,0,0
 Mark Szepieniec,2018-Q2,0,0,0
 Mark Szepieniec,2018-Q1,0,0,0
-John C F,2021-Q4,0,0,0
-John C F,2021-Q3,0,0,0
 John C F,2021-Q2,0,0,0
 John C F,2021-Q1,0,0,0
 John C F,2020-Q4,0,0,0
@@ -44911,8 +39297,6 @@ John C F,2018-Q4,0,0,0
 John C F,2018-Q3,0,0,0
 John C F,2018-Q2,0,0,0
 John C F,2018-Q1,0,0,0
-Conchylicultor,2021-Q4,0,0,0
-Conchylicultor,2021-Q3,0,0,0
 Conchylicultor,2021-Q2,0,0,0
 Conchylicultor,2021-Q1,0,0,0
 Conchylicultor,2020-Q4,0,0,0
@@ -44927,8 +39311,6 @@ Conchylicultor,2018-Q4,0,0,0
 Conchylicultor,2018-Q3,0,0,0
 Conchylicultor,2018-Q2,0,0,0
 Conchylicultor,2018-Q1,0,0,0
-Saisai Shao,2021-Q4,0,0,0
-Saisai Shao,2021-Q3,0,0,0
 Saisai Shao,2021-Q2,0,0,0
 Saisai Shao,2021-Q1,0,0,0
 Saisai Shao,2020-Q4,0,0,0
@@ -44943,8 +39325,6 @@ Saisai Shao,2018-Q4,0,0,0
 Saisai Shao,2018-Q3,0,0,0
 Saisai Shao,2018-Q2,0,0,0
 Saisai Shao,2018-Q1,0,0,0
-Eddie,2021-Q4,0,0,0
-Eddie,2021-Q3,0,0,0
 Eddie,2021-Q2,0,0,0
 Eddie,2021-Q1,0,0,0
 Eddie,2020-Q4,0,0,0
@@ -44959,8 +39339,6 @@ Eddie,2018-Q4,0,0,0
 Eddie,2018-Q3,0,0,0
 Eddie,2018-Q2,0,0,0
 Eddie,2018-Q1,0,0,0
-Mandeep Singh,2021-Q4,0,0,0
-Mandeep Singh,2021-Q3,0,0,0
 Mandeep Singh,2021-Q2,0,0,0
 Mandeep Singh,2021-Q1,0,0,0
 Mandeep Singh,2020-Q4,0,0,0
@@ -44975,8 +39353,6 @@ Mandeep Singh,2018-Q4,0,0,0
 Mandeep Singh,2018-Q3,0,0,0
 Mandeep Singh,2018-Q2,0,0,0
 Mandeep Singh,2018-Q1,0,0,0
-Sriram Narayanamoorthy,2021-Q4,0,0,0
-Sriram Narayanamoorthy,2021-Q3,0,0,0
 Sriram Narayanamoorthy,2021-Q2,0,0,0
 Sriram Narayanamoorthy,2021-Q1,0,0,0
 Sriram Narayanamoorthy,2020-Q4,0,0,0
@@ -44991,8 +39367,6 @@ Sriram Narayanamoorthy,2018-Q4,0,0,0
 Sriram Narayanamoorthy,2018-Q3,0,0,0
 Sriram Narayanamoorthy,2018-Q2,0,0,0
 Sriram Narayanamoorthy,2018-Q1,0,0,0
-Nicholas Connor,2021-Q4,0,0,0
-Nicholas Connor,2021-Q3,0,0,0
 Nicholas Connor,2021-Q2,0,0,0
 Nicholas Connor,2021-Q1,0,0,0
 Nicholas Connor,2020-Q4,0,0,0
@@ -45007,8 +39381,6 @@ Nicholas Connor,2018-Q4,0,0,0
 Nicholas Connor,2018-Q3,0,0,0
 Nicholas Connor,2018-Q2,0,0,0
 Nicholas Connor,2018-Q1,0,0,0
-Hannah Provenza,2021-Q4,0,0,0
-Hannah Provenza,2021-Q3,0,0,0
 Hannah Provenza,2021-Q2,0,0,0
 Hannah Provenza,2021-Q1,0,0,0
 Hannah Provenza,2020-Q4,0,0,0
@@ -45023,8 +39395,6 @@ Hannah Provenza,2018-Q4,0,0,0
 Hannah Provenza,2018-Q3,0,0,0
 Hannah Provenza,2018-Q2,0,0,0
 Hannah Provenza,2018-Q1,0,0,0
-Memo Akten,2021-Q4,0,0,0
-Memo Akten,2021-Q3,0,0,0
 Memo Akten,2021-Q2,0,0,0
 Memo Akten,2021-Q1,0,0,0
 Memo Akten,2020-Q4,0,0,0
@@ -45039,8 +39409,6 @@ Memo Akten,2018-Q4,0,0,0
 Memo Akten,2018-Q3,0,0,0
 Memo Akten,2018-Q2,0,0,0
 Memo Akten,2018-Q1,0,0,0
-Gefu Tang,2021-Q4,0,0,0
-Gefu Tang,2021-Q3,0,0,0
 Gefu Tang,2021-Q2,0,0,0
 Gefu Tang,2021-Q1,0,0,0
 Gefu Tang,2020-Q4,0,0,0
@@ -45055,8 +39423,6 @@ Gefu Tang,2018-Q4,0,0,0
 Gefu Tang,2018-Q3,0,0,0
 Gefu Tang,2018-Q2,0,0,0
 Gefu Tang,2018-Q1,0,0,0
-Niraj Patel,2021-Q4,0,0,0
-Niraj Patel,2021-Q3,0,0,0
 Niraj Patel,2021-Q2,0,0,0
 Niraj Patel,2021-Q1,0,0,0
 Niraj Patel,2020-Q4,0,0,0
@@ -45071,8 +39437,6 @@ Niraj Patel,2018-Q4,0,0,0
 Niraj Patel,2018-Q3,0,0,0
 Niraj Patel,2018-Q2,0,0,0
 Niraj Patel,2018-Q1,0,0,0
-Marek Kolodziej,2021-Q4,0,0,0
-Marek Kolodziej,2021-Q3,0,0,0
 Marek Kolodziej,2021-Q2,0,0,0
 Marek Kolodziej,2021-Q1,0,0,0
 Marek Kolodziej,2020-Q4,0,0,0
@@ -45087,8 +39451,6 @@ Marek Kolodziej,2018-Q4,0,0,0
 Marek Kolodziej,2018-Q3,0,0,0
 Marek Kolodziej,2018-Q2,0,0,0
 Marek Kolodziej,2018-Q1,0,0,0
-Tim Anglade,2021-Q4,0,0,0
-Tim Anglade,2021-Q3,0,0,0
 Tim Anglade,2021-Q2,0,0,0
 Tim Anglade,2021-Q1,0,0,0
 Tim Anglade,2020-Q4,0,0,0
@@ -45103,8 +39465,6 @@ Tim Anglade,2018-Q4,0,0,0
 Tim Anglade,2018-Q3,0,0,0
 Tim Anglade,2018-Q2,0,0,0
 Tim Anglade,2018-Q1,0,0,0
-Viktor Malyi,2021-Q4,0,0,0
-Viktor Malyi,2021-Q3,0,0,0
 Viktor Malyi,2021-Q2,0,0,0
 Viktor Malyi,2021-Q1,0,0,0
 Viktor Malyi,2020-Q4,0,0,0
@@ -45119,8 +39479,6 @@ Viktor Malyi,2018-Q4,0,0,0
 Viktor Malyi,2018-Q3,0,0,0
 Viktor Malyi,2018-Q2,0,0,0
 Viktor Malyi,2018-Q1,0,0,0
-Alec-DeSouza,2021-Q4,0,0,0
-Alec-DeSouza,2021-Q3,0,0,0
 Alec-DeSouza,2021-Q2,0,0,0
 Alec-DeSouza,2021-Q1,0,0,0
 Alec-DeSouza,2020-Q4,0,0,0
@@ -45135,8 +39493,6 @@ Alec-DeSouza,2018-Q4,0,0,0
 Alec-DeSouza,2018-Q3,0,0,0
 Alec-DeSouza,2018-Q2,0,0,0
 Alec-DeSouza,2018-Q1,0,0,0
-Nathan Silberman,2021-Q4,0,0,0
-Nathan Silberman,2021-Q3,0,0,0
 Nathan Silberman,2021-Q2,0,0,0
 Nathan Silberman,2021-Q1,0,0,0
 Nathan Silberman,2020-Q4,0,0,0
@@ -45151,8 +39507,6 @@ Nathan Silberman,2018-Q4,0,0,0
 Nathan Silberman,2018-Q3,0,0,0
 Nathan Silberman,2018-Q2,0,0,0
 Nathan Silberman,2018-Q1,0,0,0
-Micael Carvalho,2021-Q4,0,0,0
-Micael Carvalho,2021-Q3,0,0,0
 Micael Carvalho,2021-Q2,0,0,0
 Micael Carvalho,2021-Q1,0,0,0
 Micael Carvalho,2020-Q4,0,0,0
@@ -45167,8 +39521,6 @@ Micael Carvalho,2018-Q4,0,0,0
 Micael Carvalho,2018-Q3,0,0,0
 Micael Carvalho,2018-Q2,0,0,0
 Micael Carvalho,2018-Q1,0,0,0
-sanosay,2021-Q4,0,0,0
-sanosay,2021-Q3,0,0,0
 sanosay,2021-Q2,0,0,0
 sanosay,2021-Q1,0,0,0
 sanosay,2020-Q4,0,0,0
@@ -45183,8 +39535,6 @@ sanosay,2018-Q4,0,0,0
 sanosay,2018-Q3,0,0,0
 sanosay,2018-Q2,0,0,0
 sanosay,2018-Q1,0,0,0
-Yi Hsiao,2021-Q4,0,0,0
-Yi Hsiao,2021-Q3,0,0,0
 Yi Hsiao,2021-Q2,0,0,0
 Yi Hsiao,2021-Q1,0,0,0
 Yi Hsiao,2020-Q4,0,0,0
@@ -45199,8 +39549,6 @@ Yi Hsiao,2018-Q4,0,0,0
 Yi Hsiao,2018-Q3,0,0,0
 Yi Hsiao,2018-Q2,0,0,0
 Yi Hsiao,2018-Q1,0,0,0
-Ben Visser,2021-Q4,0,0,0
-Ben Visser,2021-Q3,0,0,0
 Ben Visser,2021-Q2,0,0,0
 Ben Visser,2021-Q1,0,0,0
 Ben Visser,2020-Q4,0,0,0
@@ -45215,8 +39563,6 @@ Ben Visser,2018-Q4,0,0,0
 Ben Visser,2018-Q3,0,0,0
 Ben Visser,2018-Q2,0,0,0
 Ben Visser,2018-Q1,0,0,0
-hsiao yi,2021-Q4,0,0,0
-hsiao yi,2021-Q3,0,0,0
 hsiao yi,2021-Q2,0,0,0
 hsiao yi,2021-Q1,0,0,0
 hsiao yi,2020-Q4,0,0,0
@@ -45231,8 +39577,6 @@ hsiao yi,2018-Q4,0,0,0
 hsiao yi,2018-Q3,0,0,0
 hsiao yi,2018-Q2,0,0,0
 hsiao yi,2018-Q1,0,0,0
-nghiattran,2021-Q4,0,0,0
-nghiattran,2021-Q3,0,0,0
 nghiattran,2021-Q2,0,0,0
 nghiattran,2021-Q1,0,0,0
 nghiattran,2020-Q4,0,0,0
@@ -45247,8 +39591,6 @@ nghiattran,2018-Q4,0,0,0
 nghiattran,2018-Q3,0,0,0
 nghiattran,2018-Q2,0,0,0
 nghiattran,2018-Q1,0,0,0
-Dimitar Pavlov,2021-Q4,0,0,0
-Dimitar Pavlov,2021-Q3,0,0,0
 Dimitar Pavlov,2021-Q2,0,0,0
 Dimitar Pavlov,2021-Q1,0,0,0
 Dimitar Pavlov,2020-Q4,0,0,0
@@ -45263,8 +39605,6 @@ Dimitar Pavlov,2018-Q4,0,0,0
 Dimitar Pavlov,2018-Q3,0,0,0
 Dimitar Pavlov,2018-Q2,0,0,0
 Dimitar Pavlov,2018-Q1,0,0,0
-Erfan Noury,2021-Q4,0,0,0
-Erfan Noury,2021-Q3,0,0,0
 Erfan Noury,2021-Q2,0,0,0
 Erfan Noury,2021-Q1,0,0,0
 Erfan Noury,2020-Q4,0,0,0
@@ -45279,8 +39619,6 @@ Erfan Noury,2018-Q4,0,0,0
 Erfan Noury,2018-Q3,0,0,0
 Erfan Noury,2018-Q2,0,0,0
 Erfan Noury,2018-Q1,0,0,0
-Mark McDonald,2021-Q4,0,0,0
-Mark McDonald,2021-Q3,0,0,0
 Mark McDonald,2021-Q2,0,0,0
 Mark McDonald,2021-Q1,0,0,0
 Mark McDonald,2020-Q4,0,0,0
@@ -45295,8 +39633,6 @@ Mark McDonald,2018-Q4,0,0,0
 Mark McDonald,2018-Q3,0,0,0
 Mark McDonald,2018-Q2,0,0,0
 Mark McDonald,2018-Q1,0,0,0
-Ivan Bogatyy,2021-Q4,0,0,0
-Ivan Bogatyy,2021-Q3,0,0,0
 Ivan Bogatyy,2021-Q2,0,0,0
 Ivan Bogatyy,2021-Q1,0,0,0
 Ivan Bogatyy,2020-Q4,0,0,0
@@ -45311,8 +39647,6 @@ Ivan Bogatyy,2018-Q4,0,0,0
 Ivan Bogatyy,2018-Q3,0,0,0
 Ivan Bogatyy,2018-Q2,0,0,0
 Ivan Bogatyy,2018-Q1,0,0,0
-Jojy G Varghese,2021-Q4,0,0,0
-Jojy G Varghese,2021-Q3,0,0,0
 Jojy G Varghese,2021-Q2,0,0,0
 Jojy G Varghese,2021-Q1,0,0,0
 Jojy G Varghese,2020-Q4,0,0,0
@@ -45327,8 +39661,6 @@ Jojy G Varghese,2018-Q4,0,0,0
 Jojy G Varghese,2018-Q3,0,0,0
 Jojy G Varghese,2018-Q2,0,0,0
 Jojy G Varghese,2018-Q1,0,0,0
-Jason Morton,2021-Q4,0,0,0
-Jason Morton,2021-Q3,0,0,0
 Jason Morton,2021-Q2,0,0,0
 Jason Morton,2021-Q1,0,0,0
 Jason Morton,2020-Q4,0,0,0
@@ -45343,8 +39675,6 @@ Jason Morton,2018-Q4,0,0,0
 Jason Morton,2018-Q3,0,0,0
 Jason Morton,2018-Q2,0,0,0
 Jason Morton,2018-Q1,0,0,0
-Jojy George Varghese,2021-Q4,0,0,0
-Jojy George Varghese,2021-Q3,0,0,0
 Jojy George Varghese,2021-Q2,0,0,0
 Jojy George Varghese,2021-Q1,0,0,0
 Jojy George Varghese,2020-Q4,0,0,0
@@ -45359,8 +39689,6 @@ Jojy George Varghese,2018-Q4,0,0,0
 Jojy George Varghese,2018-Q3,0,0,0
 Jojy George Varghese,2018-Q2,0,0,0
 Jojy George Varghese,2018-Q1,0,0,0
-Zifei Tong,2021-Q4,0,0,0
-Zifei Tong,2021-Q3,0,0,0
 Zifei Tong,2021-Q2,0,0,0
 Zifei Tong,2021-Q1,0,0,0
 Zifei Tong,2020-Q4,0,0,0
@@ -45375,8 +39703,6 @@ Zifei Tong,2018-Q4,0,0,0
 Zifei Tong,2018-Q3,0,0,0
 Zifei Tong,2018-Q2,0,0,0
 Zifei Tong,2018-Q1,0,0,0
-Allen Guo,2021-Q4,0,0,0
-Allen Guo,2021-Q3,0,0,0
 Allen Guo,2021-Q2,0,0,0
 Allen Guo,2021-Q1,0,0,0
 Allen Guo,2020-Q4,0,0,0
@@ -45391,8 +39717,6 @@ Allen Guo,2018-Q4,0,0,0
 Allen Guo,2018-Q3,0,0,0
 Allen Guo,2018-Q2,0,0,0
 Allen Guo,2018-Q1,0,0,0
-Jason Gavris,2021-Q4,0,0,0
-Jason Gavris,2021-Q3,0,0,0
 Jason Gavris,2021-Q2,0,0,0
 Jason Gavris,2021-Q1,0,0,0
 Jason Gavris,2020-Q4,0,0,0
@@ -45407,8 +39731,6 @@ Jason Gavris,2018-Q4,0,0,0
 Jason Gavris,2018-Q3,0,0,0
 Jason Gavris,2018-Q2,0,0,0
 Jason Gavris,2018-Q1,0,0,0
-Ryo ASAKURA,2021-Q4,0,0,0
-Ryo ASAKURA,2021-Q3,0,0,0
 Ryo ASAKURA,2021-Q2,0,0,0
 Ryo ASAKURA,2021-Q1,0,0,0
 Ryo ASAKURA,2020-Q4,0,0,0
@@ -45423,8 +39745,6 @@ Ryo ASAKURA,2018-Q4,0,0,0
 Ryo ASAKURA,2018-Q3,0,0,0
 Ryo ASAKURA,2018-Q2,0,0,0
 Ryo ASAKURA,2018-Q1,0,0,0
-MircoT,2021-Q4,0,0,0
-MircoT,2021-Q3,0,0,0
 MircoT,2021-Q2,0,0,0
 MircoT,2021-Q1,0,0,0
 MircoT,2020-Q4,0,0,0
@@ -45439,8 +39759,6 @@ MircoT,2018-Q4,0,0,0
 MircoT,2018-Q3,0,0,0
 MircoT,2018-Q2,0,0,0
 MircoT,2018-Q1,0,0,0
-Jiaming Liu,2021-Q4,0,0,0
-Jiaming Liu,2021-Q3,0,0,0
 Jiaming Liu,2021-Q2,0,0,0
 Jiaming Liu,2021-Q1,0,0,0
 Jiaming Liu,2020-Q4,0,0,0
@@ -45455,8 +39773,6 @@ Jiaming Liu,2018-Q4,0,0,0
 Jiaming Liu,2018-Q3,0,0,0
 Jiaming Liu,2018-Q2,0,0,0
 Jiaming Liu,2018-Q1,0,0,0
-Vlad Firoiu,2021-Q4,0,0,0
-Vlad Firoiu,2021-Q3,0,0,0
 Vlad Firoiu,2021-Q2,0,0,0
 Vlad Firoiu,2021-Q1,0,0,0
 Vlad Firoiu,2020-Q4,0,0,0
@@ -45471,8 +39787,6 @@ Vlad Firoiu,2018-Q4,0,0,0
 Vlad Firoiu,2018-Q3,0,0,0
 Vlad Firoiu,2018-Q2,0,0,0
 Vlad Firoiu,2018-Q1,0,0,0
-Stefano Probst,2021-Q4,0,0,0
-Stefano Probst,2021-Q3,0,0,0
 Stefano Probst,2021-Q2,0,0,0
 Stefano Probst,2021-Q1,0,0,0
 Stefano Probst,2020-Q4,0,0,0
@@ -45487,8 +39801,6 @@ Stefano Probst,2018-Q4,0,0,0
 Stefano Probst,2018-Q3,0,0,0
 Stefano Probst,2018-Q2,0,0,0
 Stefano Probst,2018-Q1,0,0,0
-rasbt,2021-Q4,0,0,0
-rasbt,2021-Q3,0,0,0
 rasbt,2021-Q2,0,0,0
 rasbt,2021-Q1,0,0,0
 rasbt,2020-Q4,0,0,0
@@ -45503,8 +39815,6 @@ rasbt,2018-Q4,0,0,0
 rasbt,2018-Q3,0,0,0
 rasbt,2018-Q2,0,0,0
 rasbt,2018-Q1,0,0,0
-Igor Chorążewicz,2021-Q4,0,0,0
-Igor Chorążewicz,2021-Q3,0,0,0
 Igor Chorążewicz,2021-Q2,0,0,0
 Igor Chorążewicz,2021-Q1,0,0,0
 Igor Chorążewicz,2020-Q4,0,0,0
@@ -45519,8 +39829,6 @@ Igor Chorążewicz,2018-Q4,0,0,0
 Igor Chorążewicz,2018-Q3,0,0,0
 Igor Chorążewicz,2018-Q2,0,0,0
 Igor Chorążewicz,2018-Q1,0,0,0
-wangg12,2021-Q4,0,0,0
-wangg12,2021-Q3,0,0,0
 wangg12,2021-Q2,0,0,0
 wangg12,2021-Q1,0,0,0
 wangg12,2020-Q4,0,0,0
@@ -45535,8 +39843,6 @@ wangg12,2018-Q4,0,0,0
 wangg12,2018-Q3,0,0,0
 wangg12,2018-Q2,0,0,0
 wangg12,2018-Q1,0,0,0
-Pavel Bulanov,2021-Q4,0,0,0
-Pavel Bulanov,2021-Q3,0,0,0
 Pavel Bulanov,2021-Q2,0,0,0
 Pavel Bulanov,2021-Q1,0,0,0
 Pavel Bulanov,2020-Q4,0,0,0
@@ -45551,8 +39857,6 @@ Pavel Bulanov,2018-Q4,0,0,0
 Pavel Bulanov,2018-Q3,0,0,0
 Pavel Bulanov,2018-Q2,0,0,0
 Pavel Bulanov,2018-Q1,0,0,0
-Vijay D'Silva,2021-Q4,0,0,0
-Vijay D'Silva,2021-Q3,0,0,0
 Vijay D'Silva,2021-Q2,0,0,0
 Vijay D'Silva,2021-Q1,0,0,0
 Vijay D'Silva,2020-Q4,0,0,0
@@ -45567,8 +39871,6 @@ Vijay D'Silva,2018-Q4,0,0,0
 Vijay D'Silva,2018-Q3,0,0,0
 Vijay D'Silva,2018-Q2,0,0,0
 Vijay D'Silva,2018-Q1,0,0,0
-Christopher Berner,2021-Q4,0,0,0
-Christopher Berner,2021-Q3,0,0,0
 Christopher Berner,2021-Q2,0,0,0
 Christopher Berner,2021-Q1,0,0,0
 Christopher Berner,2020-Q4,0,0,0
@@ -45583,8 +39885,6 @@ Christopher Berner,2018-Q4,0,0,0
 Christopher Berner,2018-Q3,0,0,0
 Christopher Berner,2018-Q2,0,0,0
 Christopher Berner,2018-Q1,0,0,0
-Calpa Liu,2021-Q4,0,0,0
-Calpa Liu,2021-Q3,0,0,0
 Calpa Liu,2021-Q2,0,0,0
 Calpa Liu,2021-Q1,0,0,0
 Calpa Liu,2020-Q4,0,0,0
@@ -45599,8 +39899,6 @@ Calpa Liu,2018-Q4,0,0,0
 Calpa Liu,2018-Q3,0,0,0
 Calpa Liu,2018-Q2,0,0,0
 Calpa Liu,2018-Q1,0,0,0
-jiqiu,2021-Q4,0,0,0
-jiqiu,2021-Q3,0,0,0
 jiqiu,2021-Q2,0,0,0
 jiqiu,2021-Q1,0,0,0
 jiqiu,2020-Q4,0,0,0
@@ -45615,8 +39913,6 @@ jiqiu,2018-Q4,0,0,0
 jiqiu,2018-Q3,0,0,0
 jiqiu,2018-Q2,0,0,0
 jiqiu,2018-Q1,0,0,0
-Vamsi Sripathi,2021-Q4,0,0,0
-Vamsi Sripathi,2021-Q3,0,0,0
 Vamsi Sripathi,2021-Q2,0,0,0
 Vamsi Sripathi,2021-Q1,0,0,0
 Vamsi Sripathi,2020-Q4,0,0,0
@@ -45631,8 +39927,6 @@ Vamsi Sripathi,2018-Q4,0,0,0
 Vamsi Sripathi,2018-Q3,0,0,0
 Vamsi Sripathi,2018-Q2,0,0,0
 Vamsi Sripathi,2018-Q1,0,0,0
-Clark Zinzow,2021-Q4,0,0,0
-Clark Zinzow,2021-Q3,0,0,0
 Clark Zinzow,2021-Q2,0,0,0
 Clark Zinzow,2021-Q1,0,0,0
 Clark Zinzow,2020-Q4,0,0,0
@@ -45647,8 +39941,6 @@ Clark Zinzow,2018-Q4,0,0,0
 Clark Zinzow,2018-Q3,0,0,0
 Clark Zinzow,2018-Q2,0,0,0
 Clark Zinzow,2018-Q1,0,0,0
-Dmitry Persiyanov,2021-Q4,0,0,0
-Dmitry Persiyanov,2021-Q3,0,0,0
 Dmitry Persiyanov,2021-Q2,0,0,0
 Dmitry Persiyanov,2021-Q1,0,0,0
 Dmitry Persiyanov,2020-Q4,0,0,0
@@ -45663,8 +39955,6 @@ Dmitry Persiyanov,2018-Q4,0,0,0
 Dmitry Persiyanov,2018-Q3,0,0,0
 Dmitry Persiyanov,2018-Q2,0,0,0
 Dmitry Persiyanov,2018-Q1,0,0,0
-Jack Rae,2021-Q4,0,0,0
-Jack Rae,2021-Q3,0,0,0
 Jack Rae,2021-Q2,0,0,0
 Jack Rae,2021-Q1,0,0,0
 Jack Rae,2020-Q4,0,0,0
@@ -45679,8 +39969,6 @@ Jack Rae,2018-Q4,0,0,0
 Jack Rae,2018-Q3,0,0,0
 Jack Rae,2018-Q2,0,0,0
 Jack Rae,2018-Q1,0,0,0
-Xiaoyu Tao,2021-Q4,0,0,0
-Xiaoyu Tao,2021-Q3,0,0,0
 Xiaoyu Tao,2021-Q2,0,0,0
 Xiaoyu Tao,2021-Q1,0,0,0
 Xiaoyu Tao,2020-Q4,0,0,0
@@ -45695,8 +39983,6 @@ Xiaoyu Tao,2018-Q4,0,0,0
 Xiaoyu Tao,2018-Q3,0,0,0
 Xiaoyu Tao,2018-Q2,0,0,0
 Xiaoyu Tao,2018-Q1,0,0,0
-Franck Dernoncourt,2021-Q4,0,0,0
-Franck Dernoncourt,2021-Q3,0,0,0
 Franck Dernoncourt,2021-Q2,0,0,0
 Franck Dernoncourt,2021-Q1,0,0,0
 Franck Dernoncourt,2020-Q4,0,0,0
@@ -45711,8 +39997,6 @@ Franck Dernoncourt,2018-Q4,0,0,0
 Franck Dernoncourt,2018-Q3,0,0,0
 Franck Dernoncourt,2018-Q2,0,0,0
 Franck Dernoncourt,2018-Q1,0,0,0
-teldridge11,2021-Q4,0,0,0
-teldridge11,2021-Q3,0,0,0
 teldridge11,2021-Q2,0,0,0
 teldridge11,2021-Q1,0,0,0
 teldridge11,2020-Q4,0,0,0
@@ -45727,8 +40011,6 @@ teldridge11,2018-Q4,0,0,0
 teldridge11,2018-Q3,0,0,0
 teldridge11,2018-Q2,0,0,0
 teldridge11,2018-Q1,0,0,0
-Tomas Reimers,2021-Q4,0,0,0
-Tomas Reimers,2021-Q3,0,0,0
 Tomas Reimers,2021-Q2,0,0,0
 Tomas Reimers,2021-Q1,0,0,0
 Tomas Reimers,2020-Q4,0,0,0
@@ -45743,8 +40025,6 @@ Tomas Reimers,2018-Q4,0,0,0
 Tomas Reimers,2018-Q3,0,0,0
 Tomas Reimers,2018-Q2,0,0,0
 Tomas Reimers,2018-Q1,0,0,0
-tbonza,2021-Q4,0,0,0
-tbonza,2021-Q3,0,0,0
 tbonza,2021-Q2,0,0,0
 tbonza,2021-Q1,0,0,0
 tbonza,2020-Q4,0,0,0
@@ -45759,8 +40039,6 @@ tbonza,2018-Q4,0,0,0
 tbonza,2018-Q3,0,0,0
 tbonza,2018-Q2,0,0,0
 tbonza,2018-Q1,0,0,0
-Dan Ellis,2021-Q4,0,0,0
-Dan Ellis,2021-Q3,0,0,0
 Dan Ellis,2021-Q2,0,0,0
 Dan Ellis,2021-Q1,0,0,0
 Dan Ellis,2020-Q4,0,0,0
@@ -45775,8 +40053,6 @@ Dan Ellis,2018-Q4,0,0,0
 Dan Ellis,2018-Q3,0,0,0
 Dan Ellis,2018-Q2,0,0,0
 Dan Ellis,2018-Q1,0,0,0
-guilherme,2021-Q4,0,0,0
-guilherme,2021-Q3,0,0,0
 guilherme,2021-Q2,0,0,0
 guilherme,2021-Q1,0,0,0
 guilherme,2020-Q4,0,0,0
@@ -45791,8 +40067,6 @@ guilherme,2018-Q4,0,0,0
 guilherme,2018-Q3,0,0,0
 guilherme,2018-Q2,0,0,0
 guilherme,2018-Q1,0,0,0
-Michael Gharbi,2021-Q4,0,0,0
-Michael Gharbi,2021-Q3,0,0,0
 Michael Gharbi,2021-Q2,0,0,0
 Michael Gharbi,2021-Q1,0,0,0
 Michael Gharbi,2020-Q4,0,0,0
@@ -45807,8 +40081,6 @@ Michael Gharbi,2018-Q4,0,0,0
 Michael Gharbi,2018-Q3,0,0,0
 Michael Gharbi,2018-Q2,0,0,0
 Michael Gharbi,2018-Q1,0,0,0
-Jan Prach,2021-Q4,0,0,0
-Jan Prach,2021-Q3,0,0,0
 Jan Prach,2021-Q2,0,0,0
 Jan Prach,2021-Q1,0,0,0
 Jan Prach,2020-Q4,0,0,0
@@ -45823,8 +40095,6 @@ Jan Prach,2018-Q4,0,0,0
 Jan Prach,2018-Q3,0,0,0
 Jan Prach,2018-Q2,0,0,0
 Jan Prach,2018-Q1,0,0,0
-Shaurya Sharma,2021-Q4,0,0,0
-Shaurya Sharma,2021-Q3,0,0,0
 Shaurya Sharma,2021-Q2,0,0,0
 Shaurya Sharma,2021-Q1,0,0,0
 Shaurya Sharma,2020-Q4,0,0,0
@@ -45839,8 +40109,6 @@ Shaurya Sharma,2018-Q4,0,0,0
 Shaurya Sharma,2018-Q3,0,0,0
 Shaurya Sharma,2018-Q2,0,0,0
 Shaurya Sharma,2018-Q1,0,0,0
-alanwang93,2021-Q4,0,0,0
-alanwang93,2021-Q3,0,0,0
 alanwang93,2021-Q2,0,0,0
 alanwang93,2021-Q1,0,0,0
 alanwang93,2020-Q4,0,0,0
@@ -45855,8 +40123,6 @@ alanwang93,2018-Q4,0,0,0
 alanwang93,2018-Q3,0,0,0
 alanwang93,2018-Q2,0,0,0
 alanwang93,2018-Q1,0,0,0
-Ankesh Anand,2021-Q4,0,0,0
-Ankesh Anand,2021-Q3,0,0,0
 Ankesh Anand,2021-Q2,0,0,0
 Ankesh Anand,2021-Q1,0,0,0
 Ankesh Anand,2020-Q4,0,0,0
@@ -45871,8 +40137,6 @@ Ankesh Anand,2018-Q4,0,0,0
 Ankesh Anand,2018-Q3,0,0,0
 Ankesh Anand,2018-Q2,0,0,0
 Ankesh Anand,2018-Q1,0,0,0
-Reid Pryzant,2021-Q4,0,0,0
-Reid Pryzant,2021-Q3,0,0,0
 Reid Pryzant,2021-Q2,0,0,0
 Reid Pryzant,2021-Q1,0,0,0
 Reid Pryzant,2020-Q4,0,0,0
@@ -45887,8 +40151,6 @@ Reid Pryzant,2018-Q4,0,0,0
 Reid Pryzant,2018-Q3,0,0,0
 Reid Pryzant,2018-Q2,0,0,0
 Reid Pryzant,2018-Q1,0,0,0
-Jeremy Sawruk,2021-Q4,0,0,0
-Jeremy Sawruk,2021-Q3,0,0,0
 Jeremy Sawruk,2021-Q2,0,0,0
 Jeremy Sawruk,2021-Q1,0,0,0
 Jeremy Sawruk,2020-Q4,0,0,0
@@ -45903,8 +40165,6 @@ Jeremy Sawruk,2018-Q4,0,0,0
 Jeremy Sawruk,2018-Q3,0,0,0
 Jeremy Sawruk,2018-Q2,0,0,0
 Jeremy Sawruk,2018-Q1,0,0,0
-Ivan Smirnov,2021-Q4,0,0,0
-Ivan Smirnov,2021-Q3,0,0,0
 Ivan Smirnov,2021-Q2,0,0,0
 Ivan Smirnov,2021-Q1,0,0,0
 Ivan Smirnov,2020-Q4,0,0,0
@@ -45919,8 +40179,6 @@ Ivan Smirnov,2018-Q4,0,0,0
 Ivan Smirnov,2018-Q3,0,0,0
 Ivan Smirnov,2018-Q2,0,0,0
 Ivan Smirnov,2018-Q1,0,0,0
-Adal Chiriliuc,2021-Q4,0,0,0
-Adal Chiriliuc,2021-Q3,0,0,0
 Adal Chiriliuc,2021-Q2,0,0,0
 Adal Chiriliuc,2021-Q1,0,0,0
 Adal Chiriliuc,2020-Q4,0,0,0
@@ -45935,8 +40193,6 @@ Adal Chiriliuc,2018-Q4,0,0,0
 Adal Chiriliuc,2018-Q3,0,0,0
 Adal Chiriliuc,2018-Q2,0,0,0
 Adal Chiriliuc,2018-Q1,0,0,0
-Javi Ribera,2021-Q4,0,0,0
-Javi Ribera,2021-Q3,0,0,0
 Javi Ribera,2021-Q2,0,0,0
 Javi Ribera,2021-Q1,0,0,0
 Javi Ribera,2020-Q4,0,0,0
@@ -45951,8 +40207,6 @@ Javi Ribera,2018-Q4,0,0,0
 Javi Ribera,2018-Q3,0,0,0
 Javi Ribera,2018-Q2,0,0,0
 Javi Ribera,2018-Q1,0,0,0
-selay01,2021-Q4,0,0,0
-selay01,2021-Q3,0,0,0
 selay01,2021-Q2,0,0,0
 selay01,2021-Q1,0,0,0
 selay01,2020-Q4,0,0,0
@@ -45967,8 +40221,6 @@ selay01,2018-Q4,0,0,0
 selay01,2018-Q3,0,0,0
 selay01,2018-Q2,0,0,0
 selay01,2018-Q1,0,0,0
-LI Yi,2021-Q4,0,0,0
-LI Yi,2021-Q3,0,0,0
 LI Yi,2021-Q2,0,0,0
 LI Yi,2021-Q1,0,0,0
 LI Yi,2020-Q4,0,0,0
@@ -45983,8 +40235,6 @@ LI Yi,2018-Q4,0,0,0
 LI Yi,2018-Q3,0,0,0
 LI Yi,2018-Q2,0,0,0
 LI Yi,2018-Q1,0,0,0
-Jihun Choi,2021-Q4,0,0,0
-Jihun Choi,2021-Q3,0,0,0
 Jihun Choi,2021-Q2,0,0,0
 Jihun Choi,2021-Q1,0,0,0
 Jihun Choi,2020-Q4,0,0,0
@@ -45999,8 +40249,6 @@ Jihun Choi,2018-Q4,0,0,0
 Jihun Choi,2018-Q3,0,0,0
 Jihun Choi,2018-Q2,0,0,0
 Jihun Choi,2018-Q1,0,0,0
-Huazuo Gao,2021-Q4,0,0,0
-Huazuo Gao,2021-Q3,0,0,0
 Huazuo Gao,2021-Q2,0,0,0
 Huazuo Gao,2021-Q1,0,0,0
 Huazuo Gao,2020-Q4,0,0,0
@@ -46015,8 +40263,6 @@ Huazuo Gao,2018-Q4,0,0,0
 Huazuo Gao,2018-Q3,0,0,0
 Huazuo Gao,2018-Q2,0,0,0
 Huazuo Gao,2018-Q1,0,0,0
-Rahul Kavi,2021-Q4,0,0,0
-Rahul Kavi,2021-Q3,0,0,0
 Rahul Kavi,2021-Q2,0,0,0
 Rahul Kavi,2021-Q1,0,0,0
 Rahul Kavi,2020-Q4,0,0,0
@@ -46031,8 +40277,6 @@ Rahul Kavi,2018-Q4,0,0,0
 Rahul Kavi,2018-Q3,0,0,0
 Rahul Kavi,2018-Q2,0,0,0
 Rahul Kavi,2018-Q1,0,0,0
-Prayag Verma,2021-Q4,0,0,0
-Prayag Verma,2021-Q3,0,0,0
 Prayag Verma,2021-Q2,0,0,0
 Prayag Verma,2021-Q1,0,0,0
 Prayag Verma,2020-Q4,0,0,0
@@ -46047,8 +40291,6 @@ Prayag Verma,2018-Q4,0,0,0
 Prayag Verma,2018-Q3,0,0,0
 Prayag Verma,2018-Q2,0,0,0
 Prayag Verma,2018-Q1,0,0,0
-David Truong,2021-Q4,0,0,0
-David Truong,2021-Q3,0,0,0
 David Truong,2021-Q2,0,0,0
 David Truong,2021-Q1,0,0,0
 David Truong,2020-Q4,0,0,0
@@ -46063,8 +40305,6 @@ David Truong,2018-Q4,0,0,0
 David Truong,2018-Q3,0,0,0
 David Truong,2018-Q2,0,0,0
 David Truong,2018-Q1,0,0,0
-will,2021-Q4,0,0,0
-will,2021-Q3,0,0,0
 will,2021-Q2,0,0,0
 will,2021-Q1,0,0,0
 will,2020-Q4,0,0,0
@@ -46079,8 +40319,6 @@ will,2018-Q4,0,0,0
 will,2018-Q3,0,0,0
 will,2018-Q2,0,0,0
 will,2018-Q1,0,0,0
-Kankroc,2021-Q4,0,0,0
-Kankroc,2021-Q3,0,0,0
 Kankroc,2021-Q2,0,0,0
 Kankroc,2021-Q1,0,0,0
 Kankroc,2020-Q4,0,0,0
@@ -46095,8 +40333,6 @@ Kankroc,2018-Q4,0,0,0
 Kankroc,2018-Q3,0,0,0
 Kankroc,2018-Q2,0,0,0
 Kankroc,2018-Q1,0,0,0
-lurker,2021-Q4,0,0,0
-lurker,2021-Q3,0,0,0
 lurker,2021-Q2,0,0,0
 lurker,2021-Q1,0,0,0
 lurker,2020-Q4,0,0,0
@@ -46111,8 +40347,6 @@ lurker,2018-Q4,0,0,0
 lurker,2018-Q3,0,0,0
 lurker,2018-Q2,0,0,0
 lurker,2018-Q1,0,0,0
-Rüdiger Busche,2021-Q4,0,0,0
-Rüdiger Busche,2021-Q3,0,0,0
 Rüdiger Busche,2021-Q2,0,0,0
 Rüdiger Busche,2021-Q1,0,0,0
 Rüdiger Busche,2020-Q4,0,0,0
@@ -46127,8 +40361,6 @@ Rüdiger Busche,2018-Q4,0,0,0
 Rüdiger Busche,2018-Q3,0,0,0
 Rüdiger Busche,2018-Q2,0,0,0
 Rüdiger Busche,2018-Q1,0,0,0
-Anton Loss,2021-Q4,0,0,0
-Anton Loss,2021-Q3,0,0,0
 Anton Loss,2021-Q2,0,0,0
 Anton Loss,2021-Q1,0,0,0
 Anton Loss,2020-Q4,0,0,0
@@ -46143,8 +40375,6 @@ Anton Loss,2018-Q4,0,0,0
 Anton Loss,2018-Q3,0,0,0
 Anton Loss,2018-Q2,0,0,0
 Anton Loss,2018-Q1,0,0,0
-Raven Iqqe,2021-Q4,0,0,0
-Raven Iqqe,2021-Q3,0,0,0
 Raven Iqqe,2021-Q2,0,0,0
 Raven Iqqe,2021-Q1,0,0,0
 Raven Iqqe,2020-Q4,0,0,0
@@ -46159,8 +40389,6 @@ Raven Iqqe,2018-Q4,0,0,0
 Raven Iqqe,2018-Q3,0,0,0
 Raven Iqqe,2018-Q2,0,0,0
 Raven Iqqe,2018-Q1,0,0,0
-bakunyo,2021-Q4,0,0,0
-bakunyo,2021-Q3,0,0,0
 bakunyo,2021-Q2,0,0,0
 bakunyo,2021-Q1,0,0,0
 bakunyo,2020-Q4,0,0,0
@@ -46175,8 +40403,6 @@ bakunyo,2018-Q4,0,0,0
 bakunyo,2018-Q3,0,0,0
 bakunyo,2018-Q2,0,0,0
 bakunyo,2018-Q1,0,0,0
-Raphael Gontijo Lopes,2021-Q4,0,0,0
-Raphael Gontijo Lopes,2021-Q3,0,0,0
 Raphael Gontijo Lopes,2021-Q2,0,0,0
 Raphael Gontijo Lopes,2021-Q1,0,0,0
 Raphael Gontijo Lopes,2020-Q4,0,0,0
@@ -46191,8 +40417,6 @@ Raphael Gontijo Lopes,2018-Q4,0,0,0
 Raphael Gontijo Lopes,2018-Q3,0,0,0
 Raphael Gontijo Lopes,2018-Q2,0,0,0
 Raphael Gontijo Lopes,2018-Q1,0,0,0
-Kristina Chodorow,2021-Q4,0,0,0
-Kristina Chodorow,2021-Q3,0,0,0
 Kristina Chodorow,2021-Q2,0,0,0
 Kristina Chodorow,2021-Q1,0,0,0
 Kristina Chodorow,2020-Q4,0,0,0
@@ -46207,8 +40431,6 @@ Kristina Chodorow,2018-Q4,0,0,0
 Kristina Chodorow,2018-Q3,0,0,0
 Kristina Chodorow,2018-Q2,0,0,0
 Kristina Chodorow,2018-Q1,0,0,0
-Joan Thibault,2021-Q4,0,0,0
-Joan Thibault,2021-Q3,0,0,0
 Joan Thibault,2021-Q2,0,0,0
 Joan Thibault,2021-Q1,0,0,0
 Joan Thibault,2020-Q4,0,0,0
@@ -46223,8 +40445,6 @@ Joan Thibault,2018-Q4,0,0,0
 Joan Thibault,2018-Q3,0,0,0
 Joan Thibault,2018-Q2,0,0,0
 Joan Thibault,2018-Q1,0,0,0
-Julian Berman,2021-Q4,0,0,0
-Julian Berman,2021-Q3,0,0,0
 Julian Berman,2021-Q2,0,0,0
 Julian Berman,2021-Q1,0,0,0
 Julian Berman,2020-Q4,0,0,0
@@ -46239,8 +40459,6 @@ Julian Berman,2018-Q4,0,0,0
 Julian Berman,2018-Q3,0,0,0
 Julian Berman,2018-Q2,0,0,0
 Julian Berman,2018-Q1,0,0,0
-Russell Kaplan,2021-Q4,0,0,0
-Russell Kaplan,2021-Q3,0,0,0
 Russell Kaplan,2021-Q2,0,0,0
 Russell Kaplan,2021-Q1,0,0,0
 Russell Kaplan,2020-Q4,0,0,0
@@ -46255,8 +40473,6 @@ Russell Kaplan,2018-Q4,0,0,0
 Russell Kaplan,2018-Q3,0,0,0
 Russell Kaplan,2018-Q2,0,0,0
 Russell Kaplan,2018-Q1,0,0,0
-Evgeny Mazovetskiy,2021-Q4,0,0,0
-Evgeny Mazovetskiy,2021-Q3,0,0,0
 Evgeny Mazovetskiy,2021-Q2,0,0,0
 Evgeny Mazovetskiy,2021-Q1,0,0,0
 Evgeny Mazovetskiy,2020-Q4,0,0,0
@@ -46271,8 +40487,6 @@ Evgeny Mazovetskiy,2018-Q4,0,0,0
 Evgeny Mazovetskiy,2018-Q3,0,0,0
 Evgeny Mazovetskiy,2018-Q2,0,0,0
 Evgeny Mazovetskiy,2018-Q1,0,0,0
-Chad Whipkey,2021-Q4,0,0,0
-Chad Whipkey,2021-Q3,0,0,0
 Chad Whipkey,2021-Q2,0,0,0
 Chad Whipkey,2021-Q1,0,0,0
 Chad Whipkey,2020-Q4,0,0,0
@@ -46287,8 +40501,6 @@ Chad Whipkey,2018-Q4,0,0,0
 Chad Whipkey,2018-Q3,0,0,0
 Chad Whipkey,2018-Q2,0,0,0
 Chad Whipkey,2018-Q1,0,0,0
-Brady Zhou,2021-Q4,0,0,0
-Brady Zhou,2021-Q3,0,0,0
 Brady Zhou,2021-Q2,0,0,0
 Brady Zhou,2021-Q1,0,0,0
 Brady Zhou,2020-Q4,0,0,0
@@ -46303,8 +40515,6 @@ Brady Zhou,2018-Q4,0,0,0
 Brady Zhou,2018-Q3,0,0,0
 Brady Zhou,2018-Q2,0,0,0
 Brady Zhou,2018-Q1,0,0,0
-Lezcano,2021-Q4,0,0,0
-Lezcano,2021-Q3,0,0,0
 Lezcano,2021-Q2,0,0,0
 Lezcano,2021-Q1,0,0,0
 Lezcano,2020-Q4,0,0,0
@@ -46319,8 +40529,6 @@ Lezcano,2018-Q4,0,0,0
 Lezcano,2018-Q3,0,0,0
 Lezcano,2018-Q2,0,0,0
 Lezcano,2018-Q1,0,0,0
-mahmoud-abuzaina,2021-Q4,0,0,0
-mahmoud-abuzaina,2021-Q3,0,0,0
 mahmoud-abuzaina,2021-Q2,0,0,0
 mahmoud-abuzaina,2021-Q1,0,0,0
 mahmoud-abuzaina,2020-Q4,0,0,0
@@ -46335,8 +40543,6 @@ mahmoud-abuzaina,2018-Q4,0,0,0
 mahmoud-abuzaina,2018-Q3,0,0,0
 mahmoud-abuzaina,2018-Q2,0,0,0
 mahmoud-abuzaina,2018-Q1,0,0,0
-Nikolaas Steenbergen,2021-Q4,0,0,0
-Nikolaas Steenbergen,2021-Q3,0,0,0
 Nikolaas Steenbergen,2021-Q2,0,0,0
 Nikolaas Steenbergen,2021-Q1,0,0,0
 Nikolaas Steenbergen,2020-Q4,0,0,0
@@ -46351,8 +40557,6 @@ Nikolaas Steenbergen,2018-Q4,0,0,0
 Nikolaas Steenbergen,2018-Q3,0,0,0
 Nikolaas Steenbergen,2018-Q2,0,0,0
 Nikolaas Steenbergen,2018-Q1,0,0,0
-Rizwan Asif,2021-Q4,0,0,0
-Rizwan Asif,2021-Q3,0,0,0
 Rizwan Asif,2021-Q2,0,0,0
 Rizwan Asif,2021-Q1,0,0,0
 Rizwan Asif,2020-Q4,0,0,0
@@ -46367,8 +40571,6 @@ Rizwan Asif,2018-Q4,0,0,0
 Rizwan Asif,2018-Q3,0,0,0
 Rizwan Asif,2018-Q2,0,0,0
 Rizwan Asif,2018-Q1,0,0,0
-mlucool,2021-Q4,0,0,0
-mlucool,2021-Q3,0,0,0
 mlucool,2021-Q2,0,0,0
 mlucool,2021-Q1,0,0,0
 mlucool,2020-Q4,0,0,0
@@ -46383,8 +40585,6 @@ mlucool,2018-Q4,0,0,0
 mlucool,2018-Q3,0,0,0
 mlucool,2018-Q2,0,0,0
 mlucool,2018-Q1,0,0,0
-LUO Yun,2021-Q4,0,0,0
-LUO Yun,2021-Q3,0,0,0
 LUO Yun,2021-Q2,0,0,0
 LUO Yun,2021-Q1,0,0,0
 LUO Yun,2020-Q4,0,0,0
@@ -46399,8 +40599,6 @@ LUO Yun,2018-Q4,0,0,0
 LUO Yun,2018-Q3,0,0,0
 LUO Yun,2018-Q2,0,0,0
 LUO Yun,2018-Q1,0,0,0
-Jongwook Choi,2021-Q4,0,0,0
-Jongwook Choi,2021-Q3,0,0,0
 Jongwook Choi,2021-Q2,0,0,0
 Jongwook Choi,2021-Q1,0,0,0
 Jongwook Choi,2020-Q4,0,0,0
@@ -46415,8 +40613,6 @@ Jongwook Choi,2018-Q4,0,0,0
 Jongwook Choi,2018-Q3,0,0,0
 Jongwook Choi,2018-Q2,0,0,0
 Jongwook Choi,2018-Q1,0,0,0
-hartb,2021-Q4,0,0,0
-hartb,2021-Q3,0,0,0
 hartb,2021-Q2,0,0,0
 hartb,2021-Q1,0,0,0
 hartb,2020-Q4,0,0,0
@@ -46431,8 +40627,6 @@ hartb,2018-Q4,0,0,0
 hartb,2018-Q3,0,0,0
 hartb,2018-Q2,0,0,0
 hartb,2018-Q1,0,0,0
-Eron Wright,2021-Q4,0,0,0
-Eron Wright,2021-Q3,0,0,0
 Eron Wright,2021-Q2,0,0,0
 Eron Wright,2021-Q1,0,0,0
 Eron Wright,2020-Q4,0,0,0
@@ -46447,8 +40641,6 @@ Eron Wright,2018-Q4,0,0,0
 Eron Wright,2018-Q3,0,0,0
 Eron Wright,2018-Q2,0,0,0
 Eron Wright,2018-Q1,0,0,0
-Muammar ibn Faisal,2021-Q4,0,0,0
-Muammar ibn Faisal,2021-Q3,0,0,0
 Muammar ibn Faisal,2021-Q2,0,0,0
 Muammar ibn Faisal,2021-Q1,0,0,0
 Muammar ibn Faisal,2020-Q4,0,0,0
@@ -46463,8 +40655,6 @@ Muammar ibn Faisal,2018-Q4,0,0,0
 Muammar ibn Faisal,2018-Q3,0,0,0
 Muammar ibn Faisal,2018-Q2,0,0,0
 Muammar ibn Faisal,2018-Q1,0,0,0
-Martial Hue,2021-Q4,0,0,0
-Martial Hue,2021-Q3,0,0,0
 Martial Hue,2021-Q2,0,0,0
 Martial Hue,2021-Q1,0,0,0
 Martial Hue,2020-Q4,0,0,0
@@ -46479,8 +40669,6 @@ Martial Hue,2018-Q4,0,0,0
 Martial Hue,2018-Q3,0,0,0
 Martial Hue,2018-Q2,0,0,0
 Martial Hue,2018-Q1,0,0,0
-Richard Shin,2021-Q4,0,0,0
-Richard Shin,2021-Q3,0,0,0
 Richard Shin,2021-Q2,0,0,0
 Richard Shin,2021-Q1,0,0,0
 Richard Shin,2020-Q4,0,0,0
@@ -46495,8 +40683,6 @@ Richard Shin,2018-Q4,0,0,0
 Richard Shin,2018-Q3,0,0,0
 Richard Shin,2018-Q2,0,0,0
 Richard Shin,2018-Q1,0,0,0
-akash,2021-Q4,0,0,0
-akash,2021-Q3,0,0,0
 akash,2021-Q2,0,0,0
 akash,2021-Q1,0,0,0
 akash,2020-Q4,0,0,0
@@ -46511,8 +40697,6 @@ akash,2018-Q4,0,0,0
 akash,2018-Q3,0,0,0
 akash,2018-Q2,0,0,0
 akash,2018-Q1,0,0,0
-Ashutosh Das,2021-Q4,0,0,0
-Ashutosh Das,2021-Q3,0,0,0
 Ashutosh Das,2021-Q2,0,0,0
 Ashutosh Das,2021-Q1,0,0,0
 Ashutosh Das,2020-Q4,0,0,0
@@ -46527,8 +40711,6 @@ Ashutosh Das,2018-Q4,0,0,0
 Ashutosh Das,2018-Q3,0,0,0
 Ashutosh Das,2018-Q2,0,0,0
 Ashutosh Das,2018-Q1,0,0,0
-Alexander Mossin,2021-Q4,0,0,0
-Alexander Mossin,2021-Q3,0,0,0
 Alexander Mossin,2021-Q2,0,0,0
 Alexander Mossin,2021-Q1,0,0,0
 Alexander Mossin,2020-Q4,0,0,0
@@ -46543,8 +40725,6 @@ Alexander Mossin,2018-Q4,0,0,0
 Alexander Mossin,2018-Q3,0,0,0
 Alexander Mossin,2018-Q2,0,0,0
 Alexander Mossin,2018-Q1,0,0,0
-Chih Cheng Liang,2021-Q4,0,0,0
-Chih Cheng Liang,2021-Q3,0,0,0
 Chih Cheng Liang,2021-Q2,0,0,0
 Chih Cheng Liang,2021-Q1,0,0,0
 Chih Cheng Liang,2020-Q4,0,0,0
@@ -46559,8 +40739,6 @@ Chih Cheng Liang,2018-Q4,0,0,0
 Chih Cheng Liang,2018-Q3,0,0,0
 Chih Cheng Liang,2018-Q2,0,0,0
 Chih Cheng Liang,2018-Q1,0,0,0
-Philip Pries Henningsen,2021-Q4,0,0,0
-Philip Pries Henningsen,2021-Q3,0,0,0
 Philip Pries Henningsen,2021-Q2,0,0,0
 Philip Pries Henningsen,2021-Q1,0,0,0
 Philip Pries Henningsen,2020-Q4,0,0,0
@@ -46575,8 +40753,6 @@ Philip Pries Henningsen,2018-Q4,0,0,0
 Philip Pries Henningsen,2018-Q3,0,0,0
 Philip Pries Henningsen,2018-Q2,0,0,0
 Philip Pries Henningsen,2018-Q1,0,0,0
-Fisher Coder,2021-Q4,0,0,0
-Fisher Coder,2021-Q3,0,0,0
 Fisher Coder,2021-Q2,0,0,0
 Fisher Coder,2021-Q1,0,0,0
 Fisher Coder,2020-Q4,0,0,0
@@ -46591,8 +40767,6 @@ Fisher Coder,2018-Q4,0,0,0
 Fisher Coder,2018-Q3,0,0,0
 Fisher Coder,2018-Q2,0,0,0
 Fisher Coder,2018-Q1,0,0,0
-Hanna Revinskaya,2021-Q4,0,0,0
-Hanna Revinskaya,2021-Q3,0,0,0
 Hanna Revinskaya,2021-Q2,0,0,0
 Hanna Revinskaya,2021-Q1,0,0,0
 Hanna Revinskaya,2020-Q4,0,0,0
@@ -46607,8 +40781,6 @@ Hanna Revinskaya,2018-Q4,0,0,0
 Hanna Revinskaya,2018-Q3,0,0,0
 Hanna Revinskaya,2018-Q2,0,0,0
 Hanna Revinskaya,2018-Q1,0,0,0
-Medhat Omr,2021-Q4,0,0,0
-Medhat Omr,2021-Q3,0,0,0
 Medhat Omr,2021-Q2,0,0,0
 Medhat Omr,2021-Q1,0,0,0
 Medhat Omr,2020-Q4,0,0,0
@@ -46623,8 +40795,6 @@ Medhat Omr,2018-Q4,0,0,0
 Medhat Omr,2018-Q3,0,0,0
 Medhat Omr,2018-Q2,0,0,0
 Medhat Omr,2018-Q1,0,0,0
-Johannes Haux,2021-Q4,0,0,0
-Johannes Haux,2021-Q3,0,0,0
 Johannes Haux,2021-Q2,0,0,0
 Johannes Haux,2021-Q1,0,0,0
 Johannes Haux,2020-Q4,0,0,0
@@ -46639,8 +40809,6 @@ Johannes Haux,2018-Q4,0,0,0
 Johannes Haux,2018-Q3,0,0,0
 Johannes Haux,2018-Q2,0,0,0
 Johannes Haux,2018-Q1,0,0,0
-Gagan Goel,2021-Q4,0,0,0
-Gagan Goel,2021-Q3,0,0,0
 Gagan Goel,2021-Q2,0,0,0
 Gagan Goel,2021-Q1,0,0,0
 Gagan Goel,2020-Q4,0,0,0
@@ -46655,8 +40823,6 @@ Gagan Goel,2018-Q4,0,0,0
 Gagan Goel,2018-Q3,0,0,0
 Gagan Goel,2018-Q2,0,0,0
 Gagan Goel,2018-Q1,0,0,0
-Fabrizio (Misto) Milo,2021-Q4,0,0,0
-Fabrizio (Misto) Milo,2021-Q3,0,0,0
 Fabrizio (Misto) Milo,2021-Q2,0,0,0
 Fabrizio (Misto) Milo,2021-Q1,0,0,0
 Fabrizio (Misto) Milo,2020-Q4,0,0,0
@@ -46671,8 +40837,6 @@ Fabrizio (Misto) Milo,2018-Q4,0,0,0
 Fabrizio (Misto) Milo,2018-Q3,0,0,0
 Fabrizio (Misto) Milo,2018-Q2,0,0,0
 Fabrizio (Misto) Milo,2018-Q1,0,0,0
-Zafar Takhirov,2021-Q4,0,0,0
-Zafar Takhirov,2021-Q3,0,0,0
 Zafar Takhirov,2021-Q2,0,0,0
 Zafar Takhirov,2021-Q1,0,0,0
 Zafar Takhirov,2020-Q4,0,0,0
@@ -46687,8 +40851,6 @@ Zafar Takhirov,2018-Q4,0,0,0
 Zafar Takhirov,2018-Q3,0,0,0
 Zafar Takhirov,2018-Q2,0,0,0
 Zafar Takhirov,2018-Q1,0,0,0
-polonez,2021-Q4,0,0,0
-polonez,2021-Q3,0,0,0
 polonez,2021-Q2,0,0,0
 polonez,2021-Q1,0,0,0
 polonez,2020-Q4,0,0,0
@@ -46703,8 +40865,6 @@ polonez,2018-Q4,0,0,0
 polonez,2018-Q3,0,0,0
 polonez,2018-Q2,0,0,0
 polonez,2018-Q1,0,0,0
-Illia Polosukhin,2021-Q4,0,0,0
-Illia Polosukhin,2021-Q3,0,0,0
 Illia Polosukhin,2021-Q2,0,0,0
 Illia Polosukhin,2021-Q1,0,0,0
 Illia Polosukhin,2020-Q4,0,0,0
@@ -46719,8 +40879,6 @@ Illia Polosukhin,2018-Q4,0,0,0
 Illia Polosukhin,2018-Q3,0,0,0
 Illia Polosukhin,2018-Q2,0,0,0
 Illia Polosukhin,2018-Q1,0,0,0
-Kyle Bostelmann,2021-Q4,0,0,0
-Kyle Bostelmann,2021-Q3,0,0,0
 Kyle Bostelmann,2021-Q2,0,0,0
 Kyle Bostelmann,2021-Q1,0,0,0
 Kyle Bostelmann,2020-Q4,0,0,0
@@ -46735,8 +40893,6 @@ Kyle Bostelmann,2018-Q4,0,0,0
 Kyle Bostelmann,2018-Q3,0,0,0
 Kyle Bostelmann,2018-Q2,0,0,0
 Kyle Bostelmann,2018-Q1,0,0,0
-elirex,2021-Q4,0,0,0
-elirex,2021-Q3,0,0,0
 elirex,2021-Q2,0,0,0
 elirex,2021-Q1,0,0,0
 elirex,2020-Q4,0,0,0
@@ -46751,8 +40907,6 @@ elirex,2018-Q4,0,0,0
 elirex,2018-Q3,0,0,0
 elirex,2018-Q2,0,0,0
 elirex,2018-Q1,0,0,0
-KOUASSI Konan Jean-Claude,2021-Q4,0,0,0
-KOUASSI Konan Jean-Claude,2021-Q3,0,0,0
 KOUASSI Konan Jean-Claude,2021-Q2,0,0,0
 KOUASSI Konan Jean-Claude,2021-Q1,0,0,0
 KOUASSI Konan Jean-Claude,2020-Q4,0,0,0
@@ -46767,8 +40921,6 @@ KOUASSI Konan Jean-Claude,2018-Q4,0,0,0
 KOUASSI Konan Jean-Claude,2018-Q3,0,0,0
 KOUASSI Konan Jean-Claude,2018-Q2,0,0,0
 KOUASSI Konan Jean-Claude,2018-Q1,0,0,0
-Alexander Rosenberg Johansen,2021-Q4,0,0,0
-Alexander Rosenberg Johansen,2021-Q3,0,0,0
 Alexander Rosenberg Johansen,2021-Q2,0,0,0
 Alexander Rosenberg Johansen,2021-Q1,0,0,0
 Alexander Rosenberg Johansen,2020-Q4,0,0,0
@@ -46783,8 +40935,6 @@ Alexander Rosenberg Johansen,2018-Q4,0,0,0
 Alexander Rosenberg Johansen,2018-Q3,0,0,0
 Alexander Rosenberg Johansen,2018-Q2,0,0,0
 Alexander Rosenberg Johansen,2018-Q1,0,0,0
-Leo Mao,2021-Q4,0,0,0
-Leo Mao,2021-Q3,0,0,0
 Leo Mao,2021-Q2,0,0,0
 Leo Mao,2021-Q1,0,0,0
 Leo Mao,2020-Q4,0,0,0
@@ -46799,8 +40949,6 @@ Leo Mao,2018-Q4,0,0,0
 Leo Mao,2018-Q3,0,0,0
 Leo Mao,2018-Q2,0,0,0
 Leo Mao,2018-Q1,0,0,0
-Andy Chong Chin Shin,2021-Q4,0,0,0
-Andy Chong Chin Shin,2021-Q3,0,0,0
 Andy Chong Chin Shin,2021-Q2,0,0,0
 Andy Chong Chin Shin,2021-Q1,0,0,0
 Andy Chong Chin Shin,2020-Q4,0,0,0
@@ -46815,8 +40963,6 @@ Andy Chong Chin Shin,2018-Q4,0,0,0
 Andy Chong Chin Shin,2018-Q3,0,0,0
 Andy Chong Chin Shin,2018-Q2,0,0,0
 Andy Chong Chin Shin,2018-Q1,0,0,0
-Norman Heckscher,2021-Q4,0,0,0
-Norman Heckscher,2021-Q3,0,0,0
 Norman Heckscher,2021-Q2,0,0,0
 Norman Heckscher,2021-Q1,0,0,0
 Norman Heckscher,2020-Q4,0,0,0
@@ -46831,8 +40977,6 @@ Norman Heckscher,2018-Q4,0,0,0
 Norman Heckscher,2018-Q3,0,0,0
 Norman Heckscher,2018-Q2,0,0,0
 Norman Heckscher,2018-Q1,0,0,0
-Erik Aigner,2021-Q4,0,0,0
-Erik Aigner,2021-Q3,0,0,0
 Erik Aigner,2021-Q2,0,0,0
 Erik Aigner,2021-Q1,0,0,0
 Erik Aigner,2020-Q4,0,0,0
@@ -46847,8 +40991,6 @@ Erik Aigner,2018-Q4,0,0,0
 Erik Aigner,2018-Q3,0,0,0
 Erik Aigner,2018-Q2,0,0,0
 Erik Aigner,2018-Q1,0,0,0
-taknevski,2021-Q4,0,0,0
-taknevski,2021-Q3,0,0,0
 taknevski,2021-Q2,0,0,0
 taknevski,2021-Q1,0,0,0
 taknevski,2020-Q4,0,0,0
@@ -46863,8 +41005,6 @@ taknevski,2018-Q4,0,0,0
 taknevski,2018-Q3,0,0,0
 taknevski,2018-Q2,0,0,0
 taknevski,2018-Q1,0,0,0
-Hvass-Labs,2021-Q4,0,0,0
-Hvass-Labs,2021-Q3,0,0,0
 Hvass-Labs,2021-Q2,0,0,0
 Hvass-Labs,2021-Q1,0,0,0
 Hvass-Labs,2020-Q4,0,0,0
@@ -46879,8 +41019,6 @@ Hvass-Labs,2018-Q4,0,0,0
 Hvass-Labs,2018-Q3,0,0,0
 Hvass-Labs,2018-Q2,0,0,0
 Hvass-Labs,2018-Q1,0,0,0
-Keiji Kanazawa,2021-Q4,0,0,0
-Keiji Kanazawa,2021-Q3,0,0,0
 Keiji Kanazawa,2021-Q2,0,0,0
 Keiji Kanazawa,2021-Q1,0,0,0
 Keiji Kanazawa,2020-Q4,0,0,0
@@ -46895,8 +41033,6 @@ Keiji Kanazawa,2018-Q4,0,0,0
 Keiji Kanazawa,2018-Q3,0,0,0
 Keiji Kanazawa,2018-Q2,0,0,0
 Keiji Kanazawa,2018-Q1,0,0,0
-Yoni Ben-Meshulam,2021-Q4,0,0,0
-Yoni Ben-Meshulam,2021-Q3,0,0,0
 Yoni Ben-Meshulam,2021-Q2,0,0,0
 Yoni Ben-Meshulam,2021-Q1,0,0,0
 Yoni Ben-Meshulam,2020-Q4,0,0,0
@@ -46911,8 +41047,6 @@ Yoni Ben-Meshulam,2018-Q4,0,0,0
 Yoni Ben-Meshulam,2018-Q3,0,0,0
 Yoni Ben-Meshulam,2018-Q2,0,0,0
 Yoni Ben-Meshulam,2018-Q1,0,0,0
-nagachika,2021-Q4,0,0,0
-nagachika,2021-Q3,0,0,0
 nagachika,2021-Q2,0,0,0
 nagachika,2021-Q1,0,0,0
 nagachika,2020-Q4,0,0,0
@@ -46927,8 +41061,6 @@ nagachika,2018-Q4,0,0,0
 nagachika,2018-Q3,0,0,0
 nagachika,2018-Q2,0,0,0
 nagachika,2018-Q1,0,0,0
-Inflation,2021-Q4,0,0,0
-Inflation,2021-Q3,0,0,0
 Inflation,2021-Q2,0,0,0
 Inflation,2021-Q1,0,0,0
 Inflation,2020-Q4,0,0,0
@@ -46943,8 +41075,6 @@ Inflation,2018-Q4,0,0,0
 Inflation,2018-Q3,0,0,0
 Inflation,2018-Q2,0,0,0
 Inflation,2018-Q1,0,0,0
-David Z. Chen,2021-Q4,0,0,0
-David Z. Chen,2021-Q3,0,0,0
 David Z. Chen,2021-Q2,0,0,0
 David Z. Chen,2021-Q1,0,0,0
 David Z. Chen,2020-Q4,0,0,0
@@ -46959,8 +41089,6 @@ David Z. Chen,2018-Q4,0,0,0
 David Z. Chen,2018-Q3,0,0,0
 David Z. Chen,2018-Q2,0,0,0
 David Z. Chen,2018-Q1,0,0,0
-Michael Basilyan,2021-Q4,0,0,0
-Michael Basilyan,2021-Q3,0,0,0
 Michael Basilyan,2021-Q2,0,0,0
 Michael Basilyan,2021-Q1,0,0,0
 Michael Basilyan,2020-Q4,0,0,0
@@ -46975,8 +41103,6 @@ Michael Basilyan,2018-Q4,0,0,0
 Michael Basilyan,2018-Q3,0,0,0
 Michael Basilyan,2018-Q2,0,0,0
 Michael Basilyan,2018-Q1,0,0,0
-yaroslavvb@gmail.com,2021-Q4,0,0,0
-yaroslavvb@gmail.com,2021-Q3,0,0,0
 yaroslavvb@gmail.com,2021-Q2,0,0,0
 yaroslavvb@gmail.com,2021-Q1,0,0,0
 yaroslavvb@gmail.com,2020-Q4,0,0,0
@@ -46991,8 +41117,6 @@ yaroslavvb@gmail.com,2018-Q4,0,0,0
 yaroslavvb@gmail.com,2018-Q3,0,0,0
 yaroslavvb@gmail.com,2018-Q2,0,0,0
 yaroslavvb@gmail.com,2018-Q1,0,0,0
-Pengfei Ni,2021-Q4,0,0,0
-Pengfei Ni,2021-Q3,0,0,0
 Pengfei Ni,2021-Q2,0,0,0
 Pengfei Ni,2021-Q1,0,0,0
 Pengfei Ni,2020-Q4,0,0,0
@@ -47007,8 +41131,6 @@ Pengfei Ni,2018-Q4,0,0,0
 Pengfei Ni,2018-Q3,0,0,0
 Pengfei Ni,2018-Q2,0,0,0
 Pengfei Ni,2018-Q1,0,0,0
-Morten Just,2021-Q4,0,0,0
-Morten Just,2021-Q3,0,0,0
 Morten Just,2021-Q2,0,0,0
 Morten Just,2021-Q1,0,0,0
 Morten Just,2020-Q4,0,0,0
@@ -47023,8 +41145,6 @@ Morten Just,2018-Q4,0,0,0
 Morten Just,2018-Q3,0,0,0
 Morten Just,2018-Q2,0,0,0
 Morten Just,2018-Q1,0,0,0
-Daniel N. Lang,2021-Q4,0,0,0
-Daniel N. Lang,2021-Q3,0,0,0
 Daniel N. Lang,2021-Q2,0,0,0
 Daniel N. Lang,2021-Q1,0,0,0
 Daniel N. Lang,2020-Q4,0,0,0
@@ -47039,8 +41159,6 @@ Daniel N. Lang,2018-Q4,0,0,0
 Daniel N. Lang,2018-Q3,0,0,0
 Daniel N. Lang,2018-Q2,0,0,0
 Daniel N. Lang,2018-Q1,0,0,0
-Steffen Müller,2021-Q4,0,0,0
-Steffen Müller,2021-Q3,0,0,0
 Steffen Müller,2021-Q2,0,0,0
 Steffen Müller,2021-Q1,0,0,0
 Steffen Müller,2020-Q4,0,0,0
@@ -47055,8 +41173,6 @@ Steffen Müller,2018-Q4,0,0,0
 Steffen Müller,2018-Q3,0,0,0
 Steffen Müller,2018-Q2,0,0,0
 Steffen Müller,2018-Q1,0,0,0
-Wangda Tan,2021-Q4,0,0,0
-Wangda Tan,2021-Q3,0,0,0
 Wangda Tan,2021-Q2,0,0,0
 Wangda Tan,2021-Q1,0,0,0
 Wangda Tan,2020-Q4,0,0,0
@@ -47071,8 +41187,6 @@ Wangda Tan,2018-Q4,0,0,0
 Wangda Tan,2018-Q3,0,0,0
 Wangda Tan,2018-Q2,0,0,0
 Wangda Tan,2018-Q1,0,0,0
-Yota Toyama,2021-Q4,0,0,0
-Yota Toyama,2021-Q3,0,0,0
 Yota Toyama,2021-Q2,0,0,0
 Yota Toyama,2021-Q1,0,0,0
 Yota Toyama,2020-Q4,0,0,0
@@ -47087,8 +41201,6 @@ Yota Toyama,2018-Q4,0,0,0
 Yota Toyama,2018-Q3,0,0,0
 Yota Toyama,2018-Q2,0,0,0
 Yota Toyama,2018-Q1,0,0,0
-Alexander Novikov,2021-Q4,0,0,0
-Alexander Novikov,2021-Q3,0,0,0
 Alexander Novikov,2021-Q2,0,0,0
 Alexander Novikov,2021-Q1,0,0,0
 Alexander Novikov,2020-Q4,0,0,0
@@ -47103,8 +41215,6 @@ Alexander Novikov,2018-Q4,0,0,0
 Alexander Novikov,2018-Q3,0,0,0
 Alexander Novikov,2018-Q2,0,0,0
 Alexander Novikov,2018-Q1,0,0,0
-Jacob Israel,2021-Q4,0,0,0
-Jacob Israel,2021-Q3,0,0,0
 Jacob Israel,2021-Q2,0,0,0
 Jacob Israel,2021-Q1,0,0,0
 Jacob Israel,2020-Q4,0,0,0
@@ -47119,8 +41229,6 @@ Jacob Israel,2018-Q4,0,0,0
 Jacob Israel,2018-Q3,0,0,0
 Jacob Israel,2018-Q2,0,0,0
 Jacob Israel,2018-Q1,0,0,0
-John Pope,2021-Q4,0,0,0
-John Pope,2021-Q3,0,0,0
 John Pope,2021-Q2,0,0,0
 John Pope,2021-Q1,0,0,0
 John Pope,2020-Q4,0,0,0
@@ -47135,8 +41243,6 @@ John Pope,2018-Q4,0,0,0
 John Pope,2018-Q3,0,0,0
 John Pope,2018-Q2,0,0,0
 John Pope,2018-Q1,0,0,0
-Sam Putnam,2021-Q4,0,0,0
-Sam Putnam,2021-Q3,0,0,0
 Sam Putnam,2021-Q2,0,0,0
 Sam Putnam,2021-Q1,0,0,0
 Sam Putnam,2020-Q4,0,0,0
@@ -47151,8 +41257,6 @@ Sam Putnam,2018-Q4,0,0,0
 Sam Putnam,2018-Q3,0,0,0
 Sam Putnam,2018-Q2,0,0,0
 Sam Putnam,2018-Q1,0,0,0
-Finbarr Timbers,2021-Q4,0,0,0
-Finbarr Timbers,2021-Q3,0,0,0
 Finbarr Timbers,2021-Q2,0,0,0
 Finbarr Timbers,2021-Q1,0,0,0
 Finbarr Timbers,2020-Q4,0,0,0
@@ -47167,8 +41271,6 @@ Finbarr Timbers,2018-Q4,0,0,0
 Finbarr Timbers,2018-Q3,0,0,0
 Finbarr Timbers,2018-Q2,0,0,0
 Finbarr Timbers,2018-Q1,0,0,0
-SeongAhJo,2021-Q4,0,0,0
-SeongAhJo,2021-Q3,0,0,0
 SeongAhJo,2021-Q2,0,0,0
 SeongAhJo,2021-Q1,0,0,0
 SeongAhJo,2020-Q4,0,0,0
@@ -47183,8 +41285,6 @@ SeongAhJo,2018-Q4,0,0,0
 SeongAhJo,2018-Q3,0,0,0
 SeongAhJo,2018-Q2,0,0,0
 SeongAhJo,2018-Q1,0,0,0
-Jin Kim,2021-Q4,0,0,0
-Jin Kim,2021-Q3,0,0,0
 Jin Kim,2021-Q2,0,0,0
 Jin Kim,2021-Q1,0,0,0
 Jin Kim,2020-Q4,0,0,0
@@ -47199,8 +41299,6 @@ Jin Kim,2018-Q4,0,0,0
 Jin Kim,2018-Q3,0,0,0
 Jin Kim,2018-Q2,0,0,0
 Jin Kim,2018-Q1,0,0,0
-Xingdong Zuo,2021-Q4,0,0,0
-Xingdong Zuo,2021-Q3,0,0,0
 Xingdong Zuo,2021-Q2,0,0,0
 Xingdong Zuo,2021-Q1,0,0,0
 Xingdong Zuo,2020-Q4,0,0,0
@@ -47215,8 +41313,6 @@ Xingdong Zuo,2018-Q4,0,0,0
 Xingdong Zuo,2018-Q3,0,0,0
 Xingdong Zuo,2018-Q2,0,0,0
 Xingdong Zuo,2018-Q1,0,0,0
-TheUSER123,2021-Q4,0,0,0
-TheUSER123,2021-Q3,0,0,0
 TheUSER123,2021-Q2,0,0,0
 TheUSER123,2021-Q1,0,0,0
 TheUSER123,2020-Q4,0,0,0
@@ -47231,8 +41327,6 @@ TheUSER123,2018-Q4,0,0,0
 TheUSER123,2018-Q3,0,0,0
 TheUSER123,2018-Q2,0,0,0
 TheUSER123,2018-Q1,0,0,0
-Wenjian Huang,2021-Q4,0,0,0
-Wenjian Huang,2021-Q3,0,0,0
 Wenjian Huang,2021-Q2,0,0,0
 Wenjian Huang,2021-Q1,0,0,0
 Wenjian Huang,2020-Q4,0,0,0
@@ -47247,8 +41341,6 @@ Wenjian Huang,2018-Q4,0,0,0
 Wenjian Huang,2018-Q3,0,0,0
 Wenjian Huang,2018-Q2,0,0,0
 Wenjian Huang,2018-Q1,0,0,0
-Comic Chang,2021-Q4,0,0,0
-Comic Chang,2021-Q3,0,0,0
 Comic Chang,2021-Q2,0,0,0
 Comic Chang,2021-Q1,0,0,0
 Comic Chang,2020-Q4,0,0,0
@@ -47263,8 +41355,6 @@ Comic Chang,2018-Q4,0,0,0
 Comic Chang,2018-Q3,0,0,0
 Comic Chang,2018-Q2,0,0,0
 Comic Chang,2018-Q1,0,0,0
-Rudolf Rosa,2021-Q4,0,0,0
-Rudolf Rosa,2021-Q3,0,0,0
 Rudolf Rosa,2021-Q2,0,0,0
 Rudolf Rosa,2021-Q1,0,0,0
 Rudolf Rosa,2020-Q4,0,0,0
@@ -47279,8 +41369,6 @@ Rudolf Rosa,2018-Q4,0,0,0
 Rudolf Rosa,2018-Q3,0,0,0
 Rudolf Rosa,2018-Q2,0,0,0
 Rudolf Rosa,2018-Q1,0,0,0
-danielgordon10,2021-Q4,0,0,0
-danielgordon10,2021-Q3,0,0,0
 danielgordon10,2021-Q2,0,0,0
 danielgordon10,2021-Q1,0,0,0
 danielgordon10,2020-Q4,0,0,0
@@ -47295,8 +41383,6 @@ danielgordon10,2018-Q4,0,0,0
 danielgordon10,2018-Q3,0,0,0
 danielgordon10,2018-Q2,0,0,0
 danielgordon10,2018-Q1,0,0,0
-Nishant Shukla,2021-Q4,0,0,0
-Nishant Shukla,2021-Q3,0,0,0
 Nishant Shukla,2021-Q2,0,0,0
 Nishant Shukla,2021-Q1,0,0,0
 Nishant Shukla,2020-Q4,0,0,0
@@ -47311,8 +41397,6 @@ Nishant Shukla,2018-Q4,0,0,0
 Nishant Shukla,2018-Q3,0,0,0
 Nishant Shukla,2018-Q2,0,0,0
 Nishant Shukla,2018-Q1,0,0,0
-Adam Michael,2021-Q4,0,0,0
-Adam Michael,2021-Q3,0,0,0
 Adam Michael,2021-Q2,0,0,0
 Adam Michael,2021-Q1,0,0,0
 Adam Michael,2020-Q4,0,0,0
@@ -47327,8 +41411,6 @@ Adam Michael,2018-Q4,0,0,0
 Adam Michael,2018-Q3,0,0,0
 Adam Michael,2018-Q2,0,0,0
 Adam Michael,2018-Q1,0,0,0
-Aaron Hu,2021-Q4,0,0,0
-Aaron Hu,2021-Q3,0,0,0
 Aaron Hu,2021-Q2,0,0,0
 Aaron Hu,2021-Q1,0,0,0
 Aaron Hu,2020-Q4,0,0,0
@@ -47343,8 +41425,6 @@ Aaron Hu,2018-Q4,0,0,0
 Aaron Hu,2018-Q3,0,0,0
 Aaron Hu,2018-Q2,0,0,0
 Aaron Hu,2018-Q1,0,0,0
-Dmitri Lapin,2021-Q4,0,0,0
-Dmitri Lapin,2021-Q3,0,0,0
 Dmitri Lapin,2021-Q2,0,0,0
 Dmitri Lapin,2021-Q1,0,0,0
 Dmitri Lapin,2020-Q4,0,0,0
@@ -47359,8 +41439,6 @@ Dmitri Lapin,2018-Q4,0,0,0
 Dmitri Lapin,2018-Q3,0,0,0
 Dmitri Lapin,2018-Q2,0,0,0
 Dmitri Lapin,2018-Q1,0,0,0
-Jingtian Peng,2021-Q4,0,0,0
-Jingtian Peng,2021-Q3,0,0,0
 Jingtian Peng,2021-Q2,0,0,0
 Jingtian Peng,2021-Q1,0,0,0
 Jingtian Peng,2020-Q4,0,0,0
@@ -47375,8 +41453,6 @@ Jingtian Peng,2018-Q4,0,0,0
 Jingtian Peng,2018-Q3,0,0,0
 Jingtian Peng,2018-Q2,0,0,0
 Jingtian Peng,2018-Q1,0,0,0
-Carmezim,2021-Q4,0,0,0
-Carmezim,2021-Q3,0,0,0
 Carmezim,2021-Q2,0,0,0
 Carmezim,2021-Q1,0,0,0
 Carmezim,2020-Q4,0,0,0
@@ -47391,8 +41467,6 @@ Carmezim,2018-Q4,0,0,0
 Carmezim,2018-Q3,0,0,0
 Carmezim,2018-Q2,0,0,0
 Carmezim,2018-Q1,0,0,0
-Kye Bostelmann,2021-Q4,0,0,0
-Kye Bostelmann,2021-Q3,0,0,0
 Kye Bostelmann,2021-Q2,0,0,0
 Kye Bostelmann,2021-Q1,0,0,0
 Kye Bostelmann,2020-Q4,0,0,0
@@ -47407,8 +41481,6 @@ Kye Bostelmann,2018-Q4,0,0,0
 Kye Bostelmann,2018-Q3,0,0,0
 Kye Bostelmann,2018-Q2,0,0,0
 Kye Bostelmann,2018-Q1,0,0,0
-Chad Kennedy,2021-Q4,0,0,0
-Chad Kennedy,2021-Q3,0,0,0
 Chad Kennedy,2021-Q2,0,0,0
 Chad Kennedy,2021-Q1,0,0,0
 Chad Kennedy,2020-Q4,0,0,0
@@ -47423,8 +41495,6 @@ Chad Kennedy,2018-Q4,0,0,0
 Chad Kennedy,2018-Q3,0,0,0
 Chad Kennedy,2018-Q2,0,0,0
 Chad Kennedy,2018-Q1,0,0,0
-chadkennedyonline,2021-Q4,0,0,0
-chadkennedyonline,2021-Q3,0,0,0
 chadkennedyonline,2021-Q2,0,0,0
 chadkennedyonline,2021-Q1,0,0,0
 chadkennedyonline,2020-Q4,0,0,0
@@ -47439,8 +41509,6 @@ chadkennedyonline,2018-Q4,0,0,0
 chadkennedyonline,2018-Q3,0,0,0
 chadkennedyonline,2018-Q2,0,0,0
 chadkennedyonline,2018-Q1,0,0,0
-cais,2021-Q4,0,0,0
-cais,2021-Q3,0,0,0
 cais,2021-Q2,0,0,0
 cais,2021-Q1,0,0,0
 cais,2020-Q4,0,0,0
@@ -47455,8 +41523,6 @@ cais,2018-Q4,0,0,0
 cais,2018-Q3,0,0,0
 cais,2018-Q2,0,0,0
 cais,2018-Q1,0,0,0
-Dan Mané,2021-Q4,0,0,0
-Dan Mané,2021-Q3,0,0,0
 Dan Mané,2021-Q2,0,0,0
 Dan Mané,2021-Q1,0,0,0
 Dan Mané,2020-Q4,0,0,0
@@ -47471,8 +41537,6 @@ Dan Mané,2018-Q4,0,0,0
 Dan Mané,2018-Q3,0,0,0
 Dan Mané,2018-Q2,0,0,0
 Dan Mané,2018-Q1,0,0,0
-Ronny,2021-Q4,0,0,0
-Ronny,2021-Q3,0,0,0
 Ronny,2021-Q2,0,0,0
 Ronny,2021-Q1,0,0,0
 Ronny,2020-Q4,0,0,0
@@ -47487,8 +41551,6 @@ Ronny,2018-Q4,0,0,0
 Ronny,2018-Q3,0,0,0
 Ronny,2018-Q2,0,0,0
 Ronny,2018-Q1,0,0,0
-b0noI,2021-Q4,0,0,0
-b0noI,2021-Q3,0,0,0
 b0noI,2021-Q2,0,0,0
 b0noI,2021-Q1,0,0,0
 b0noI,2020-Q4,0,0,0
@@ -47503,8 +41565,6 @@ b0noI,2018-Q4,0,0,0
 b0noI,2018-Q3,0,0,0
 b0noI,2018-Q2,0,0,0
 b0noI,2018-Q1,0,0,0
-Dan,2021-Q4,0,0,0
-Dan,2021-Q3,0,0,0
 Dan,2021-Q2,0,0,0
 Dan,2021-Q1,0,0,0
 Dan,2020-Q4,0,0,0
@@ -47519,8 +41579,6 @@ Dan,2018-Q4,0,0,0
 Dan,2018-Q3,0,0,0
 Dan,2018-Q2,0,0,0
 Dan,2018-Q1,0,0,0
-Issac,2021-Q4,0,0,0
-Issac,2021-Q3,0,0,0
 Issac,2021-Q2,0,0,0
 Issac,2021-Q1,0,0,0
 Issac,2020-Q4,0,0,0
@@ -47535,8 +41593,6 @@ Issac,2018-Q4,0,0,0
 Issac,2018-Q3,0,0,0
 Issac,2018-Q2,0,0,0
 Issac,2018-Q1,0,0,0
-Evan Cofer,2021-Q4,0,0,0
-Evan Cofer,2021-Q3,0,0,0
 Evan Cofer,2021-Q2,0,0,0
 Evan Cofer,2021-Q1,0,0,0
 Evan Cofer,2020-Q4,0,0,0
@@ -47551,8 +41607,6 @@ Evan Cofer,2018-Q4,0,0,0
 Evan Cofer,2018-Q3,0,0,0
 Evan Cofer,2018-Q2,0,0,0
 Evan Cofer,2018-Q1,0,0,0
-Darcy Liu,2021-Q4,0,0,0
-Darcy Liu,2021-Q3,0,0,0
 Darcy Liu,2021-Q2,0,0,0
 Darcy Liu,2021-Q1,0,0,0
 Darcy Liu,2020-Q4,0,0,0
@@ -47567,8 +41621,6 @@ Darcy Liu,2018-Q4,0,0,0
 Darcy Liu,2018-Q3,0,0,0
 Darcy Liu,2018-Q2,0,0,0
 Darcy Liu,2018-Q1,0,0,0
-newge,2021-Q4,0,0,0
-newge,2021-Q3,0,0,0
 newge,2021-Q2,0,0,0
 newge,2021-Q1,0,0,0
 newge,2020-Q4,0,0,0
@@ -47583,8 +41635,6 @@ newge,2018-Q4,0,0,0
 newge,2018-Q3,0,0,0
 newge,2018-Q2,0,0,0
 newge,2018-Q1,0,0,0
-Mihir Patel,2021-Q4,0,0,0
-Mihir Patel,2021-Q3,0,0,0
 Mihir Patel,2021-Q2,0,0,0
 Mihir Patel,2021-Q1,0,0,0
 Mihir Patel,2020-Q4,0,0,0
@@ -47599,8 +41649,6 @@ Mihir Patel,2018-Q4,0,0,0
 Mihir Patel,2018-Q3,0,0,0
 Mihir Patel,2018-Q2,0,0,0
 Mihir Patel,2018-Q1,0,0,0
-Ian,2021-Q4,0,0,0
-Ian,2021-Q3,0,0,0
 Ian,2021-Q2,0,0,0
 Ian,2021-Q1,0,0,0
 Ian,2020-Q4,0,0,0
@@ -47615,8 +41663,6 @@ Ian,2018-Q4,0,0,0
 Ian,2018-Q3,0,0,0
 Ian,2018-Q2,0,0,0
 Ian,2018-Q1,0,0,0
-jangsoo park,2021-Q4,0,0,0
-jangsoo park,2021-Q3,0,0,0
 jangsoo park,2021-Q2,0,0,0
 jangsoo park,2021-Q1,0,0,0
 jangsoo park,2020-Q4,0,0,0
@@ -47631,8 +41677,6 @@ jangsoo park,2018-Q4,0,0,0
 jangsoo park,2018-Q3,0,0,0
 jangsoo park,2018-Q2,0,0,0
 jangsoo park,2018-Q1,0,0,0
-Ling Zhang,2021-Q4,0,0,0
-Ling Zhang,2021-Q3,0,0,0
 Ling Zhang,2021-Q2,0,0,0
 Ling Zhang,2021-Q1,0,0,0
 Ling Zhang,2020-Q4,0,0,0
@@ -47647,8 +41691,6 @@ Ling Zhang,2018-Q4,0,0,0
 Ling Zhang,2018-Q3,0,0,0
 Ling Zhang,2018-Q2,0,0,0
 Ling Zhang,2018-Q1,0,0,0
-Luheng He,2021-Q4,0,0,0
-Luheng He,2021-Q3,0,0,0
 Luheng He,2021-Q2,0,0,0
 Luheng He,2021-Q1,0,0,0
 Luheng He,2020-Q4,0,0,0
@@ -47663,8 +41705,6 @@ Luheng He,2018-Q4,0,0,0
 Luheng He,2018-Q3,0,0,0
 Luheng He,2018-Q2,0,0,0
 Luheng He,2018-Q1,0,0,0
-Nick Butlin,2021-Q4,0,0,0
-Nick Butlin,2021-Q3,0,0,0
 Nick Butlin,2021-Q2,0,0,0
 Nick Butlin,2021-Q1,0,0,0
 Nick Butlin,2020-Q4,0,0,0
@@ -47679,8 +41719,6 @@ Nick Butlin,2018-Q4,0,0,0
 Nick Butlin,2018-Q3,0,0,0
 Nick Butlin,2018-Q2,0,0,0
 Nick Butlin,2018-Q1,0,0,0
-Thiébaud Weksteen,2021-Q4,0,0,0
-Thiébaud Weksteen,2021-Q3,0,0,0
 Thiébaud Weksteen,2021-Q2,0,0,0
 Thiébaud Weksteen,2021-Q1,0,0,0
 Thiébaud Weksteen,2020-Q4,0,0,0
@@ -47695,8 +41733,6 @@ Thiébaud Weksteen,2018-Q4,0,0,0
 Thiébaud Weksteen,2018-Q3,0,0,0
 Thiébaud Weksteen,2018-Q2,0,0,0
 Thiébaud Weksteen,2018-Q1,0,0,0
-RustingSword,2021-Q4,0,0,0
-RustingSword,2021-Q3,0,0,0
 RustingSword,2021-Q2,0,0,0
 RustingSword,2021-Q1,0,0,0
 RustingSword,2020-Q4,0,0,0
@@ -47711,8 +41747,6 @@ RustingSword,2018-Q4,0,0,0
 RustingSword,2018-Q3,0,0,0
 RustingSword,2018-Q2,0,0,0
 RustingSword,2018-Q1,0,0,0
-skavulya,2021-Q4,0,0,0
-skavulya,2021-Q3,0,0,0
 skavulya,2021-Q2,0,0,0
 skavulya,2021-Q1,0,0,0
 skavulya,2020-Q4,0,0,0
@@ -47727,8 +41761,6 @@ skavulya,2018-Q4,0,0,0
 skavulya,2018-Q3,0,0,0
 skavulya,2018-Q2,0,0,0
 skavulya,2018-Q1,0,0,0
-Przemyslaw Tredak,2021-Q4,0,0,0
-Przemyslaw Tredak,2021-Q3,0,0,0
 Przemyslaw Tredak,2021-Q2,0,0,0
 Przemyslaw Tredak,2021-Q1,0,0,0
 Przemyslaw Tredak,2020-Q4,0,0,0
@@ -47743,8 +41775,6 @@ Przemyslaw Tredak,2018-Q4,0,0,0
 Przemyslaw Tredak,2018-Q3,0,0,0
 Przemyslaw Tredak,2018-Q2,0,0,0
 Przemyslaw Tredak,2018-Q1,0,0,0
-Connor Braa,2021-Q4,0,0,0
-Connor Braa,2021-Q3,0,0,0
 Connor Braa,2021-Q2,0,0,0
 Connor Braa,2021-Q1,0,0,0
 Connor Braa,2020-Q4,0,0,0
@@ -47759,8 +41789,6 @@ Connor Braa,2018-Q4,0,0,0
 Connor Braa,2018-Q3,0,0,0
 Connor Braa,2018-Q2,0,0,0
 Connor Braa,2018-Q1,0,0,0
-A. Rosenberg Johansen,2021-Q4,0,0,0
-A. Rosenberg Johansen,2021-Q3,0,0,0
 A. Rosenberg Johansen,2021-Q2,0,0,0
 A. Rosenberg Johansen,2021-Q1,0,0,0
 A. Rosenberg Johansen,2020-Q4,0,0,0
@@ -47775,8 +41803,6 @@ A. Rosenberg Johansen,2018-Q4,0,0,0
 A. Rosenberg Johansen,2018-Q3,0,0,0
 A. Rosenberg Johansen,2018-Q2,0,0,0
 A. Rosenberg Johansen,2018-Q1,0,0,0
-Abhishek Aggarwal,2021-Q4,0,0,0
-Abhishek Aggarwal,2021-Q3,0,0,0
 Abhishek Aggarwal,2021-Q2,0,0,0
 Abhishek Aggarwal,2021-Q1,0,0,0
 Abhishek Aggarwal,2020-Q4,0,0,0
@@ -47791,8 +41817,6 @@ Abhishek Aggarwal,2018-Q4,0,0,0
 Abhishek Aggarwal,2018-Q3,0,0,0
 Abhishek Aggarwal,2018-Q2,0,0,0
 Abhishek Aggarwal,2018-Q1,0,0,0
-Shi Jiaxin,2021-Q4,0,0,0
-Shi Jiaxin,2021-Q3,0,0,0
 Shi Jiaxin,2021-Q2,0,0,0
 Shi Jiaxin,2021-Q1,0,0,0
 Shi Jiaxin,2020-Q4,0,0,0
@@ -47807,8 +41831,6 @@ Shi Jiaxin,2018-Q4,0,0,0
 Shi Jiaxin,2018-Q3,0,0,0
 Shi Jiaxin,2018-Q2,0,0,0
 Shi Jiaxin,2018-Q1,0,0,0
-Garrett Smith,2021-Q4,0,0,0
-Garrett Smith,2021-Q3,0,0,0
 Garrett Smith,2021-Q2,0,0,0
 Garrett Smith,2021-Q1,0,0,0
 Garrett Smith,2020-Q4,0,0,0
@@ -47823,8 +41845,6 @@ Garrett Smith,2018-Q4,0,0,0
 Garrett Smith,2018-Q3,0,0,0
 Garrett Smith,2018-Q2,0,0,0
 Garrett Smith,2018-Q1,0,0,0
-Daniel W Mane,2021-Q4,0,0,0
-Daniel W Mane,2021-Q3,0,0,0
 Daniel W Mane,2021-Q2,0,0,0
 Daniel W Mane,2021-Q1,0,0,0
 Daniel W Mane,2020-Q4,0,0,0
@@ -47839,8 +41859,6 @@ Daniel W Mane,2018-Q4,0,0,0
 Daniel W Mane,2018-Q3,0,0,0
 Daniel W Mane,2018-Q2,0,0,0
 Daniel W Mane,2018-Q1,0,0,0
-AfirSraftGarrier,2021-Q4,0,0,0
-AfirSraftGarrier,2021-Q3,0,0,0
 AfirSraftGarrier,2021-Q2,0,0,0
 AfirSraftGarrier,2021-Q1,0,0,0
 AfirSraftGarrier,2020-Q4,0,0,0
@@ -47855,8 +41873,6 @@ AfirSraftGarrier,2018-Q4,0,0,0
 AfirSraftGarrier,2018-Q3,0,0,0
 AfirSraftGarrier,2018-Q2,0,0,0
 AfirSraftGarrier,2018-Q1,0,0,0
-tiriplicamihai,2021-Q4,0,0,0
-tiriplicamihai,2021-Q3,0,0,0
 tiriplicamihai,2021-Q2,0,0,0
 tiriplicamihai,2021-Q1,0,0,0
 tiriplicamihai,2020-Q4,0,0,0
@@ -47871,8 +41887,6 @@ tiriplicamihai,2018-Q4,0,0,0
 tiriplicamihai,2018-Q3,0,0,0
 tiriplicamihai,2018-Q2,0,0,0
 tiriplicamihai,2018-Q1,0,0,0
-Hao WEI,2021-Q4,0,0,0
-Hao WEI,2021-Q3,0,0,0
 Hao WEI,2021-Q2,0,0,0
 Hao WEI,2021-Q1,0,0,0
 Hao WEI,2020-Q4,0,0,0
@@ -47887,8 +41901,6 @@ Hao WEI,2018-Q4,0,0,0
 Hao WEI,2018-Q3,0,0,0
 Hao WEI,2018-Q2,0,0,0
 Hao WEI,2018-Q1,0,0,0
-BoyuanJiang,2021-Q4,0,0,0
-BoyuanJiang,2021-Q3,0,0,0
 BoyuanJiang,2021-Q2,0,0,0
 BoyuanJiang,2021-Q1,0,0,0
 BoyuanJiang,2020-Q4,0,0,0
@@ -47903,8 +41915,6 @@ BoyuanJiang,2018-Q4,0,0,0
 BoyuanJiang,2018-Q3,0,0,0
 BoyuanJiang,2018-Q2,0,0,0
 BoyuanJiang,2018-Q1,0,0,0
-Vladislav Gubarev,2021-Q4,0,0,0
-Vladislav Gubarev,2021-Q3,0,0,0
 Vladislav Gubarev,2021-Q2,0,0,0
 Vladislav Gubarev,2021-Q1,0,0,0
 Vladislav Gubarev,2020-Q4,0,0,0
@@ -47919,8 +41929,6 @@ Vladislav Gubarev,2018-Q4,0,0,0
 Vladislav Gubarev,2018-Q3,0,0,0
 Vladislav Gubarev,2018-Q2,0,0,0
 Vladislav Gubarev,2018-Q1,0,0,0
-Kamil Hryniewicz,2021-Q4,0,0,0
-Kamil Hryniewicz,2021-Q3,0,0,0
 Kamil Hryniewicz,2021-Q2,0,0,0
 Kamil Hryniewicz,2021-Q1,0,0,0
 Kamil Hryniewicz,2020-Q4,0,0,0
@@ -47935,8 +41943,6 @@ Kamil Hryniewicz,2018-Q4,0,0,0
 Kamil Hryniewicz,2018-Q3,0,0,0
 Kamil Hryniewicz,2018-Q2,0,0,0
 Kamil Hryniewicz,2018-Q1,0,0,0
-zhongyuk,2021-Q4,0,0,0
-zhongyuk,2021-Q3,0,0,0
 zhongyuk,2021-Q2,0,0,0
 zhongyuk,2021-Q1,0,0,0
 zhongyuk,2020-Q4,0,0,0
@@ -47951,8 +41957,6 @@ zhongyuk,2018-Q4,0,0,0
 zhongyuk,2018-Q3,0,0,0
 zhongyuk,2018-Q2,0,0,0
 zhongyuk,2018-Q1,0,0,0
-Gökçen Eraslan,2021-Q4,0,0,0
-Gökçen Eraslan,2021-Q3,0,0,0
 Gökçen Eraslan,2021-Q2,0,0,0
 Gökçen Eraslan,2021-Q1,0,0,0
 Gökçen Eraslan,2020-Q4,0,0,0
@@ -47967,8 +41971,6 @@ Gökçen Eraslan,2018-Q4,0,0,0
 Gökçen Eraslan,2018-Q3,0,0,0
 Gökçen Eraslan,2018-Q2,0,0,0
 Gökçen Eraslan,2018-Q1,0,0,0
-luke,2021-Q4,0,0,0
-luke,2021-Q3,0,0,0
 luke,2021-Q2,0,0,0
 luke,2021-Q1,0,0,0
 luke,2020-Q4,0,0,0
@@ -47983,8 +41985,6 @@ luke,2018-Q4,0,0,0
 luke,2018-Q3,0,0,0
 luke,2018-Q2,0,0,0
 luke,2018-Q1,0,0,0
-DjangoPeng,2021-Q4,0,0,0
-DjangoPeng,2021-Q3,0,0,0
 DjangoPeng,2021-Q2,0,0,0
 DjangoPeng,2021-Q1,0,0,0
 DjangoPeng,2020-Q4,0,0,0
@@ -47999,8 +41999,6 @@ DjangoPeng,2018-Q4,0,0,0
 DjangoPeng,2018-Q3,0,0,0
 DjangoPeng,2018-Q2,0,0,0
 DjangoPeng,2018-Q1,0,0,0
-Jithin Odattu,2021-Q4,0,0,0
-Jithin Odattu,2021-Q3,0,0,0
 Jithin Odattu,2021-Q2,0,0,0
 Jithin Odattu,2021-Q1,0,0,0
 Jithin Odattu,2020-Q4,0,0,0
@@ -48015,8 +42013,6 @@ Jithin Odattu,2018-Q4,0,0,0
 Jithin Odattu,2018-Q3,0,0,0
 Jithin Odattu,2018-Q2,0,0,0
 Jithin Odattu,2018-Q1,0,0,0
-Javier Dehesa,2021-Q4,0,0,0
-Javier Dehesa,2021-Q3,0,0,0
 Javier Dehesa,2021-Q2,0,0,0
 Javier Dehesa,2021-Q1,0,0,0
 Javier Dehesa,2020-Q4,0,0,0
@@ -48031,8 +42027,6 @@ Javier Dehesa,2018-Q4,0,0,0
 Javier Dehesa,2018-Q3,0,0,0
 Javier Dehesa,2018-Q2,0,0,0
 Javier Dehesa,2018-Q1,0,0,0
-Ken Shirriff,2021-Q4,0,0,0
-Ken Shirriff,2021-Q3,0,0,0
 Ken Shirriff,2021-Q2,0,0,0
 Ken Shirriff,2021-Q1,0,0,0
 Ken Shirriff,2020-Q4,0,0,0
@@ -48047,8 +42041,6 @@ Ken Shirriff,2018-Q4,0,0,0
 Ken Shirriff,2018-Q3,0,0,0
 Ken Shirriff,2018-Q2,0,0,0
 Ken Shirriff,2018-Q1,0,0,0
-Kai Wolf,2021-Q4,0,0,0
-Kai Wolf,2021-Q3,0,0,0
 Kai Wolf,2021-Q2,0,0,0
 Kai Wolf,2021-Q1,0,0,0
 Kai Wolf,2020-Q4,0,0,0
@@ -48063,8 +42055,6 @@ Kai Wolf,2018-Q4,0,0,0
 Kai Wolf,2018-Q3,0,0,0
 Kai Wolf,2018-Q2,0,0,0
 Kai Wolf,2018-Q1,0,0,0
-Terry Tang,2021-Q4,0,0,0
-Terry Tang,2021-Q3,0,0,0
 Terry Tang,2021-Q2,0,0,0
 Terry Tang,2021-Q1,0,0,0
 Terry Tang,2020-Q4,0,0,0
@@ -48079,8 +42069,6 @@ Terry Tang,2018-Q4,0,0,0
 Terry Tang,2018-Q3,0,0,0
 Terry Tang,2018-Q2,0,0,0
 Terry Tang,2018-Q1,0,0,0
-xmbrst,2021-Q4,0,0,0
-xmbrst,2021-Q3,0,0,0
 xmbrst,2021-Q2,0,0,0
 xmbrst,2021-Q1,0,0,0
 xmbrst,2020-Q4,0,0,0
@@ -48095,8 +42083,6 @@ xmbrst,2018-Q4,0,0,0
 xmbrst,2018-Q3,0,0,0
 xmbrst,2018-Q2,0,0,0
 xmbrst,2018-Q1,0,0,0
-Frank Li,2021-Q4,0,0,0
-Frank Li,2021-Q3,0,0,0
 Frank Li,2021-Q2,0,0,0
 Frank Li,2021-Q1,0,0,0
 Frank Li,2020-Q4,0,0,0
@@ -48111,8 +42097,6 @@ Frank Li,2018-Q4,0,0,0
 Frank Li,2018-Q3,0,0,0
 Frank Li,2018-Q2,0,0,0
 Frank Li,2018-Q1,0,0,0
-Uwe Schmidt,2021-Q4,0,0,0
-Uwe Schmidt,2021-Q3,0,0,0
 Uwe Schmidt,2021-Q2,0,0,0
 Uwe Schmidt,2021-Q1,0,0,0
 Uwe Schmidt,2020-Q4,0,0,0
@@ -48127,8 +42111,6 @@ Uwe Schmidt,2018-Q4,0,0,0
 Uwe Schmidt,2018-Q3,0,0,0
 Uwe Schmidt,2018-Q2,0,0,0
 Uwe Schmidt,2018-Q1,0,0,0
-Adriano,2021-Q4,0,0,0
-Adriano,2021-Q3,0,0,0
 Adriano,2021-Q2,0,0,0
 Adriano,2021-Q1,0,0,0
 Adriano,2020-Q4,0,0,0
@@ -48143,8 +42125,6 @@ Adriano,2018-Q4,0,0,0
 Adriano,2018-Q3,0,0,0
 Adriano,2018-Q2,0,0,0
 Adriano,2018-Q1,0,0,0
-Leonard Lee,2021-Q4,0,0,0
-Leonard Lee,2021-Q3,0,0,0
 Leonard Lee,2021-Q2,0,0,0
 Leonard Lee,2021-Q1,0,0,0
 Leonard Lee,2020-Q4,0,0,0
@@ -48159,8 +42139,6 @@ Leonard Lee,2018-Q4,0,0,0
 Leonard Lee,2018-Q3,0,0,0
 Leonard Lee,2018-Q2,0,0,0
 Leonard Lee,2018-Q1,0,0,0
-Ghedeon,2021-Q4,0,0,0
-Ghedeon,2021-Q3,0,0,0
 Ghedeon,2021-Q2,0,0,0
 Ghedeon,2021-Q1,0,0,0
 Ghedeon,2020-Q4,0,0,0
@@ -48175,8 +42153,6 @@ Ghedeon,2018-Q4,0,0,0
 Ghedeon,2018-Q3,0,0,0
 Ghedeon,2018-Q2,0,0,0
 Ghedeon,2018-Q1,0,0,0
-Xuesong Yang,2021-Q4,0,0,0
-Xuesong Yang,2021-Q3,0,0,0
 Xuesong Yang,2021-Q2,0,0,0
 Xuesong Yang,2021-Q1,0,0,0
 Xuesong Yang,2020-Q4,0,0,0
@@ -48191,8 +42167,6 @@ Xuesong Yang,2018-Q4,0,0,0
 Xuesong Yang,2018-Q3,0,0,0
 Xuesong Yang,2018-Q2,0,0,0
 Xuesong Yang,2018-Q1,0,0,0
-hoangmit,2021-Q4,0,0,0
-hoangmit,2021-Q3,0,0,0
 hoangmit,2021-Q2,0,0,0
 hoangmit,2021-Q1,0,0,0
 hoangmit,2020-Q4,0,0,0
@@ -48207,8 +42181,6 @@ hoangmit,2018-Q4,0,0,0
 hoangmit,2018-Q3,0,0,0
 hoangmit,2018-Q2,0,0,0
 hoangmit,2018-Q1,0,0,0
-Karen Brems,2021-Q4,0,0,0
-Karen Brems,2021-Q3,0,0,0
 Karen Brems,2021-Q2,0,0,0
 Karen Brems,2021-Q1,0,0,0
 Karen Brems,2020-Q4,0,0,0
@@ -48223,8 +42195,6 @@ Karen Brems,2018-Q4,0,0,0
 Karen Brems,2018-Q3,0,0,0
 Karen Brems,2018-Q2,0,0,0
 Karen Brems,2018-Q1,0,0,0
-Fabrício Ceschin,2021-Q4,0,0,0
-Fabrício Ceschin,2021-Q3,0,0,0
 Fabrício Ceschin,2021-Q2,0,0,0
 Fabrício Ceschin,2021-Q1,0,0,0
 Fabrício Ceschin,2020-Q4,0,0,0
@@ -48239,8 +42209,6 @@ Fabrício Ceschin,2018-Q4,0,0,0
 Fabrício Ceschin,2018-Q3,0,0,0
 Fabrício Ceschin,2018-Q2,0,0,0
 Fabrício Ceschin,2018-Q1,0,0,0
-郭同jet · 耐心,2021-Q4,0,0,0
-郭同jet · 耐心,2021-Q3,0,0,0
 郭同jet · 耐心,2021-Q2,0,0,0
 郭同jet · 耐心,2021-Q1,0,0,0
 郭同jet · 耐心,2020-Q4,0,0,0
@@ -48255,8 +42223,6 @@ Fabrício Ceschin,2018-Q1,0,0,0
 郭同jet · 耐心,2018-Q3,0,0,0
 郭同jet · 耐心,2018-Q2,0,0,0
 郭同jet · 耐心,2018-Q1,0,0,0
-a7744hsc,2021-Q4,0,0,0
-a7744hsc,2021-Q3,0,0,0
 a7744hsc,2021-Q2,0,0,0
 a7744hsc,2021-Q1,0,0,0
 a7744hsc,2020-Q4,0,0,0
@@ -48271,8 +42237,6 @@ a7744hsc,2018-Q4,0,0,0
 a7744hsc,2018-Q3,0,0,0
 a7744hsc,2018-Q2,0,0,0
 a7744hsc,2018-Q1,0,0,0
-qitaishui,2021-Q4,0,0,0
-qitaishui,2021-Q3,0,0,0
 qitaishui,2021-Q2,0,0,0
 qitaishui,2021-Q1,0,0,0
 qitaishui,2020-Q4,0,0,0
@@ -48287,8 +42251,6 @@ qitaishui,2018-Q4,0,0,0
 qitaishui,2018-Q3,0,0,0
 qitaishui,2018-Q2,0,0,0
 qitaishui,2018-Q1,0,0,0
-Moustafa Alzantot,2021-Q4,0,0,0
-Moustafa Alzantot,2021-Q3,0,0,0
 Moustafa Alzantot,2021-Q2,0,0,0
 Moustafa Alzantot,2021-Q1,0,0,0
 Moustafa Alzantot,2020-Q4,0,0,0
@@ -48303,8 +42265,6 @@ Moustafa Alzantot,2018-Q4,0,0,0
 Moustafa Alzantot,2018-Q3,0,0,0
 Moustafa Alzantot,2018-Q2,0,0,0
 Moustafa Alzantot,2018-Q1,0,0,0
-drag0,2021-Q4,0,0,0
-drag0,2021-Q3,0,0,0
 drag0,2021-Q2,0,0,0
 drag0,2021-Q1,0,0,0
 drag0,2020-Q4,0,0,0
@@ -48319,8 +42279,6 @@ drag0,2018-Q4,0,0,0
 drag0,2018-Q3,0,0,0
 drag0,2018-Q2,0,0,0
 drag0,2018-Q1,0,0,0
-Burness Duan,2021-Q4,0,0,0
-Burness Duan,2021-Q3,0,0,0
 Burness Duan,2021-Q2,0,0,0
 Burness Duan,2021-Q1,0,0,0
 Burness Duan,2020-Q4,0,0,0
@@ -48335,8 +42293,6 @@ Burness Duan,2018-Q4,0,0,0
 Burness Duan,2018-Q3,0,0,0
 Burness Duan,2018-Q2,0,0,0
 Burness Duan,2018-Q1,0,0,0
-Aki Sukegawa,2021-Q4,0,0,0
-Aki Sukegawa,2021-Q3,0,0,0
 Aki Sukegawa,2021-Q2,0,0,0
 Aki Sukegawa,2021-Q1,0,0,0
 Aki Sukegawa,2020-Q4,0,0,0
@@ -48351,8 +42307,6 @@ Aki Sukegawa,2018-Q4,0,0,0
 Aki Sukegawa,2018-Q3,0,0,0
 Aki Sukegawa,2018-Q2,0,0,0
 Aki Sukegawa,2018-Q1,0,0,0
-Kamran Amini,2021-Q4,0,0,0
-Kamran Amini,2021-Q3,0,0,0
 Kamran Amini,2021-Q2,0,0,0
 Kamran Amini,2021-Q1,0,0,0
 Kamran Amini,2020-Q4,0,0,0
@@ -48367,8 +42321,6 @@ Kamran Amini,2018-Q4,0,0,0
 Kamran Amini,2018-Q3,0,0,0
 Kamran Amini,2018-Q2,0,0,0
 Kamran Amini,2018-Q1,0,0,0
-Martin,2021-Q4,0,0,0
-Martin,2021-Q3,0,0,0
 Martin,2021-Q2,0,0,0
 Martin,2021-Q1,0,0,0
 Martin,2020-Q4,0,0,0
@@ -48383,8 +42335,6 @@ Martin,2018-Q4,0,0,0
 Martin,2018-Q3,0,0,0
 Martin,2018-Q2,0,0,0
 Martin,2018-Q1,0,0,0
-Ondřej Filip,2021-Q4,0,0,0
-Ondřej Filip,2021-Q3,0,0,0
 Ondřej Filip,2021-Q2,0,0,0
 Ondřej Filip,2021-Q1,0,0,0
 Ondřej Filip,2020-Q4,0,0,0
@@ -48399,8 +42349,6 @@ Ondřej Filip,2018-Q4,0,0,0
 Ondřej Filip,2018-Q3,0,0,0
 Ondřej Filip,2018-Q2,0,0,0
 Ondřej Filip,2018-Q1,0,0,0
-Karl Lattimer,2021-Q4,0,0,0
-Karl Lattimer,2021-Q3,0,0,0
 Karl Lattimer,2021-Q2,0,0,0
 Karl Lattimer,2021-Q1,0,0,0
 Karl Lattimer,2020-Q4,0,0,0
@@ -48415,8 +42363,6 @@ Karl Lattimer,2018-Q4,0,0,0
 Karl Lattimer,2018-Q3,0,0,0
 Karl Lattimer,2018-Q2,0,0,0
 Karl Lattimer,2018-Q1,0,0,0
-Haroen Viaene,2021-Q4,0,0,0
-Haroen Viaene,2021-Q3,0,0,0
 Haroen Viaene,2021-Q2,0,0,0
 Haroen Viaene,2021-Q1,0,0,0
 Haroen Viaene,2020-Q4,0,0,0
@@ -48431,8 +42377,6 @@ Haroen Viaene,2018-Q4,0,0,0
 Haroen Viaene,2018-Q3,0,0,0
 Haroen Viaene,2018-Q2,0,0,0
 Haroen Viaene,2018-Q1,0,0,0
-zhengxq,2021-Q4,0,0,0
-zhengxq,2021-Q3,0,0,0
 zhengxq,2021-Q2,0,0,0
 zhengxq,2021-Q1,0,0,0
 zhengxq,2020-Q4,0,0,0
@@ -48447,8 +42391,6 @@ zhengxq,2018-Q4,0,0,0
 zhengxq,2018-Q3,0,0,0
 zhengxq,2018-Q2,0,0,0
 zhengxq,2018-Q1,0,0,0
-raix852,2021-Q4,0,0,0
-raix852,2021-Q3,0,0,0
 raix852,2021-Q2,0,0,0
 raix852,2021-Q1,0,0,0
 raix852,2020-Q4,0,0,0
@@ -48463,8 +42405,6 @@ raix852,2018-Q4,0,0,0
 raix852,2018-Q3,0,0,0
 raix852,2018-Q2,0,0,0
 raix852,2018-Q1,0,0,0
-MrQianjinsi,2021-Q4,0,0,0
-MrQianjinsi,2021-Q3,0,0,0
 MrQianjinsi,2021-Q2,0,0,0
 MrQianjinsi,2021-Q1,0,0,0
 MrQianjinsi,2020-Q4,0,0,0
@@ -48479,8 +42419,6 @@ MrQianjinsi,2018-Q4,0,0,0
 MrQianjinsi,2018-Q3,0,0,0
 MrQianjinsi,2018-Q2,0,0,0
 MrQianjinsi,2018-Q1,0,0,0
-SriramRamesh,2021-Q4,0,0,0
-SriramRamesh,2021-Q3,0,0,0
 SriramRamesh,2021-Q2,0,0,0
 SriramRamesh,2021-Q1,0,0,0
 SriramRamesh,2020-Q4,0,0,0
@@ -48495,8 +42433,6 @@ SriramRamesh,2018-Q4,0,0,0
 SriramRamesh,2018-Q3,0,0,0
 SriramRamesh,2018-Q2,0,0,0
 SriramRamesh,2018-Q1,0,0,0
-c0g,2021-Q4,0,0,0
-c0g,2021-Q3,0,0,0
 c0g,2021-Q2,0,0,0
 c0g,2021-Q1,0,0,0
 c0g,2020-Q4,0,0,0
@@ -48511,8 +42447,6 @@ c0g,2018-Q4,0,0,0
 c0g,2018-Q3,0,0,0
 c0g,2018-Q2,0,0,0
 c0g,2018-Q1,0,0,0
-Di Zeng,2021-Q4,0,0,0
-Di Zeng,2021-Q3,0,0,0
 Di Zeng,2021-Q2,0,0,0
 Di Zeng,2021-Q1,0,0,0
 Di Zeng,2020-Q4,0,0,0
@@ -48527,8 +42461,6 @@ Di Zeng,2018-Q4,0,0,0
 Di Zeng,2018-Q3,0,0,0
 Di Zeng,2018-Q2,0,0,0
 Di Zeng,2018-Q1,0,0,0
-DI ZENG,2021-Q4,0,0,0
-DI ZENG,2021-Q3,0,0,0
 DI ZENG,2021-Q2,0,0,0
 DI ZENG,2021-Q1,0,0,0
 DI ZENG,2020-Q4,0,0,0
@@ -48543,8 +42475,6 @@ DI ZENG,2018-Q4,0,0,0
 DI ZENG,2018-Q3,0,0,0
 DI ZENG,2018-Q2,0,0,0
 DI ZENG,2018-Q1,0,0,0
-youyou3,2021-Q4,0,0,0
-youyou3,2021-Q3,0,0,0
 youyou3,2021-Q2,0,0,0
 youyou3,2021-Q1,0,0,0
 youyou3,2020-Q4,0,0,0
@@ -48559,8 +42489,6 @@ youyou3,2018-Q4,0,0,0
 youyou3,2018-Q3,0,0,0
 youyou3,2018-Q2,0,0,0
 youyou3,2018-Q1,0,0,0
-Ondrej Skopek,2021-Q4,0,0,0
-Ondrej Skopek,2021-Q3,0,0,0
 Ondrej Skopek,2021-Q2,0,0,0
 Ondrej Skopek,2021-Q1,0,0,0
 Ondrej Skopek,2020-Q4,0,0,0
@@ -48575,8 +42503,6 @@ Ondrej Skopek,2018-Q4,0,0,0
 Ondrej Skopek,2018-Q3,0,0,0
 Ondrej Skopek,2018-Q2,0,0,0
 Ondrej Skopek,2018-Q1,0,0,0
-David Jones,2021-Q4,0,0,0
-David Jones,2021-Q3,0,0,0
 David Jones,2021-Q2,0,0,0
 David Jones,2021-Q1,0,0,0
 David Jones,2020-Q4,0,0,0
@@ -48591,8 +42517,6 @@ David Jones,2018-Q4,0,0,0
 David Jones,2018-Q3,0,0,0
 David Jones,2018-Q2,0,0,0
 David Jones,2018-Q1,0,0,0
-Benjamin Mularczyk,2021-Q4,0,0,0
-Benjamin Mularczyk,2021-Q3,0,0,0
 Benjamin Mularczyk,2021-Q2,0,0,0
 Benjamin Mularczyk,2021-Q1,0,0,0
 Benjamin Mularczyk,2020-Q4,0,0,0
@@ -48607,8 +42531,6 @@ Benjamin Mularczyk,2018-Q4,0,0,0
 Benjamin Mularczyk,2018-Q3,0,0,0
 Benjamin Mularczyk,2018-Q2,0,0,0
 Benjamin Mularczyk,2018-Q1,0,0,0
-tyfkda,2021-Q4,0,0,0
-tyfkda,2021-Q3,0,0,0
 tyfkda,2021-Q2,0,0,0
 tyfkda,2021-Q1,0,0,0
 tyfkda,2020-Q4,0,0,0
@@ -48623,8 +42545,6 @@ tyfkda,2018-Q4,0,0,0
 tyfkda,2018-Q3,0,0,0
 tyfkda,2018-Q2,0,0,0
 tyfkda,2018-Q1,0,0,0
-Victor Villas,2021-Q4,0,0,0
-Victor Villas,2021-Q3,0,0,0
 Victor Villas,2021-Q2,0,0,0
 Victor Villas,2021-Q1,0,0,0
 Victor Villas,2020-Q4,0,0,0
@@ -48639,8 +42559,6 @@ Victor Villas,2018-Q4,0,0,0
 Victor Villas,2018-Q3,0,0,0
 Victor Villas,2018-Q2,0,0,0
 Victor Villas,2018-Q1,0,0,0
-fp,2021-Q4,0,0,0
-fp,2021-Q3,0,0,0
 fp,2021-Q2,0,0,0
 fp,2021-Q1,0,0,0
 fp,2020-Q4,0,0,0
@@ -48655,8 +42573,6 @@ fp,2018-Q4,0,0,0
 fp,2018-Q3,0,0,0
 fp,2018-Q2,0,0,0
 fp,2018-Q1,0,0,0
-tvn,2021-Q4,0,0,0
-tvn,2021-Q3,0,0,0
 tvn,2021-Q2,0,0,0
 tvn,2021-Q1,0,0,0
 tvn,2020-Q4,0,0,0
@@ -48671,8 +42587,6 @@ tvn,2018-Q4,0,0,0
 tvn,2018-Q3,0,0,0
 tvn,2018-Q2,0,0,0
 tvn,2018-Q1,0,0,0
-Anand Chakravarty,2021-Q4,0,0,0
-Anand Chakravarty,2021-Q3,0,0,0
 Anand Chakravarty,2021-Q2,0,0,0
 Anand Chakravarty,2021-Q1,0,0,0
 Anand Chakravarty,2020-Q4,0,0,0
@@ -48687,8 +42601,6 @@ Anand Chakravarty,2018-Q4,0,0,0
 Anand Chakravarty,2018-Q3,0,0,0
 Anand Chakravarty,2018-Q2,0,0,0
 Anand Chakravarty,2018-Q1,0,0,0
-Hannes,2021-Q4,0,0,0
-Hannes,2021-Q3,0,0,0
 Hannes,2021-Q2,0,0,0
 Hannes,2021-Q1,0,0,0
 Hannes,2020-Q4,0,0,0
@@ -48703,8 +42615,6 @@ Hannes,2018-Q4,0,0,0
 Hannes,2018-Q3,0,0,0
 Hannes,2018-Q2,0,0,0
 Hannes,2018-Q1,0,0,0
-Jianmin Chen,2021-Q4,0,0,0
-Jianmin Chen,2021-Q3,0,0,0
 Jianmin Chen,2021-Q2,0,0,0
 Jianmin Chen,2021-Q1,0,0,0
 Jianmin Chen,2020-Q4,0,0,0
@@ -48719,8 +42629,6 @@ Jianmin Chen,2018-Q4,0,0,0
 Jianmin Chen,2018-Q3,0,0,0
 Jianmin Chen,2018-Q2,0,0,0
 Jianmin Chen,2018-Q1,0,0,0
-Quarazy,2021-Q4,0,0,0
-Quarazy,2021-Q3,0,0,0
 Quarazy,2021-Q2,0,0,0
 Quarazy,2021-Q1,0,0,0
 Quarazy,2020-Q4,0,0,0
@@ -48735,8 +42643,6 @@ Quarazy,2018-Q4,0,0,0
 Quarazy,2018-Q3,0,0,0
 Quarazy,2018-Q2,0,0,0
 Quarazy,2018-Q1,0,0,0
-thuyenvn,2021-Q4,0,0,0
-thuyenvn,2021-Q3,0,0,0
 thuyenvn,2021-Q2,0,0,0
 thuyenvn,2021-Q1,0,0,0
 thuyenvn,2020-Q4,0,0,0
@@ -48751,8 +42657,6 @@ thuyenvn,2018-Q4,0,0,0
 thuyenvn,2018-Q3,0,0,0
 thuyenvn,2018-Q2,0,0,0
 thuyenvn,2018-Q1,0,0,0
-wujingyue,2021-Q4,0,0,0
-wujingyue,2021-Q3,0,0,0
 wujingyue,2021-Q2,0,0,0
 wujingyue,2021-Q1,0,0,0
 wujingyue,2020-Q4,0,0,0
@@ -48767,8 +42671,6 @@ wujingyue,2018-Q4,0,0,0
 wujingyue,2018-Q3,0,0,0
 wujingyue,2018-Q2,0,0,0
 wujingyue,2018-Q1,0,0,0
-nschuc,2021-Q4,0,0,0
-nschuc,2021-Q3,0,0,0
 nschuc,2021-Q2,0,0,0
 nschuc,2021-Q1,0,0,0
 nschuc,2020-Q4,0,0,0
@@ -48783,8 +42685,6 @@ nschuc,2018-Q4,0,0,0
 nschuc,2018-Q3,0,0,0
 nschuc,2018-Q2,0,0,0
 nschuc,2018-Q1,0,0,0
-Nikhil Mishra,2021-Q4,0,0,0
-Nikhil Mishra,2021-Q3,0,0,0
 Nikhil Mishra,2021-Q2,0,0,0
 Nikhil Mishra,2021-Q1,0,0,0
 Nikhil Mishra,2020-Q4,0,0,0
@@ -48799,8 +42699,6 @@ Nikhil Mishra,2018-Q4,0,0,0
 Nikhil Mishra,2018-Q3,0,0,0
 Nikhil Mishra,2018-Q2,0,0,0
 Nikhil Mishra,2018-Q1,0,0,0
-Ben guidarelli,2021-Q4,0,0,0
-Ben guidarelli,2021-Q3,0,0,0
 Ben guidarelli,2021-Q2,0,0,0
 Ben guidarelli,2021-Q1,0,0,0
 Ben guidarelli,2020-Q4,0,0,0
@@ -48815,8 +42713,6 @@ Ben guidarelli,2018-Q4,0,0,0
 Ben guidarelli,2018-Q3,0,0,0
 Ben guidarelli,2018-Q2,0,0,0
 Ben guidarelli,2018-Q1,0,0,0
-Haosdent Huang,2021-Q4,0,0,0
-Haosdent Huang,2021-Q3,0,0,0
 Haosdent Huang,2021-Q2,0,0,0
 Haosdent Huang,2021-Q1,0,0,0
 Haosdent Huang,2020-Q4,0,0,0
@@ -48831,8 +42727,6 @@ Haosdent Huang,2018-Q4,0,0,0
 Haosdent Huang,2018-Q3,0,0,0
 Haosdent Huang,2018-Q2,0,0,0
 Haosdent Huang,2018-Q1,0,0,0
-beopst,2021-Q4,0,0,0
-beopst,2021-Q3,0,0,0
 beopst,2021-Q2,0,0,0
 beopst,2021-Q1,0,0,0
 beopst,2020-Q4,0,0,0
@@ -48847,8 +42741,6 @@ beopst,2018-Q4,0,0,0
 beopst,2018-Q3,0,0,0
 beopst,2018-Q2,0,0,0
 beopst,2018-Q1,0,0,0
-Lie He,2021-Q4,0,0,0
-Lie He,2021-Q3,0,0,0
 Lie He,2021-Q2,0,0,0
 Lie He,2021-Q1,0,0,0
 Lie He,2020-Q4,0,0,0
@@ -48863,8 +42755,6 @@ Lie He,2018-Q4,0,0,0
 Lie He,2018-Q3,0,0,0
 Lie He,2018-Q2,0,0,0
 Lie He,2018-Q1,0,0,0
-haosdent,2021-Q4,0,0,0
-haosdent,2021-Q3,0,0,0
 haosdent,2021-Q2,0,0,0
 haosdent,2021-Q1,0,0,0
 haosdent,2020-Q4,0,0,0
@@ -48879,8 +42769,6 @@ haosdent,2018-Q4,0,0,0
 haosdent,2018-Q3,0,0,0
 haosdent,2018-Q2,0,0,0
 haosdent,2018-Q1,0,0,0
-Olivia,2021-Q4,0,0,0
-Olivia,2021-Q3,0,0,0
 Olivia,2021-Q2,0,0,0
 Olivia,2021-Q1,0,0,0
 Olivia,2020-Q4,0,0,0
@@ -48895,8 +42783,6 @@ Olivia,2018-Q4,0,0,0
 Olivia,2018-Q3,0,0,0
 Olivia,2018-Q2,0,0,0
 Olivia,2018-Q1,0,0,0
-Johan Mathe,2021-Q4,0,0,0
-Johan Mathe,2021-Q3,0,0,0
 Johan Mathe,2021-Q2,0,0,0
 Johan Mathe,2021-Q1,0,0,0
 Johan Mathe,2020-Q4,0,0,0
@@ -48911,8 +42797,6 @@ Johan Mathe,2018-Q4,0,0,0
 Johan Mathe,2018-Q3,0,0,0
 Johan Mathe,2018-Q2,0,0,0
 Johan Mathe,2018-Q1,0,0,0
-caisq,2021-Q4,0,0,0
-caisq,2021-Q3,0,0,0
 caisq,2021-Q2,0,0,0
 caisq,2021-Q1,0,0,0
 caisq,2020-Q4,0,0,0
@@ -48927,8 +42811,6 @@ caisq,2018-Q4,0,0,0
 caisq,2018-Q3,0,0,0
 caisq,2018-Q2,0,0,0
 caisq,2018-Q1,0,0,0
-Joan Pastor,2021-Q4,0,0,0
-Joan Pastor,2021-Q3,0,0,0
 Joan Pastor,2021-Q2,0,0,0
 Joan Pastor,2021-Q1,0,0,0
 Joan Pastor,2020-Q4,0,0,0
@@ -48943,8 +42825,6 @@ Joan Pastor,2018-Q4,0,0,0
 Joan Pastor,2018-Q3,0,0,0
 Joan Pastor,2018-Q2,0,0,0
 Joan Pastor,2018-Q1,0,0,0
-kborer,2021-Q4,0,0,0
-kborer,2021-Q3,0,0,0
 kborer,2021-Q2,0,0,0
 kborer,2021-Q1,0,0,0
 kborer,2020-Q4,0,0,0
@@ -48959,8 +42839,6 @@ kborer,2018-Q4,0,0,0
 kborer,2018-Q3,0,0,0
 kborer,2018-Q2,0,0,0
 kborer,2018-Q1,0,0,0
-Laurent Mazare,2021-Q4,0,0,0
-Laurent Mazare,2021-Q3,0,0,0
 Laurent Mazare,2021-Q2,0,0,0
 Laurent Mazare,2021-Q1,0,0,0
 Laurent Mazare,2020-Q4,0,0,0
@@ -48975,8 +42853,6 @@ Laurent Mazare,2018-Q4,0,0,0
 Laurent Mazare,2018-Q3,0,0,0
 Laurent Mazare,2018-Q2,0,0,0
 Laurent Mazare,2018-Q1,0,0,0
-Nick Meehan,2021-Q4,0,0,0
-Nick Meehan,2021-Q3,0,0,0
 Nick Meehan,2021-Q2,0,0,0
 Nick Meehan,2021-Q1,0,0,0
 Nick Meehan,2020-Q4,0,0,0
@@ -48991,8 +42867,6 @@ Nick Meehan,2018-Q4,0,0,0
 Nick Meehan,2018-Q3,0,0,0
 Nick Meehan,2018-Q2,0,0,0
 Nick Meehan,2018-Q1,0,0,0
-amcrae,2021-Q4,0,0,0
-amcrae,2021-Q3,0,0,0
 amcrae,2021-Q2,0,0,0
 amcrae,2021-Q1,0,0,0
 amcrae,2020-Q4,0,0,0
@@ -49007,8 +42881,6 @@ amcrae,2018-Q4,0,0,0
 amcrae,2018-Q3,0,0,0
 amcrae,2018-Q2,0,0,0
 amcrae,2018-Q1,0,0,0
-Pablo Moyano,2021-Q4,0,0,0
-Pablo Moyano,2021-Q3,0,0,0
 Pablo Moyano,2021-Q2,0,0,0
 Pablo Moyano,2021-Q1,0,0,0
 Pablo Moyano,2020-Q4,0,0,0
@@ -49023,8 +42895,6 @@ Pablo Moyano,2018-Q4,0,0,0
 Pablo Moyano,2018-Q3,0,0,0
 Pablo Moyano,2018-Q2,0,0,0
 Pablo Moyano,2018-Q1,0,0,0
-Andre Simpelo,2021-Q4,0,0,0
-Andre Simpelo,2021-Q3,0,0,0
 Andre Simpelo,2021-Q2,0,0,0
 Andre Simpelo,2021-Q1,0,0,0
 Andre Simpelo,2020-Q4,0,0,0
@@ -49039,8 +42909,6 @@ Andre Simpelo,2018-Q4,0,0,0
 Andre Simpelo,2018-Q3,0,0,0
 Andre Simpelo,2018-Q2,0,0,0
 Andre Simpelo,2018-Q1,0,0,0
-Balachander Ramachandran,2021-Q4,0,0,0
-Balachander Ramachandran,2021-Q3,0,0,0
 Balachander Ramachandran,2021-Q2,0,0,0
 Balachander Ramachandran,2021-Q1,0,0,0
 Balachander Ramachandran,2020-Q4,0,0,0
@@ -49055,8 +42923,6 @@ Balachander Ramachandran,2018-Q4,0,0,0
 Balachander Ramachandran,2018-Q3,0,0,0
 Balachander Ramachandran,2018-Q2,0,0,0
 Balachander Ramachandran,2018-Q1,0,0,0
-Henrik Holst,2021-Q4,0,0,0
-Henrik Holst,2021-Q3,0,0,0
 Henrik Holst,2021-Q2,0,0,0
 Henrik Holst,2021-Q1,0,0,0
 Henrik Holst,2020-Q4,0,0,0
@@ -49071,8 +42937,6 @@ Henrik Holst,2018-Q4,0,0,0
 Henrik Holst,2018-Q3,0,0,0
 Henrik Holst,2018-Q2,0,0,0
 Henrik Holst,2018-Q1,0,0,0
-Neil Han,2021-Q4,0,0,0
-Neil Han,2021-Q3,0,0,0
 Neil Han,2021-Q2,0,0,0
 Neil Han,2021-Q1,0,0,0
 Neil Han,2020-Q4,0,0,0
@@ -49087,8 +42951,6 @@ Neil Han,2018-Q4,0,0,0
 Neil Han,2018-Q3,0,0,0
 Neil Han,2018-Q2,0,0,0
 Neil Han,2018-Q1,0,0,0
-harold cooper,2021-Q4,0,0,0
-harold cooper,2021-Q3,0,0,0
 harold cooper,2021-Q2,0,0,0
 harold cooper,2021-Q1,0,0,0
 harold cooper,2020-Q4,0,0,0
@@ -49103,8 +42965,6 @@ harold cooper,2018-Q4,0,0,0
 harold cooper,2018-Q3,0,0,0
 harold cooper,2018-Q2,0,0,0
 harold cooper,2018-Q1,0,0,0
-Amlan Kar,2021-Q4,0,0,0
-Amlan Kar,2021-Q3,0,0,0
 Amlan Kar,2021-Q2,0,0,0
 Amlan Kar,2021-Q1,0,0,0
 Amlan Kar,2020-Q4,0,0,0
@@ -49119,8 +42979,6 @@ Amlan Kar,2018-Q4,0,0,0
 Amlan Kar,2018-Q3,0,0,0
 Amlan Kar,2018-Q2,0,0,0
 Amlan Kar,2018-Q1,0,0,0
-Justus Schwabedal,2021-Q4,0,0,0
-Justus Schwabedal,2021-Q3,0,0,0
 Justus Schwabedal,2021-Q2,0,0,0
 Justus Schwabedal,2021-Q1,0,0,0
 Justus Schwabedal,2020-Q4,0,0,0
@@ -49135,8 +42993,6 @@ Justus Schwabedal,2018-Q4,0,0,0
 Justus Schwabedal,2018-Q3,0,0,0
 Justus Schwabedal,2018-Q2,0,0,0
 Justus Schwabedal,2018-Q1,0,0,0
-Tushar Soni,2021-Q4,0,0,0
-Tushar Soni,2021-Q3,0,0,0
 Tushar Soni,2021-Q2,0,0,0
 Tushar Soni,2021-Q1,0,0,0
 Tushar Soni,2020-Q4,0,0,0
@@ -49151,8 +43007,6 @@ Tushar Soni,2018-Q4,0,0,0
 Tushar Soni,2018-Q3,0,0,0
 Tushar Soni,2018-Q2,0,0,0
 Tushar Soni,2018-Q1,0,0,0
-OscarDPan,2021-Q4,0,0,0
-OscarDPan,2021-Q3,0,0,0
 OscarDPan,2021-Q2,0,0,0
 OscarDPan,2021-Q1,0,0,0
 OscarDPan,2020-Q4,0,0,0
@@ -49167,8 +43021,6 @@ OscarDPan,2018-Q4,0,0,0
 OscarDPan,2018-Q3,0,0,0
 OscarDPan,2018-Q2,0,0,0
 OscarDPan,2018-Q1,0,0,0
-Ivan Ukhov,2021-Q4,0,0,0
-Ivan Ukhov,2021-Q3,0,0,0
 Ivan Ukhov,2021-Q2,0,0,0
 Ivan Ukhov,2021-Q1,0,0,0
 Ivan Ukhov,2020-Q4,0,0,0
@@ -49183,8 +43035,6 @@ Ivan Ukhov,2018-Q4,0,0,0
 Ivan Ukhov,2018-Q3,0,0,0
 Ivan Ukhov,2018-Q2,0,0,0
 Ivan Ukhov,2018-Q1,0,0,0
-Larissa Laich,2021-Q4,0,0,0
-Larissa Laich,2021-Q3,0,0,0
 Larissa Laich,2021-Q2,0,0,0
 Larissa Laich,2021-Q1,0,0,0
 Larissa Laich,2020-Q4,0,0,0
@@ -49199,8 +43049,6 @@ Larissa Laich,2018-Q4,0,0,0
 Larissa Laich,2018-Q3,0,0,0
 Larissa Laich,2018-Q2,0,0,0
 Larissa Laich,2018-Q1,0,0,0
-Alex Kendall,2021-Q4,0,0,0
-Alex Kendall,2021-Q3,0,0,0
 Alex Kendall,2021-Q2,0,0,0
 Alex Kendall,2021-Q1,0,0,0
 Alex Kendall,2020-Q4,0,0,0
@@ -49215,8 +43063,6 @@ Alex Kendall,2018-Q4,0,0,0
 Alex Kendall,2018-Q3,0,0,0
 Alex Kendall,2018-Q2,0,0,0
 Alex Kendall,2018-Q1,0,0,0
-Arnaud Lenglet,2021-Q4,0,0,0
-Arnaud Lenglet,2021-Q3,0,0,0
 Arnaud Lenglet,2021-Q2,0,0,0
 Arnaud Lenglet,2021-Q1,0,0,0
 Arnaud Lenglet,2020-Q4,0,0,0
@@ -49231,8 +43077,6 @@ Arnaud Lenglet,2018-Q4,0,0,0
 Arnaud Lenglet,2018-Q3,0,0,0
 Arnaud Lenglet,2018-Q2,0,0,0
 Arnaud Lenglet,2018-Q1,0,0,0
-chanis,2021-Q4,0,0,0
-chanis,2021-Q3,0,0,0
 chanis,2021-Q2,0,0,0
 chanis,2021-Q1,0,0,0
 chanis,2020-Q4,0,0,0
@@ -49247,8 +43091,6 @@ chanis,2018-Q4,0,0,0
 chanis,2018-Q3,0,0,0
 chanis,2018-Q2,0,0,0
 chanis,2018-Q1,0,0,0
-Eric Platon,2021-Q4,0,0,0
-Eric Platon,2021-Q3,0,0,0
 Eric Platon,2021-Q2,0,0,0
 Eric Platon,2021-Q1,0,0,0
 Eric Platon,2020-Q4,0,0,0
@@ -49263,8 +43105,6 @@ Eric Platon,2018-Q4,0,0,0
 Eric Platon,2018-Q3,0,0,0
 Eric Platon,2018-Q2,0,0,0
 Eric Platon,2018-Q1,0,0,0
-Danijar Hafner,2021-Q4,0,0,0
-Danijar Hafner,2021-Q3,0,0,0
 Danijar Hafner,2021-Q2,0,0,0
 Danijar Hafner,2021-Q1,0,0,0
 Danijar Hafner,2020-Q4,0,0,0
@@ -49279,8 +43119,6 @@ Danijar Hafner,2018-Q4,0,0,0
 Danijar Hafner,2018-Q3,0,0,0
 Danijar Hafner,2018-Q2,0,0,0
 Danijar Hafner,2018-Q1,0,0,0
-Gaetan Semet,2021-Q4,0,0,0
-Gaetan Semet,2021-Q3,0,0,0
 Gaetan Semet,2021-Q2,0,0,0
 Gaetan Semet,2021-Q1,0,0,0
 Gaetan Semet,2020-Q4,0,0,0
@@ -49295,8 +43133,6 @@ Gaetan Semet,2018-Q4,0,0,0
 Gaetan Semet,2018-Q3,0,0,0
 Gaetan Semet,2018-Q2,0,0,0
 Gaetan Semet,2018-Q1,0,0,0
-Daeyun Shin,2021-Q4,0,0,0
-Daeyun Shin,2021-Q3,0,0,0
 Daeyun Shin,2021-Q2,0,0,0
 Daeyun Shin,2021-Q1,0,0,0
 Daeyun Shin,2020-Q4,0,0,0
@@ -49311,8 +43147,6 @@ Daeyun Shin,2018-Q4,0,0,0
 Daeyun Shin,2018-Q3,0,0,0
 Daeyun Shin,2018-Q2,0,0,0
 Daeyun Shin,2018-Q1,0,0,0
-ironhead,2021-Q4,0,0,0
-ironhead,2021-Q3,0,0,0
 ironhead,2021-Q2,0,0,0
 ironhead,2021-Q1,0,0,0
 ironhead,2020-Q4,0,0,0
@@ -49327,8 +43161,6 @@ ironhead,2018-Q4,0,0,0
 ironhead,2018-Q3,0,0,0
 ironhead,2018-Q2,0,0,0
 ironhead,2018-Q1,0,0,0
-郑泽宇,2021-Q4,0,0,0
-郑泽宇,2021-Q3,0,0,0
 郑泽宇,2021-Q2,0,0,0
 郑泽宇,2021-Q1,0,0,0
 郑泽宇,2020-Q4,0,0,0
@@ -49343,8 +43175,6 @@ ironhead,2018-Q1,0,0,0
 郑泽宇,2018-Q3,0,0,0
 郑泽宇,2018-Q2,0,0,0
 郑泽宇,2018-Q1,0,0,0
-Zack Polizzi,2021-Q4,0,0,0
-Zack Polizzi,2021-Q3,0,0,0
 Zack Polizzi,2021-Q2,0,0,0
 Zack Polizzi,2021-Q1,0,0,0
 Zack Polizzi,2020-Q4,0,0,0
@@ -49359,8 +43189,6 @@ Zack Polizzi,2018-Q4,0,0,0
 Zack Polizzi,2018-Q3,0,0,0
 Zack Polizzi,2018-Q2,0,0,0
 Zack Polizzi,2018-Q1,0,0,0
-Andrew Thomas,2021-Q4,0,0,0
-Andrew Thomas,2021-Q3,0,0,0
 Andrew Thomas,2021-Q2,0,0,0
 Andrew Thomas,2021-Q1,0,0,0
 Andrew Thomas,2020-Q4,0,0,0
@@ -49375,8 +43203,6 @@ Andrew Thomas,2018-Q4,0,0,0
 Andrew Thomas,2018-Q3,0,0,0
 Andrew Thomas,2018-Q2,0,0,0
 Andrew Thomas,2018-Q1,0,0,0
-Kirill Bobyrev,2021-Q4,0,0,0
-Kirill Bobyrev,2021-Q3,0,0,0
 Kirill Bobyrev,2021-Q2,0,0,0
 Kirill Bobyrev,2021-Q1,0,0,0
 Kirill Bobyrev,2020-Q4,0,0,0
@@ -49391,8 +43217,6 @@ Kirill Bobyrev,2018-Q4,0,0,0
 Kirill Bobyrev,2018-Q3,0,0,0
 Kirill Bobyrev,2018-Q2,0,0,0
 Kirill Bobyrev,2018-Q1,0,0,0
-Malith Yapa,2021-Q4,0,0,0
-Malith Yapa,2021-Q3,0,0,0
 Malith Yapa,2021-Q2,0,0,0
 Malith Yapa,2021-Q1,0,0,0
 Malith Yapa,2020-Q4,0,0,0
@@ -49407,8 +43231,6 @@ Malith Yapa,2018-Q4,0,0,0
 Malith Yapa,2018-Q3,0,0,0
 Malith Yapa,2018-Q2,0,0,0
 Malith Yapa,2018-Q1,0,0,0
-Gustav Larsson,2021-Q4,0,0,0
-Gustav Larsson,2021-Q3,0,0,0
 Gustav Larsson,2021-Q2,0,0,0
 Gustav Larsson,2021-Q1,0,0,0
 Gustav Larsson,2020-Q4,0,0,0
@@ -49423,8 +43245,6 @@ Gustav Larsson,2018-Q4,0,0,0
 Gustav Larsson,2018-Q3,0,0,0
 Gustav Larsson,2018-Q2,0,0,0
 Gustav Larsson,2018-Q1,0,0,0
-Matthias Winkelmann,2021-Q4,0,0,0
-Matthias Winkelmann,2021-Q3,0,0,0
 Matthias Winkelmann,2021-Q2,0,0,0
 Matthias Winkelmann,2021-Q1,0,0,0
 Matthias Winkelmann,2020-Q4,0,0,0
@@ -49439,8 +43259,6 @@ Matthias Winkelmann,2018-Q4,0,0,0
 Matthias Winkelmann,2018-Q3,0,0,0
 Matthias Winkelmann,2018-Q2,0,0,0
 Matthias Winkelmann,2018-Q1,0,0,0
-Erik Erwitt,2021-Q4,0,0,0
-Erik Erwitt,2021-Q3,0,0,0
 Erik Erwitt,2021-Q2,0,0,0
 Erik Erwitt,2021-Q1,0,0,0
 Erik Erwitt,2020-Q4,0,0,0
@@ -49455,8 +43273,6 @@ Erik Erwitt,2018-Q4,0,0,0
 Erik Erwitt,2018-Q3,0,0,0
 Erik Erwitt,2018-Q2,0,0,0
 Erik Erwitt,2018-Q1,0,0,0
-Igor Macedo Quintanilha,2021-Q4,0,0,0
-Igor Macedo Quintanilha,2021-Q3,0,0,0
 Igor Macedo Quintanilha,2021-Q2,0,0,0
 Igor Macedo Quintanilha,2021-Q1,0,0,0
 Igor Macedo Quintanilha,2020-Q4,0,0,0
@@ -49471,8 +43287,6 @@ Igor Macedo Quintanilha,2018-Q4,0,0,0
 Igor Macedo Quintanilha,2018-Q3,0,0,0
 Igor Macedo Quintanilha,2018-Q2,0,0,0
 Igor Macedo Quintanilha,2018-Q1,0,0,0
-Daniel Julius Lasiman,2021-Q4,0,0,0
-Daniel Julius Lasiman,2021-Q3,0,0,0
 Daniel Julius Lasiman,2021-Q2,0,0,0
 Daniel Julius Lasiman,2021-Q1,0,0,0
 Daniel Julius Lasiman,2020-Q4,0,0,0
@@ -49487,8 +43301,6 @@ Daniel Julius Lasiman,2018-Q4,0,0,0
 Daniel Julius Lasiman,2018-Q3,0,0,0
 Daniel Julius Lasiman,2018-Q2,0,0,0
 Daniel Julius Lasiman,2018-Q1,0,0,0
-Steve,2021-Q4,0,0,0
-Steve,2021-Q3,0,0,0
 Steve,2021-Q2,0,0,0
 Steve,2021-Q1,0,0,0
 Steve,2020-Q4,0,0,0
@@ -49503,8 +43315,6 @@ Steve,2018-Q4,0,0,0
 Steve,2018-Q3,0,0,0
 Steve,2018-Q2,0,0,0
 Steve,2018-Q1,0,0,0
-Ajay Rao,2021-Q4,0,0,0
-Ajay Rao,2021-Q3,0,0,0
 Ajay Rao,2021-Q2,0,0,0
 Ajay Rao,2021-Q1,0,0,0
 Ajay Rao,2020-Q4,0,0,0
@@ -49519,8 +43329,6 @@ Ajay Rao,2018-Q4,0,0,0
 Ajay Rao,2018-Q3,0,0,0
 Ajay Rao,2018-Q2,0,0,0
 Ajay Rao,2018-Q1,0,0,0
-Yunfeng Wang,2021-Q4,0,0,0
-Yunfeng Wang,2021-Q3,0,0,0
 Yunfeng Wang,2021-Q2,0,0,0
 Yunfeng Wang,2021-Q1,0,0,0
 Yunfeng Wang,2020-Q4,0,0,0
@@ -49535,8 +43343,6 @@ Yunfeng Wang,2018-Q4,0,0,0
 Yunfeng Wang,2018-Q3,0,0,0
 Yunfeng Wang,2018-Q2,0,0,0
 Yunfeng Wang,2018-Q1,0,0,0
-YenChenLin,2021-Q4,0,0,0
-YenChenLin,2021-Q3,0,0,0
 YenChenLin,2021-Q2,0,0,0
 YenChenLin,2021-Q1,0,0,0
 YenChenLin,2020-Q4,0,0,0
@@ -49551,8 +43357,6 @@ YenChenLin,2018-Q4,0,0,0
 YenChenLin,2018-Q3,0,0,0
 YenChenLin,2018-Q2,0,0,0
 YenChenLin,2018-Q1,0,0,0
-Chenyang Liu,2021-Q4,0,0,0
-Chenyang Liu,2021-Q3,0,0,0
 Chenyang Liu,2021-Q2,0,0,0
 Chenyang Liu,2021-Q1,0,0,0
 Chenyang Liu,2020-Q4,0,0,0
@@ -49567,8 +43371,6 @@ Chenyang Liu,2018-Q4,0,0,0
 Chenyang Liu,2018-Q3,0,0,0
 Chenyang Liu,2018-Q2,0,0,0
 Chenyang Liu,2018-Q1,0,0,0
-Shinichiro Hamaji,2021-Q4,0,0,0
-Shinichiro Hamaji,2021-Q3,0,0,0
 Shinichiro Hamaji,2021-Q2,0,0,0
 Shinichiro Hamaji,2021-Q1,0,0,0
 Shinichiro Hamaji,2020-Q4,0,0,0
@@ -49583,8 +43385,6 @@ Shinichiro Hamaji,2018-Q4,0,0,0
 Shinichiro Hamaji,2018-Q3,0,0,0
 Shinichiro Hamaji,2018-Q2,0,0,0
 Shinichiro Hamaji,2018-Q1,0,0,0
-Fangwei Li,2021-Q4,0,0,0
-Fangwei Li,2021-Q3,0,0,0
 Fangwei Li,2021-Q2,0,0,0
 Fangwei Li,2021-Q1,0,0,0
 Fangwei Li,2020-Q4,0,0,0
@@ -49599,8 +43399,6 @@ Fangwei Li,2018-Q4,0,0,0
 Fangwei Li,2018-Q3,0,0,0
 Fangwei Li,2018-Q2,0,0,0
 Fangwei Li,2018-Q1,0,0,0
-Josh Bleecher Snyder,2021-Q4,0,0,0
-Josh Bleecher Snyder,2021-Q3,0,0,0
 Josh Bleecher Snyder,2021-Q2,0,0,0
 Josh Bleecher Snyder,2021-Q1,0,0,0
 Josh Bleecher Snyder,2020-Q4,0,0,0
@@ -49615,8 +43413,6 @@ Josh Bleecher Snyder,2018-Q4,0,0,0
 Josh Bleecher Snyder,2018-Q3,0,0,0
 Josh Bleecher Snyder,2018-Q2,0,0,0
 Josh Bleecher Snyder,2018-Q1,0,0,0
-Appleholic,2021-Q4,0,0,0
-Appleholic,2021-Q3,0,0,0
 Appleholic,2021-Q2,0,0,0
 Appleholic,2021-Q1,0,0,0
 Appleholic,2020-Q4,0,0,0
@@ -49631,8 +43427,6 @@ Appleholic,2018-Q4,0,0,0
 Appleholic,2018-Q3,0,0,0
 Appleholic,2018-Q2,0,0,0
 Appleholic,2018-Q1,0,0,0
-Ofir Press,2021-Q4,0,0,0
-Ofir Press,2021-Q3,0,0,0
 Ofir Press,2021-Q2,0,0,0
 Ofir Press,2021-Q1,0,0,0
 Ofir Press,2020-Q4,0,0,0
@@ -49647,8 +43441,6 @@ Ofir Press,2018-Q4,0,0,0
 Ofir Press,2018-Q3,0,0,0
 Ofir Press,2018-Q2,0,0,0
 Ofir Press,2018-Q1,0,0,0
-Robin Nabel,2021-Q4,0,0,0
-Robin Nabel,2021-Q3,0,0,0
 Robin Nabel,2021-Q2,0,0,0
 Robin Nabel,2021-Q1,0,0,0
 Robin Nabel,2020-Q4,0,0,0
@@ -49663,8 +43455,6 @@ Robin Nabel,2018-Q4,0,0,0
 Robin Nabel,2018-Q3,0,0,0
 Robin Nabel,2018-Q2,0,0,0
 Robin Nabel,2018-Q1,0,0,0
-Martin Englund,2021-Q4,0,0,0
-Martin Englund,2021-Q3,0,0,0
 Martin Englund,2021-Q2,0,0,0
 Martin Englund,2021-Q1,0,0,0
 Martin Englund,2020-Q4,0,0,0
@@ -49679,8 +43469,6 @@ Martin Englund,2018-Q4,0,0,0
 Martin Englund,2018-Q3,0,0,0
 Martin Englund,2018-Q2,0,0,0
 Martin Englund,2018-Q1,0,0,0
-Denis Gorbachev,2021-Q4,0,0,0
-Denis Gorbachev,2021-Q3,0,0,0
 Denis Gorbachev,2021-Q2,0,0,0
 Denis Gorbachev,2021-Q1,0,0,0
 Denis Gorbachev,2020-Q4,0,0,0
@@ -49695,8 +43483,6 @@ Denis Gorbachev,2018-Q4,0,0,0
 Denis Gorbachev,2018-Q3,0,0,0
 Denis Gorbachev,2018-Q2,0,0,0
 Denis Gorbachev,2018-Q1,0,0,0
-jpangburn,2021-Q4,0,0,0
-jpangburn,2021-Q3,0,0,0
 jpangburn,2021-Q2,0,0,0
 jpangburn,2021-Q1,0,0,0
 jpangburn,2020-Q4,0,0,0
@@ -49711,8 +43497,6 @@ jpangburn,2018-Q4,0,0,0
 jpangburn,2018-Q3,0,0,0
 jpangburn,2018-Q2,0,0,0
 jpangburn,2018-Q1,0,0,0
-Renato Utsch,2021-Q4,0,0,0
-Renato Utsch,2021-Q3,0,0,0
 Renato Utsch,2021-Q2,0,0,0
 Renato Utsch,2021-Q1,0,0,0
 Renato Utsch,2020-Q4,0,0,0
@@ -49727,8 +43511,6 @@ Renato Utsch,2018-Q4,0,0,0
 Renato Utsch,2018-Q3,0,0,0
 Renato Utsch,2018-Q2,0,0,0
 Renato Utsch,2018-Q1,0,0,0
-Park Jiin,2021-Q4,0,0,0
-Park Jiin,2021-Q3,0,0,0
 Park Jiin,2021-Q2,0,0,0
 Park Jiin,2021-Q1,0,0,0
 Park Jiin,2020-Q4,0,0,0
@@ -49743,8 +43525,6 @@ Park Jiin,2018-Q4,0,0,0
 Park Jiin,2018-Q3,0,0,0
 Park Jiin,2018-Q2,0,0,0
 Park Jiin,2018-Q1,0,0,0
-Mrinal Kalakrishnan,2021-Q4,0,0,0
-Mrinal Kalakrishnan,2021-Q3,0,0,0
 Mrinal Kalakrishnan,2021-Q2,0,0,0
 Mrinal Kalakrishnan,2021-Q1,0,0,0
 Mrinal Kalakrishnan,2020-Q4,0,0,0
@@ -49759,8 +43539,6 @@ Mrinal Kalakrishnan,2018-Q4,0,0,0
 Mrinal Kalakrishnan,2018-Q3,0,0,0
 Mrinal Kalakrishnan,2018-Q2,0,0,0
 Mrinal Kalakrishnan,2018-Q1,0,0,0
-Sahil Sharma,2021-Q4,0,0,0
-Sahil Sharma,2021-Q3,0,0,0
 Sahil Sharma,2021-Q2,0,0,0
 Sahil Sharma,2021-Q1,0,0,0
 Sahil Sharma,2020-Q4,0,0,0
@@ -49775,8 +43553,6 @@ Sahil Sharma,2018-Q4,0,0,0
 Sahil Sharma,2018-Q3,0,0,0
 Sahil Sharma,2018-Q2,0,0,0
 Sahil Sharma,2018-Q1,0,0,0
-Yuncheng Li,2021-Q4,0,0,0
-Yuncheng Li,2021-Q3,0,0,0
 Yuncheng Li,2021-Q2,0,0,0
 Yuncheng Li,2021-Q1,0,0,0
 Yuncheng Li,2020-Q4,0,0,0
@@ -49791,8 +43567,6 @@ Yuncheng Li,2018-Q4,0,0,0
 Yuncheng Li,2018-Q3,0,0,0
 Yuncheng Li,2018-Q2,0,0,0
 Yuncheng Li,2018-Q1,0,0,0
-afshinrahimi,2021-Q4,0,0,0
-afshinrahimi,2021-Q3,0,0,0
 afshinrahimi,2021-Q2,0,0,0
 afshinrahimi,2021-Q1,0,0,0
 afshinrahimi,2020-Q4,0,0,0
@@ -49807,8 +43581,6 @@ afshinrahimi,2018-Q4,0,0,0
 afshinrahimi,2018-Q3,0,0,0
 afshinrahimi,2018-Q2,0,0,0
 afshinrahimi,2018-Q1,0,0,0
-Jules Gagnon-Marchand,2021-Q4,0,0,0
-Jules Gagnon-Marchand,2021-Q3,0,0,0
 Jules Gagnon-Marchand,2021-Q2,0,0,0
 Jules Gagnon-Marchand,2021-Q1,0,0,0
 Jules Gagnon-Marchand,2020-Q4,0,0,0
@@ -49823,8 +43595,6 @@ Jules Gagnon-Marchand,2018-Q4,0,0,0
 Jules Gagnon-Marchand,2018-Q3,0,0,0
 Jules Gagnon-Marchand,2018-Q2,0,0,0
 Jules Gagnon-Marchand,2018-Q1,0,0,0
-Daniel Waterworth,2021-Q4,0,0,0
-Daniel Waterworth,2021-Q3,0,0,0
 Daniel Waterworth,2021-Q2,0,0,0
 Daniel Waterworth,2021-Q1,0,0,0
 Daniel Waterworth,2020-Q4,0,0,0
@@ -49839,8 +43609,6 @@ Daniel Waterworth,2018-Q4,0,0,0
 Daniel Waterworth,2018-Q3,0,0,0
 Daniel Waterworth,2018-Q2,0,0,0
 Daniel Waterworth,2018-Q1,0,0,0
-Ritwik Gupta,2021-Q4,0,0,0
-Ritwik Gupta,2021-Q3,0,0,0
 Ritwik Gupta,2021-Q2,0,0,0
 Ritwik Gupta,2021-Q1,0,0,0
 Ritwik Gupta,2020-Q4,0,0,0
@@ -49855,8 +43623,6 @@ Ritwik Gupta,2018-Q4,0,0,0
 Ritwik Gupta,2018-Q3,0,0,0
 Ritwik Gupta,2018-Q2,0,0,0
 Ritwik Gupta,2018-Q1,0,0,0
-AidanGG,2021-Q4,0,0,0
-AidanGG,2021-Q3,0,0,0
 AidanGG,2021-Q2,0,0,0
 AidanGG,2021-Q1,0,0,0
 AidanGG,2020-Q4,0,0,0
@@ -49871,8 +43637,6 @@ AidanGG,2018-Q4,0,0,0
 AidanGG,2018-Q3,0,0,0
 AidanGG,2018-Q2,0,0,0
 AidanGG,2018-Q1,0,0,0
-Maniteja Nandana,2021-Q4,0,0,0
-Maniteja Nandana,2021-Q3,0,0,0
 Maniteja Nandana,2021-Q2,0,0,0
 Maniteja Nandana,2021-Q1,0,0,0
 Maniteja Nandana,2020-Q4,0,0,0
@@ -49887,8 +43651,6 @@ Maniteja Nandana,2018-Q4,0,0,0
 Maniteja Nandana,2018-Q3,0,0,0
 Maniteja Nandana,2018-Q2,0,0,0
 Maniteja Nandana,2018-Q1,0,0,0
-Georg Nebehay,2021-Q4,0,0,0
-Georg Nebehay,2021-Q3,0,0,0
 Georg Nebehay,2021-Q2,0,0,0
 Georg Nebehay,2021-Q1,0,0,0
 Georg Nebehay,2020-Q4,0,0,0
@@ -49903,8 +43665,6 @@ Georg Nebehay,2018-Q4,0,0,0
 Georg Nebehay,2018-Q3,0,0,0
 Georg Nebehay,2018-Q2,0,0,0
 Georg Nebehay,2018-Q1,0,0,0
-Brandon Amos,2021-Q4,0,0,0
-Brandon Amos,2021-Q3,0,0,0
 Brandon Amos,2021-Q2,0,0,0
 Brandon Amos,2021-Q1,0,0,0
 Brandon Amos,2020-Q4,0,0,0
@@ -49919,8 +43679,6 @@ Brandon Amos,2018-Q4,0,0,0
 Brandon Amos,2018-Q3,0,0,0
 Brandon Amos,2018-Q2,0,0,0
 Brandon Amos,2018-Q1,0,0,0
-cwhipkey,2021-Q4,0,0,0
-cwhipkey,2021-Q3,0,0,0
 cwhipkey,2021-Q2,0,0,0
 cwhipkey,2021-Q1,0,0,0
 cwhipkey,2020-Q4,0,0,0
@@ -49935,8 +43693,6 @@ cwhipkey,2018-Q4,0,0,0
 cwhipkey,2018-Q3,0,0,0
 cwhipkey,2018-Q2,0,0,0
 cwhipkey,2018-Q1,0,0,0
-HW-ZZ,2021-Q4,0,0,0
-HW-ZZ,2021-Q3,0,0,0
 HW-ZZ,2021-Q2,0,0,0
 HW-ZZ,2021-Q1,0,0,0
 HW-ZZ,2020-Q4,0,0,0
@@ -49951,8 +43707,6 @@ HW-ZZ,2018-Q4,0,0,0
 HW-ZZ,2018-Q3,0,0,0
 HW-ZZ,2018-Q2,0,0,0
 HW-ZZ,2018-Q1,0,0,0
-ichuang,2021-Q4,0,0,0
-ichuang,2021-Q3,0,0,0
 ichuang,2021-Q2,0,0,0
 ichuang,2021-Q1,0,0,0
 ichuang,2020-Q4,0,0,0
@@ -49967,8 +43721,6 @@ ichuang,2018-Q4,0,0,0
 ichuang,2018-Q3,0,0,0
 ichuang,2018-Q2,0,0,0
 ichuang,2018-Q1,0,0,0
-Ben Dilday,2021-Q4,0,0,0
-Ben Dilday,2021-Q3,0,0,0
 Ben Dilday,2021-Q2,0,0,0
 Ben Dilday,2021-Q1,0,0,0
 Ben Dilday,2020-Q4,0,0,0
@@ -49983,8 +43735,6 @@ Ben Dilday,2018-Q4,0,0,0
 Ben Dilday,2018-Q3,0,0,0
 Ben Dilday,2018-Q2,0,0,0
 Ben Dilday,2018-Q1,0,0,0
-Sangheum,2021-Q4,0,0,0
-Sangheum,2021-Q3,0,0,0
 Sangheum,2021-Q2,0,0,0
 Sangheum,2021-Q1,0,0,0
 Sangheum,2020-Q4,0,0,0
@@ -49999,8 +43749,6 @@ Sangheum,2018-Q4,0,0,0
 Sangheum,2018-Q3,0,0,0
 Sangheum,2018-Q2,0,0,0
 Sangheum,2018-Q1,0,0,0
-Igor Babuschkin,2021-Q4,0,0,0
-Igor Babuschkin,2021-Q3,0,0,0
 Igor Babuschkin,2021-Q2,0,0,0
 Igor Babuschkin,2021-Q1,0,0,0
 Igor Babuschkin,2020-Q4,0,0,0
@@ -50015,8 +43763,6 @@ Igor Babuschkin,2018-Q4,0,0,0
 Igor Babuschkin,2018-Q3,0,0,0
 Igor Babuschkin,2018-Q2,0,0,0
 Igor Babuschkin,2018-Q1,0,0,0
-Egor-Krivov,2021-Q4,0,0,0
-Egor-Krivov,2021-Q3,0,0,0
 Egor-Krivov,2021-Q2,0,0,0
 Egor-Krivov,2021-Q1,0,0,0
 Egor-Krivov,2020-Q4,0,0,0
@@ -50031,8 +43777,6 @@ Egor-Krivov,2018-Q4,0,0,0
 Egor-Krivov,2018-Q3,0,0,0
 Egor-Krivov,2018-Q2,0,0,0
 Egor-Krivov,2018-Q1,0,0,0
-Simon DENEL,2021-Q4,0,0,0
-Simon DENEL,2021-Q3,0,0,0
 Simon DENEL,2021-Q2,0,0,0
 Simon DENEL,2021-Q1,0,0,0
 Simon DENEL,2020-Q4,0,0,0
@@ -50047,8 +43791,6 @@ Simon DENEL,2018-Q4,0,0,0
 Simon DENEL,2018-Q3,0,0,0
 Simon DENEL,2018-Q2,0,0,0
 Simon DENEL,2018-Q1,0,0,0
-Jennifer Guo,2021-Q4,0,0,0
-Jennifer Guo,2021-Q3,0,0,0
 Jennifer Guo,2021-Q2,0,0,0
 Jennifer Guo,2021-Q1,0,0,0
 Jennifer Guo,2020-Q4,0,0,0
@@ -50063,8 +43805,6 @@ Jennifer Guo,2018-Q4,0,0,0
 Jennifer Guo,2018-Q3,0,0,0
 Jennifer Guo,2018-Q2,0,0,0
 Jennifer Guo,2018-Q1,0,0,0
-Wei-Ting Kuo,2021-Q4,0,0,0
-Wei-Ting Kuo,2021-Q3,0,0,0
 Wei-Ting Kuo,2021-Q2,0,0,0
 Wei-Ting Kuo,2021-Q1,0,0,0
 Wei-Ting Kuo,2020-Q4,0,0,0
@@ -50079,8 +43819,6 @@ Wei-Ting Kuo,2018-Q4,0,0,0
 Wei-Ting Kuo,2018-Q3,0,0,0
 Wei-Ting Kuo,2018-Q2,0,0,0
 Wei-Ting Kuo,2018-Q1,0,0,0
-Pieter de Rijk,2021-Q4,0,0,0
-Pieter de Rijk,2021-Q3,0,0,0
 Pieter de Rijk,2021-Q2,0,0,0
 Pieter de Rijk,2021-Q1,0,0,0
 Pieter de Rijk,2020-Q4,0,0,0
@@ -50095,8 +43833,6 @@ Pieter de Rijk,2018-Q4,0,0,0
 Pieter de Rijk,2018-Q3,0,0,0
 Pieter de Rijk,2018-Q2,0,0,0
 Pieter de Rijk,2018-Q1,0,0,0
-Andrew Stromme,2021-Q4,0,0,0
-Andrew Stromme,2021-Q3,0,0,0
 Andrew Stromme,2021-Q2,0,0,0
 Andrew Stromme,2021-Q1,0,0,0
 Andrew Stromme,2020-Q4,0,0,0
@@ -50111,8 +43847,6 @@ Andrew Stromme,2018-Q4,0,0,0
 Andrew Stromme,2018-Q3,0,0,0
 Andrew Stromme,2018-Q2,0,0,0
 Andrew Stromme,2018-Q1,0,0,0
-Tijmen Tieleman,2021-Q4,0,0,0
-Tijmen Tieleman,2021-Q3,0,0,0
 Tijmen Tieleman,2021-Q2,0,0,0
 Tijmen Tieleman,2021-Q1,0,0,0
 Tijmen Tieleman,2020-Q4,0,0,0
@@ -50127,8 +43861,6 @@ Tijmen Tieleman,2018-Q4,0,0,0
 Tijmen Tieleman,2018-Q3,0,0,0
 Tijmen Tieleman,2018-Q2,0,0,0
 Tijmen Tieleman,2018-Q1,0,0,0
-Bastiaan Quast,2021-Q4,0,0,0
-Bastiaan Quast,2021-Q3,0,0,0
 Bastiaan Quast,2021-Q2,0,0,0
 Bastiaan Quast,2021-Q1,0,0,0
 Bastiaan Quast,2020-Q4,0,0,0
@@ -50143,8 +43875,6 @@ Bastiaan Quast,2018-Q4,0,0,0
 Bastiaan Quast,2018-Q3,0,0,0
 Bastiaan Quast,2018-Q2,0,0,0
 Bastiaan Quast,2018-Q1,0,0,0
-Daniel Castro Chin,2021-Q4,0,0,0
-Daniel Castro Chin,2021-Q3,0,0,0
 Daniel Castro Chin,2021-Q2,0,0,0
 Daniel Castro Chin,2021-Q1,0,0,0
 Daniel Castro Chin,2020-Q4,0,0,0
@@ -50159,8 +43889,6 @@ Daniel Castro Chin,2018-Q4,0,0,0
 Daniel Castro Chin,2018-Q3,0,0,0
 Daniel Castro Chin,2018-Q2,0,0,0
 Daniel Castro Chin,2018-Q1,0,0,0
-tijmentieleman,2021-Q4,0,0,0
-tijmentieleman,2021-Q3,0,0,0
 tijmentieleman,2021-Q2,0,0,0
 tijmentieleman,2021-Q1,0,0,0
 tijmentieleman,2020-Q4,0,0,0
@@ -50175,8 +43903,6 @@ tijmentieleman,2018-Q4,0,0,0
 tijmentieleman,2018-Q3,0,0,0
 tijmentieleman,2018-Q2,0,0,0
 tijmentieleman,2018-Q1,0,0,0
-Nathan Howell,2021-Q4,0,0,0
-Nathan Howell,2021-Q3,0,0,0
 Nathan Howell,2021-Q2,0,0,0
 Nathan Howell,2021-Q1,0,0,0
 Nathan Howell,2020-Q4,0,0,0
@@ -50191,8 +43917,6 @@ Nathan Howell,2018-Q4,0,0,0
 Nathan Howell,2018-Q3,0,0,0
 Nathan Howell,2018-Q2,0,0,0
 Nathan Howell,2018-Q1,0,0,0
-Longqi Yang,2021-Q4,0,0,0
-Longqi Yang,2021-Q3,0,0,0
 Longqi Yang,2021-Q2,0,0,0
 Longqi Yang,2021-Q1,0,0,0
 Longqi Yang,2020-Q4,0,0,0
@@ -50207,8 +43931,6 @@ Longqi Yang,2018-Q4,0,0,0
 Longqi Yang,2018-Q3,0,0,0
 Longqi Yang,2018-Q2,0,0,0
 Longqi Yang,2018-Q1,0,0,0
-Elia Palme,2021-Q4,0,0,0
-Elia Palme,2021-Q3,0,0,0
 Elia Palme,2021-Q2,0,0,0
 Elia Palme,2021-Q1,0,0,0
 Elia Palme,2020-Q4,0,0,0
@@ -50223,8 +43945,6 @@ Elia Palme,2018-Q4,0,0,0
 Elia Palme,2018-Q3,0,0,0
 Elia Palme,2018-Q2,0,0,0
 Elia Palme,2018-Q1,0,0,0
-suiyuan2009,2021-Q4,0,0,0
-suiyuan2009,2021-Q3,0,0,0
 suiyuan2009,2021-Q2,0,0,0
 suiyuan2009,2021-Q1,0,0,0
 suiyuan2009,2020-Q4,0,0,0
@@ -50239,8 +43959,6 @@ suiyuan2009,2018-Q4,0,0,0
 suiyuan2009,2018-Q3,0,0,0
 suiyuan2009,2018-Q2,0,0,0
 suiyuan2009,2018-Q1,0,0,0
-Josh Levenberg,2021-Q4,0,0,0
-Josh Levenberg,2021-Q3,0,0,0
 Josh Levenberg,2021-Q2,0,0,0
 Josh Levenberg,2021-Q1,0,0,0
 Josh Levenberg,2020-Q4,0,0,0
@@ -50255,8 +43973,6 @@ Josh Levenberg,2018-Q4,0,0,0
 Josh Levenberg,2018-Q3,0,0,0
 Josh Levenberg,2018-Q2,0,0,0
 Josh Levenberg,2018-Q1,0,0,0
-Tiago Jorge,2021-Q4,0,0,0
-Tiago Jorge,2021-Q3,0,0,0
 Tiago Jorge,2021-Q2,0,0,0
 Tiago Jorge,2021-Q1,0,0,0
 Tiago Jorge,2020-Q4,0,0,0
@@ -50271,8 +43987,6 @@ Tiago Jorge,2018-Q4,0,0,0
 Tiago Jorge,2018-Q3,0,0,0
 Tiago Jorge,2018-Q2,0,0,0
 Tiago Jorge,2018-Q1,0,0,0
-Adam Crume,2021-Q4,0,0,0
-Adam Crume,2021-Q3,0,0,0
 Adam Crume,2021-Q2,0,0,0
 Adam Crume,2021-Q1,0,0,0
 Adam Crume,2020-Q4,0,0,0
@@ -50287,8 +44001,6 @@ Adam Crume,2018-Q4,0,0,0
 Adam Crume,2018-Q3,0,0,0
 Adam Crume,2018-Q2,0,0,0
 Adam Crume,2018-Q1,0,0,0
-Mu-ik Jeon,2021-Q4,0,0,0
-Mu-ik Jeon,2021-Q3,0,0,0
 Mu-ik Jeon,2021-Q2,0,0,0
 Mu-ik Jeon,2021-Q1,0,0,0
 Mu-ik Jeon,2020-Q4,0,0,0
@@ -50303,8 +44015,6 @@ Mu-ik Jeon,2018-Q4,0,0,0
 Mu-ik Jeon,2018-Q3,0,0,0
 Mu-ik Jeon,2018-Q2,0,0,0
 Mu-ik Jeon,2018-Q1,0,0,0
-Bofu Chen,2021-Q4,0,0,0
-Bofu Chen,2021-Q3,0,0,0
 Bofu Chen,2021-Q2,0,0,0
 Bofu Chen,2021-Q1,0,0,0
 Bofu Chen,2020-Q4,0,0,0
@@ -50319,8 +44029,6 @@ Bofu Chen,2018-Q4,0,0,0
 Bofu Chen,2018-Q3,0,0,0
 Bofu Chen,2018-Q2,0,0,0
 Bofu Chen,2018-Q1,0,0,0
-mecab,2021-Q4,0,0,0
-mecab,2021-Q3,0,0,0
 mecab,2021-Q2,0,0,0
 mecab,2021-Q1,0,0,0
 mecab,2020-Q4,0,0,0
@@ -50335,8 +44043,6 @@ mecab,2018-Q4,0,0,0
 mecab,2018-Q3,0,0,0
 mecab,2018-Q2,0,0,0
 mecab,2018-Q1,0,0,0
-Satoshi Kataoka,2021-Q4,0,0,0
-Satoshi Kataoka,2021-Q3,0,0,0
 Satoshi Kataoka,2021-Q2,0,0,0
 Satoshi Kataoka,2021-Q1,0,0,0
 Satoshi Kataoka,2020-Q4,0,0,0
@@ -50351,8 +44057,6 @@ Satoshi Kataoka,2018-Q4,0,0,0
 Satoshi Kataoka,2018-Q3,0,0,0
 Satoshi Kataoka,2018-Q2,0,0,0
 Satoshi Kataoka,2018-Q1,0,0,0
-Pēteris Paikens,2021-Q4,0,0,0
-Pēteris Paikens,2021-Q3,0,0,0
 Pēteris Paikens,2021-Q2,0,0,0
 Pēteris Paikens,2021-Q1,0,0,0
 Pēteris Paikens,2020-Q4,0,0,0
@@ -50367,8 +44071,6 @@ Pēteris Paikens,2018-Q4,0,0,0
 Pēteris Paikens,2018-Q3,0,0,0
 Pēteris Paikens,2018-Q2,0,0,0
 Pēteris Paikens,2018-Q1,0,0,0
-Iver Jordal,2021-Q4,0,0,0
-Iver Jordal,2021-Q3,0,0,0
 Iver Jordal,2021-Q2,0,0,0
 Iver Jordal,2021-Q1,0,0,0
 Iver Jordal,2020-Q4,0,0,0
@@ -50383,8 +44085,6 @@ Iver Jordal,2018-Q4,0,0,0
 Iver Jordal,2018-Q3,0,0,0
 Iver Jordal,2018-Q2,0,0,0
 Iver Jordal,2018-Q1,0,0,0
-Wang Yang,2021-Q4,0,0,0
-Wang Yang,2021-Q3,0,0,0
 Wang Yang,2021-Q2,0,0,0
 Wang Yang,2021-Q1,0,0,0
 Wang Yang,2020-Q4,0,0,0
@@ -50399,8 +44099,6 @@ Wang Yang,2018-Q4,0,0,0
 Wang Yang,2018-Q3,0,0,0
 Wang Yang,2018-Q2,0,0,0
 Wang Yang,2018-Q1,0,0,0
-Glen Baker,2021-Q4,0,0,0
-Glen Baker,2021-Q3,0,0,0
 Glen Baker,2021-Q2,0,0,0
 Glen Baker,2021-Q1,0,0,0
 Glen Baker,2020-Q4,0,0,0
@@ -50415,8 +44113,6 @@ Glen Baker,2018-Q4,0,0,0
 Glen Baker,2018-Q3,0,0,0
 Glen Baker,2018-Q2,0,0,0
 Glen Baker,2018-Q1,0,0,0
-yifeif,2021-Q4,0,0,0
-yifeif,2021-Q3,0,0,0
 yifeif,2021-Q2,0,0,0
 yifeif,2021-Q1,0,0,0
 yifeif,2020-Q4,0,0,0
@@ -50431,8 +44127,6 @@ yifeif,2018-Q4,0,0,0
 yifeif,2018-Q3,0,0,0
 yifeif,2018-Q2,0,0,0
 yifeif,2018-Q1,0,0,0
-ssyrain,2021-Q4,0,0,0
-ssyrain,2021-Q3,0,0,0
 ssyrain,2021-Q2,0,0,0
 ssyrain,2021-Q1,0,0,0
 ssyrain,2020-Q4,0,0,0
@@ -50447,8 +44141,6 @@ ssyrain,2018-Q4,0,0,0
 ssyrain,2018-Q3,0,0,0
 ssyrain,2018-Q2,0,0,0
 ssyrain,2018-Q1,0,0,0
-John Allen,2021-Q4,0,0,0
-John Allen,2021-Q3,0,0,0
 John Allen,2021-Q2,0,0,0
 John Allen,2021-Q1,0,0,0
 John Allen,2020-Q4,0,0,0
@@ -50463,8 +44155,6 @@ John Allen,2018-Q4,0,0,0
 John Allen,2018-Q3,0,0,0
 John Allen,2018-Q2,0,0,0
 John Allen,2018-Q1,0,0,0
-Thomas Oldervoll,2021-Q4,0,0,0
-Thomas Oldervoll,2021-Q3,0,0,0
 Thomas Oldervoll,2021-Q2,0,0,0
 Thomas Oldervoll,2021-Q1,0,0,0
 Thomas Oldervoll,2020-Q4,0,0,0
@@ -50479,8 +44169,6 @@ Thomas Oldervoll,2018-Q4,0,0,0
 Thomas Oldervoll,2018-Q3,0,0,0
 Thomas Oldervoll,2018-Q2,0,0,0
 Thomas Oldervoll,2018-Q1,0,0,0
-Siddharth Agrawal,2021-Q4,0,0,0
-Siddharth Agrawal,2021-Q3,0,0,0
 Siddharth Agrawal,2021-Q2,0,0,0
 Siddharth Agrawal,2021-Q1,0,0,0
 Siddharth Agrawal,2020-Q4,0,0,0
@@ -50495,8 +44183,6 @@ Siddharth Agrawal,2018-Q4,0,0,0
 Siddharth Agrawal,2018-Q3,0,0,0
 Siddharth Agrawal,2018-Q2,0,0,0
 Siddharth Agrawal,2018-Q1,0,0,0
-Johann Petrak,2021-Q4,0,0,0
-Johann Petrak,2021-Q3,0,0,0
 Johann Petrak,2021-Q2,0,0,0
 Johann Petrak,2021-Q1,0,0,0
 Johann Petrak,2020-Q4,0,0,0
@@ -50511,8 +44197,6 @@ Johann Petrak,2018-Q4,0,0,0
 Johann Petrak,2018-Q3,0,0,0
 Johann Petrak,2018-Q2,0,0,0
 Johann Petrak,2018-Q1,0,0,0
-Haebin Shin,2021-Q4,0,0,0
-Haebin Shin,2021-Q3,0,0,0
 Haebin Shin,2021-Q2,0,0,0
 Haebin Shin,2021-Q1,0,0,0
 Haebin Shin,2020-Q4,0,0,0
@@ -50527,8 +44211,6 @@ Haebin Shin,2018-Q4,0,0,0
 Haebin Shin,2018-Q3,0,0,0
 Haebin Shin,2018-Q2,0,0,0
 Haebin Shin,2018-Q1,0,0,0
-Thomas Lee,2021-Q4,0,0,0
-Thomas Lee,2021-Q3,0,0,0
 Thomas Lee,2021-Q2,0,0,0
 Thomas Lee,2021-Q1,0,0,0
 Thomas Lee,2020-Q4,0,0,0
@@ -50543,8 +44225,6 @@ Thomas Lee,2018-Q4,0,0,0
 Thomas Lee,2018-Q3,0,0,0
 Thomas Lee,2018-Q2,0,0,0
 Thomas Lee,2018-Q1,0,0,0
-Ted Fujimoto,2021-Q4,0,0,0
-Ted Fujimoto,2021-Q3,0,0,0
 Ted Fujimoto,2021-Q2,0,0,0
 Ted Fujimoto,2021-Q1,0,0,0
 Ted Fujimoto,2020-Q4,0,0,0
@@ -50559,8 +44239,6 @@ Ted Fujimoto,2018-Q4,0,0,0
 Ted Fujimoto,2018-Q3,0,0,0
 Ted Fujimoto,2018-Q2,0,0,0
 Ted Fujimoto,2018-Q1,0,0,0
-SergejsRk,2021-Q4,0,0,0
-SergejsRk,2021-Q3,0,0,0
 SergejsRk,2021-Q2,0,0,0
 SergejsRk,2021-Q1,0,0,0
 SergejsRk,2020-Q4,0,0,0
@@ -50575,8 +44253,6 @@ SergejsRk,2018-Q4,0,0,0
 SergejsRk,2018-Q3,0,0,0
 SergejsRk,2018-Q2,0,0,0
 SergejsRk,2018-Q1,0,0,0
-James Fysh,2021-Q4,0,0,0
-James Fysh,2021-Q3,0,0,0
 James Fysh,2021-Q2,0,0,0
 James Fysh,2021-Q1,0,0,0
 James Fysh,2020-Q4,0,0,0
@@ -50591,8 +44267,6 @@ James Fysh,2018-Q4,0,0,0
 James Fysh,2018-Q3,0,0,0
 James Fysh,2018-Q2,0,0,0
 James Fysh,2018-Q1,0,0,0
-Abid K,2021-Q4,0,0,0
-Abid K,2021-Q3,0,0,0
 Abid K,2021-Q2,0,0,0
 Abid K,2021-Q1,0,0,0
 Abid K,2020-Q4,0,0,0
@@ -50607,8 +44281,6 @@ Abid K,2018-Q4,0,0,0
 Abid K,2018-Q3,0,0,0
 Abid K,2018-Q2,0,0,0
 Abid K,2018-Q1,0,0,0
-satok16,2021-Q4,0,0,0
-satok16,2021-Q3,0,0,0
 satok16,2021-Q2,0,0,0
 satok16,2021-Q1,0,0,0
 satok16,2020-Q4,0,0,0
@@ -50623,8 +44295,6 @@ satok16,2018-Q4,0,0,0
 satok16,2018-Q3,0,0,0
 satok16,2018-Q2,0,0,0
 satok16,2018-Q1,0,0,0
-Brian Diesel,2021-Q4,0,0,0
-Brian Diesel,2021-Q3,0,0,0
 Brian Diesel,2021-Q2,0,0,0
 Brian Diesel,2021-Q1,0,0,0
 Brian Diesel,2020-Q4,0,0,0
@@ -50639,8 +44309,6 @@ Brian Diesel,2018-Q4,0,0,0
 Brian Diesel,2018-Q3,0,0,0
 Brian Diesel,2018-Q2,0,0,0
 Brian Diesel,2018-Q1,0,0,0
-Nico Galoppo,2021-Q4,0,0,0
-Nico Galoppo,2021-Q3,0,0,0
 Nico Galoppo,2021-Q2,0,0,0
 Nico Galoppo,2021-Q1,0,0,0
 Nico Galoppo,2020-Q4,0,0,0
@@ -50655,8 +44323,6 @@ Nico Galoppo,2018-Q4,0,0,0
 Nico Galoppo,2018-Q3,0,0,0
 Nico Galoppo,2018-Q2,0,0,0
 Nico Galoppo,2018-Q1,0,0,0
-sono-bfio,2021-Q4,0,0,0
-sono-bfio,2021-Q3,0,0,0
 sono-bfio,2021-Q2,0,0,0
 sono-bfio,2021-Q1,0,0,0
 sono-bfio,2020-Q4,0,0,0
@@ -50671,8 +44337,6 @@ sono-bfio,2018-Q4,0,0,0
 sono-bfio,2018-Q3,0,0,0
 sono-bfio,2018-Q2,0,0,0
 sono-bfio,2018-Q1,0,0,0
-Rohit Girdhar,2021-Q4,0,0,0
-Rohit Girdhar,2021-Q3,0,0,0
 Rohit Girdhar,2021-Q2,0,0,0
 Rohit Girdhar,2021-Q1,0,0,0
 Rohit Girdhar,2020-Q4,0,0,0
@@ -50687,8 +44351,6 @@ Rohit Girdhar,2018-Q4,0,0,0
 Rohit Girdhar,2018-Q3,0,0,0
 Rohit Girdhar,2018-Q2,0,0,0
 Rohit Girdhar,2018-Q1,0,0,0
-Sergey Kishchenko,2021-Q4,0,0,0
-Sergey Kishchenko,2021-Q3,0,0,0
 Sergey Kishchenko,2021-Q2,0,0,0
 Sergey Kishchenko,2021-Q1,0,0,0
 Sergey Kishchenko,2020-Q4,0,0,0
@@ -50703,8 +44365,6 @@ Sergey Kishchenko,2018-Q4,0,0,0
 Sergey Kishchenko,2018-Q3,0,0,0
 Sergey Kishchenko,2018-Q2,0,0,0
 Sergey Kishchenko,2018-Q1,0,0,0
-Eric Nielsen,2021-Q4,0,0,0
-Eric Nielsen,2021-Q3,0,0,0
 Eric Nielsen,2021-Q2,0,0,0
 Eric Nielsen,2021-Q1,0,0,0
 Eric Nielsen,2020-Q4,0,0,0
@@ -50719,8 +44379,6 @@ Eric Nielsen,2018-Q4,0,0,0
 Eric Nielsen,2018-Q3,0,0,0
 Eric Nielsen,2018-Q2,0,0,0
 Eric Nielsen,2018-Q1,0,0,0
-maxmelnick,2021-Q4,0,0,0
-maxmelnick,2021-Q3,0,0,0
 maxmelnick,2021-Q2,0,0,0
 maxmelnick,2021-Q1,0,0,0
 maxmelnick,2020-Q4,0,0,0
@@ -50735,8 +44393,6 @@ maxmelnick,2018-Q4,0,0,0
 maxmelnick,2018-Q3,0,0,0
 maxmelnick,2018-Q2,0,0,0
 maxmelnick,2018-Q1,0,0,0
-chemelnucfin,2021-Q4,0,0,0
-chemelnucfin,2021-Q3,0,0,0
 chemelnucfin,2021-Q2,0,0,0
 chemelnucfin,2021-Q1,0,0,0
 chemelnucfin,2020-Q4,0,0,0
@@ -50751,8 +44407,6 @@ chemelnucfin,2018-Q4,0,0,0
 chemelnucfin,2018-Q3,0,0,0
 chemelnucfin,2018-Q2,0,0,0
 chemelnucfin,2018-Q1,0,0,0
-Marco Marchesi,2021-Q4,0,0,0
-Marco Marchesi,2021-Q3,0,0,0
 Marco Marchesi,2021-Q2,0,0,0
 Marco Marchesi,2021-Q1,0,0,0
 Marco Marchesi,2020-Q4,0,0,0
@@ -50767,8 +44421,6 @@ Marco Marchesi,2018-Q4,0,0,0
 Marco Marchesi,2018-Q3,0,0,0
 Marco Marchesi,2018-Q2,0,0,0
 Marco Marchesi,2018-Q1,0,0,0
-Henry Saputra,2021-Q4,0,0,0
-Henry Saputra,2021-Q3,0,0,0
 Henry Saputra,2021-Q2,0,0,0
 Henry Saputra,2021-Q1,0,0,0
 Henry Saputra,2020-Q4,0,0,0
@@ -50783,8 +44435,6 @@ Henry Saputra,2018-Q4,0,0,0
 Henry Saputra,2018-Q3,0,0,0
 Henry Saputra,2018-Q2,0,0,0
 Henry Saputra,2018-Q1,0,0,0
-dauba-dauba,2021-Q4,0,0,0
-dauba-dauba,2021-Q3,0,0,0
 dauba-dauba,2021-Q2,0,0,0
 dauba-dauba,2021-Q1,0,0,0
 dauba-dauba,2020-Q4,0,0,0
@@ -50799,8 +44449,6 @@ dauba-dauba,2018-Q4,0,0,0
 dauba-dauba,2018-Q3,0,0,0
 dauba-dauba,2018-Q2,0,0,0
 dauba-dauba,2018-Q1,0,0,0
-Gideon Dresdner,2021-Q4,0,0,0
-Gideon Dresdner,2021-Q3,0,0,0
 Gideon Dresdner,2021-Q2,0,0,0
 Gideon Dresdner,2021-Q1,0,0,0
 Gideon Dresdner,2020-Q4,0,0,0
@@ -50815,8 +44463,6 @@ Gideon Dresdner,2018-Q4,0,0,0
 Gideon Dresdner,2018-Q3,0,0,0
 Gideon Dresdner,2018-Q2,0,0,0
 Gideon Dresdner,2018-Q1,0,0,0
-Dmitry Savintsev,2021-Q4,0,0,0
-Dmitry Savintsev,2021-Q3,0,0,0
 Dmitry Savintsev,2021-Q2,0,0,0
 Dmitry Savintsev,2021-Q1,0,0,0
 Dmitry Savintsev,2020-Q4,0,0,0
@@ -50831,8 +44477,6 @@ Dmitry Savintsev,2018-Q4,0,0,0
 Dmitry Savintsev,2018-Q3,0,0,0
 Dmitry Savintsev,2018-Q2,0,0,0
 Dmitry Savintsev,2018-Q1,0,0,0
-Justin Francis,2021-Q4,0,0,0
-Justin Francis,2021-Q3,0,0,0
 Justin Francis,2021-Q2,0,0,0
 Justin Francis,2021-Q1,0,0,0
 Justin Francis,2020-Q4,0,0,0
@@ -50847,8 +44491,6 @@ Justin Francis,2018-Q4,0,0,0
 Justin Francis,2018-Q3,0,0,0
 Justin Francis,2018-Q2,0,0,0
 Justin Francis,2018-Q1,0,0,0
-Huarong,2021-Q4,0,0,0
-Huarong,2021-Q3,0,0,0
 Huarong,2021-Q2,0,0,0
 Huarong,2021-Q1,0,0,0
 Huarong,2020-Q4,0,0,0
@@ -50863,8 +44505,6 @@ Huarong,2018-Q4,0,0,0
 Huarong,2018-Q3,0,0,0
 Huarong,2018-Q2,0,0,0
 Huarong,2018-Q1,0,0,0
-tobe,2021-Q4,0,0,0
-tobe,2021-Q3,0,0,0
 tobe,2021-Q2,0,0,0
 tobe,2021-Q1,0,0,0
 tobe,2020-Q4,0,0,0
@@ -50879,8 +44519,6 @@ tobe,2018-Q4,0,0,0
 tobe,2018-Q3,0,0,0
 tobe,2018-Q2,0,0,0
 tobe,2018-Q1,0,0,0
-heinzbeinz,2021-Q4,0,0,0
-heinzbeinz,2021-Q3,0,0,0
 heinzbeinz,2021-Q2,0,0,0
 heinzbeinz,2021-Q1,0,0,0
 heinzbeinz,2020-Q4,0,0,0
@@ -50895,8 +44533,6 @@ heinzbeinz,2018-Q4,0,0,0
 heinzbeinz,2018-Q3,0,0,0
 heinzbeinz,2018-Q2,0,0,0
 heinzbeinz,2018-Q1,0,0,0
-Chris Lesniewski,2021-Q4,0,0,0
-Chris Lesniewski,2021-Q3,0,0,0
 Chris Lesniewski,2021-Q2,0,0,0
 Chris Lesniewski,2021-Q1,0,0,0
 Chris Lesniewski,2020-Q4,0,0,0
@@ -50911,8 +44547,6 @@ Chris Lesniewski,2018-Q4,0,0,0
 Chris Lesniewski,2018-Q3,0,0,0
 Chris Lesniewski,2018-Q2,0,0,0
 Chris Lesniewski,2018-Q1,0,0,0
-Jan Wilken Dörrie,2021-Q4,0,0,0
-Jan Wilken Dörrie,2021-Q3,0,0,0
 Jan Wilken Dörrie,2021-Q2,0,0,0
 Jan Wilken Dörrie,2021-Q1,0,0,0
 Jan Wilken Dörrie,2020-Q4,0,0,0
@@ -50927,8 +44561,6 @@ Jan Wilken Dörrie,2018-Q4,0,0,0
 Jan Wilken Dörrie,2018-Q3,0,0,0
 Jan Wilken Dörrie,2018-Q2,0,0,0
 Jan Wilken Dörrie,2018-Q1,0,0,0
-Shota,2021-Q4,0,0,0
-Shota,2021-Q3,0,0,0
 Shota,2021-Q2,0,0,0
 Shota,2021-Q1,0,0,0
 Shota,2020-Q4,0,0,0
@@ -50943,8 +44575,6 @@ Shota,2018-Q4,0,0,0
 Shota,2018-Q3,0,0,0
 Shota,2018-Q2,0,0,0
 Shota,2018-Q1,0,0,0
-Nishant Agrawal,2021-Q4,0,0,0
-Nishant Agrawal,2021-Q3,0,0,0
 Nishant Agrawal,2021-Q2,0,0,0
 Nishant Agrawal,2021-Q1,0,0,0
 Nishant Agrawal,2020-Q4,0,0,0
@@ -50959,8 +44589,6 @@ Nishant Agrawal,2018-Q4,0,0,0
 Nishant Agrawal,2018-Q3,0,0,0
 Nishant Agrawal,2018-Q2,0,0,0
 Nishant Agrawal,2018-Q1,0,0,0
-Emmanuel T Odeke,2021-Q4,0,0,0
-Emmanuel T Odeke,2021-Q3,0,0,0
 Emmanuel T Odeke,2021-Q2,0,0,0
 Emmanuel T Odeke,2021-Q1,0,0,0
 Emmanuel T Odeke,2020-Q4,0,0,0
@@ -50975,8 +44603,6 @@ Emmanuel T Odeke,2018-Q4,0,0,0
 Emmanuel T Odeke,2018-Q3,0,0,0
 Emmanuel T Odeke,2018-Q2,0,0,0
 Emmanuel T Odeke,2018-Q1,0,0,0
-Jonathan Raiman,2021-Q4,0,0,0
-Jonathan Raiman,2021-Q3,0,0,0
 Jonathan Raiman,2021-Q2,0,0,0
 Jonathan Raiman,2021-Q1,0,0,0
 Jonathan Raiman,2020-Q4,0,0,0
@@ -50991,8 +44617,6 @@ Jonathan Raiman,2018-Q4,0,0,0
 Jonathan Raiman,2018-Q3,0,0,0
 Jonathan Raiman,2018-Q2,0,0,0
 Jonathan Raiman,2018-Q1,0,0,0
-ysuematsu,2021-Q4,0,0,0
-ysuematsu,2021-Q3,0,0,0
 ysuematsu,2021-Q2,0,0,0
 ysuematsu,2021-Q1,0,0,0
 ysuematsu,2020-Q4,0,0,0
@@ -51007,8 +44631,6 @@ ysuematsu,2018-Q4,0,0,0
 ysuematsu,2018-Q3,0,0,0
 ysuematsu,2018-Q2,0,0,0
 ysuematsu,2018-Q1,0,0,0
-shenhanc78,2021-Q4,0,0,0
-shenhanc78,2021-Q3,0,0,0
 shenhanc78,2021-Q2,0,0,0
 shenhanc78,2021-Q1,0,0,0
 shenhanc78,2020-Q4,0,0,0
@@ -51023,8 +44645,6 @@ shenhanc78,2018-Q4,0,0,0
 shenhanc78,2018-Q3,0,0,0
 shenhanc78,2018-Q2,0,0,0
 shenhanc78,2018-Q1,0,0,0
-dcastro9,2021-Q4,0,0,0
-dcastro9,2021-Q3,0,0,0
 dcastro9,2021-Q2,0,0,0
 dcastro9,2021-Q1,0,0,0
 dcastro9,2020-Q4,0,0,0
@@ -51039,8 +44659,6 @@ dcastro9,2018-Q4,0,0,0
 dcastro9,2018-Q3,0,0,0
 dcastro9,2018-Q2,0,0,0
 dcastro9,2018-Q1,0,0,0
-Austin Marshall,2021-Q4,0,0,0
-Austin Marshall,2021-Q3,0,0,0
 Austin Marshall,2021-Q2,0,0,0
 Austin Marshall,2021-Q1,0,0,0
 Austin Marshall,2020-Q4,0,0,0
@@ -51055,8 +44673,6 @@ Austin Marshall,2018-Q4,0,0,0
 Austin Marshall,2018-Q3,0,0,0
 Austin Marshall,2018-Q2,0,0,0
 Austin Marshall,2018-Q1,0,0,0
-Gavin Sherry,2021-Q4,0,0,0
-Gavin Sherry,2021-Q3,0,0,0
 Gavin Sherry,2021-Q2,0,0,0
 Gavin Sherry,2021-Q1,0,0,0
 Gavin Sherry,2020-Q4,0,0,0
@@ -51071,8 +44687,6 @@ Gavin Sherry,2018-Q4,0,0,0
 Gavin Sherry,2018-Q3,0,0,0
 Gavin Sherry,2018-Q2,0,0,0
 Gavin Sherry,2018-Q1,0,0,0
-Bob Adolf,2021-Q4,0,0,0
-Bob Adolf,2021-Q3,0,0,0
 Bob Adolf,2021-Q2,0,0,0
 Bob Adolf,2021-Q1,0,0,0
 Bob Adolf,2020-Q4,0,0,0
@@ -51087,8 +44701,6 @@ Bob Adolf,2018-Q4,0,0,0
 Bob Adolf,2018-Q3,0,0,0
 Bob Adolf,2018-Q2,0,0,0
 Bob Adolf,2018-Q1,0,0,0
-Mostafa Gazar,2021-Q4,0,0,0
-Mostafa Gazar,2021-Q3,0,0,0
 Mostafa Gazar,2021-Q2,0,0,0
 Mostafa Gazar,2021-Q1,0,0,0
 Mostafa Gazar,2020-Q4,0,0,0
@@ -51103,8 +44715,6 @@ Mostafa Gazar,2018-Q4,0,0,0
 Mostafa Gazar,2018-Q3,0,0,0
 Mostafa Gazar,2018-Q2,0,0,0
 Mostafa Gazar,2018-Q1,0,0,0
-lilac,2021-Q4,0,0,0
-lilac,2021-Q3,0,0,0
 lilac,2021-Q2,0,0,0
 lilac,2021-Q1,0,0,0
 lilac,2020-Q4,0,0,0
@@ -51119,8 +44729,6 @@ lilac,2018-Q4,0,0,0
 lilac,2018-Q3,0,0,0
 lilac,2018-Q2,0,0,0
 lilac,2018-Q1,0,0,0
-Petr Janda,2021-Q4,0,0,0
-Petr Janda,2021-Q3,0,0,0
 Petr Janda,2021-Q2,0,0,0
 Petr Janda,2021-Q1,0,0,0
 Petr Janda,2020-Q4,0,0,0
@@ -51135,8 +44743,6 @@ Petr Janda,2018-Q4,0,0,0
 Petr Janda,2018-Q3,0,0,0
 Petr Janda,2018-Q2,0,0,0
 Petr Janda,2018-Q1,0,0,0
-Robin-des-Bois,2021-Q4,0,0,0
-Robin-des-Bois,2021-Q3,0,0,0
 Robin-des-Bois,2021-Q2,0,0,0
 Robin-des-Bois,2021-Q1,0,0,0
 Robin-des-Bois,2020-Q4,0,0,0
@@ -51151,8 +44757,6 @@ Robin-des-Bois,2018-Q4,0,0,0
 Robin-des-Bois,2018-Q3,0,0,0
 Robin-des-Bois,2018-Q2,0,0,0
 Robin-des-Bois,2018-Q1,0,0,0
-Marc Khoury,2021-Q4,0,0,0
-Marc Khoury,2021-Q3,0,0,0
 Marc Khoury,2021-Q2,0,0,0
 Marc Khoury,2021-Q1,0,0,0
 Marc Khoury,2020-Q4,0,0,0
@@ -51167,8 +44771,6 @@ Marc Khoury,2018-Q4,0,0,0
 Marc Khoury,2018-Q3,0,0,0
 Marc Khoury,2018-Q2,0,0,0
 Marc Khoury,2018-Q1,0,0,0
-Daniel Rodriguez,2021-Q4,0,0,0
-Daniel Rodriguez,2021-Q3,0,0,0
 Daniel Rodriguez,2021-Q2,0,0,0
 Daniel Rodriguez,2021-Q1,0,0,0
 Daniel Rodriguez,2020-Q4,0,0,0
@@ -51183,8 +44785,6 @@ Daniel Rodriguez,2018-Q4,0,0,0
 Daniel Rodriguez,2018-Q3,0,0,0
 Daniel Rodriguez,2018-Q2,0,0,0
 Daniel Rodriguez,2018-Q1,0,0,0
-mikowals,2021-Q4,0,0,0
-mikowals,2021-Q3,0,0,0
 mikowals,2021-Q2,0,0,0
 mikowals,2021-Q1,0,0,0
 mikowals,2020-Q4,0,0,0
@@ -51199,8 +44799,6 @@ mikowals,2018-Q4,0,0,0
 mikowals,2018-Q3,0,0,0
 mikowals,2018-Q2,0,0,0
 mikowals,2018-Q1,0,0,0
-Thijs Vogels,2021-Q4,0,0,0
-Thijs Vogels,2021-Q3,0,0,0
 Thijs Vogels,2021-Q2,0,0,0
 Thijs Vogels,2021-Q1,0,0,0
 Thijs Vogels,2020-Q4,0,0,0
@@ -51215,8 +44813,6 @@ Thijs Vogels,2018-Q4,0,0,0
 Thijs Vogels,2018-Q3,0,0,0
 Thijs Vogels,2018-Q2,0,0,0
 Thijs Vogels,2018-Q1,0,0,0
-Ernest Grzybowski,2021-Q4,0,0,0
-Ernest Grzybowski,2021-Q3,0,0,0
 Ernest Grzybowski,2021-Q2,0,0,0
 Ernest Grzybowski,2021-Q1,0,0,0
 Ernest Grzybowski,2020-Q4,0,0,0
@@ -51231,8 +44827,6 @@ Ernest Grzybowski,2018-Q4,0,0,0
 Ernest Grzybowski,2018-Q3,0,0,0
 Ernest Grzybowski,2018-Q2,0,0,0
 Ernest Grzybowski,2018-Q1,0,0,0
-baoblackcoal,2021-Q4,0,0,0
-baoblackcoal,2021-Q3,0,0,0
 baoblackcoal,2021-Q2,0,0,0
 baoblackcoal,2021-Q1,0,0,0
 baoblackcoal,2020-Q4,0,0,0
@@ -51247,8 +44841,6 @@ baoblackcoal,2018-Q4,0,0,0
 baoblackcoal,2018-Q3,0,0,0
 baoblackcoal,2018-Q2,0,0,0
 baoblackcoal,2018-Q1,0,0,0
-Andrew Royer,2021-Q4,0,0,0
-Andrew Royer,2021-Q3,0,0,0
 Andrew Royer,2021-Q2,0,0,0
 Andrew Royer,2021-Q1,0,0,0
 Andrew Royer,2020-Q4,0,0,0
@@ -51263,8 +44855,6 @@ Andrew Royer,2018-Q4,0,0,0
 Andrew Royer,2018-Q3,0,0,0
 Andrew Royer,2018-Q2,0,0,0
 Andrew Royer,2018-Q1,0,0,0
-Gregory King,2021-Q4,0,0,0
-Gregory King,2021-Q3,0,0,0
 Gregory King,2021-Q2,0,0,0
 Gregory King,2021-Q1,0,0,0
 Gregory King,2020-Q4,0,0,0
@@ -51279,8 +44869,6 @@ Gregory King,2018-Q4,0,0,0
 Gregory King,2018-Q3,0,0,0
 Gregory King,2018-Q2,0,0,0
 Gregory King,2018-Q1,0,0,0
-Johnny Lim,2021-Q4,0,0,0
-Johnny Lim,2021-Q3,0,0,0
 Johnny Lim,2021-Q2,0,0,0
 Johnny Lim,2021-Q1,0,0,0
 Johnny Lim,2020-Q4,0,0,0
@@ -51295,8 +44883,6 @@ Johnny Lim,2018-Q4,0,0,0
 Johnny Lim,2018-Q3,0,0,0
 Johnny Lim,2018-Q2,0,0,0
 Johnny Lim,2018-Q1,0,0,0
-Charles-Emmanuel,2021-Q4,0,0,0
-Charles-Emmanuel,2021-Q3,0,0,0
 Charles-Emmanuel,2021-Q2,0,0,0
 Charles-Emmanuel,2021-Q1,0,0,0
 Charles-Emmanuel,2020-Q4,0,0,0
@@ -51311,8 +44897,6 @@ Charles-Emmanuel,2018-Q4,0,0,0
 Charles-Emmanuel,2018-Q3,0,0,0
 Charles-Emmanuel,2018-Q2,0,0,0
 Charles-Emmanuel,2018-Q1,0,0,0
-Isaac Yang,2021-Q4,0,0,0
-Isaac Yang,2021-Q3,0,0,0
 Isaac Yang,2021-Q2,0,0,0
 Isaac Yang,2021-Q1,0,0,0
 Isaac Yang,2020-Q4,0,0,0
@@ -51327,8 +44911,6 @@ Isaac Yang,2018-Q4,0,0,0
 Isaac Yang,2018-Q3,0,0,0
 Isaac Yang,2018-Q2,0,0,0
 Isaac Yang,2018-Q1,0,0,0
-Undo1,2021-Q4,0,0,0
-Undo1,2021-Q3,0,0,0
 Undo1,2021-Q2,0,0,0
 Undo1,2021-Q1,0,0,0
 Undo1,2020-Q4,0,0,0
@@ -51343,8 +44925,6 @@ Undo1,2018-Q4,0,0,0
 Undo1,2018-Q3,0,0,0
 Undo1,2018-Q2,0,0,0
 Undo1,2018-Q1,0,0,0
-Dylan Paiton,2021-Q4,0,0,0
-Dylan Paiton,2021-Q3,0,0,0
 Dylan Paiton,2021-Q2,0,0,0
 Dylan Paiton,2021-Q1,0,0,0
 Dylan Paiton,2020-Q4,0,0,0
@@ -51359,8 +44939,6 @@ Dylan Paiton,2018-Q4,0,0,0
 Dylan Paiton,2018-Q3,0,0,0
 Dylan Paiton,2018-Q2,0,0,0
 Dylan Paiton,2018-Q1,0,0,0
-Jesper Steen Møller,2021-Q4,0,0,0
-Jesper Steen Møller,2021-Q3,0,0,0
 Jesper Steen Møller,2021-Q2,0,0,0
 Jesper Steen Møller,2021-Q1,0,0,0
 Jesper Steen Møller,2020-Q4,0,0,0
@@ -51375,8 +44953,6 @@ Jesper Steen Møller,2018-Q4,0,0,0
 Jesper Steen Møller,2018-Q3,0,0,0
 Jesper Steen Møller,2018-Q2,0,0,0
 Jesper Steen Møller,2018-Q1,0,0,0
-Orion Reblitz-Richardson,2021-Q4,0,0,0
-Orion Reblitz-Richardson,2021-Q3,0,0,0
 Orion Reblitz-Richardson,2021-Q2,0,0,0
 Orion Reblitz-Richardson,2021-Q1,0,0,0
 Orion Reblitz-Richardson,2020-Q4,0,0,0
@@ -51391,8 +44967,6 @@ Orion Reblitz-Richardson,2018-Q4,0,0,0
 Orion Reblitz-Richardson,2018-Q3,0,0,0
 Orion Reblitz-Richardson,2018-Q2,0,0,0
 Orion Reblitz-Richardson,2018-Q1,0,0,0
-Robert Rose,2021-Q4,0,0,0
-Robert Rose,2021-Q3,0,0,0
 Robert Rose,2021-Q2,0,0,0
 Robert Rose,2021-Q1,0,0,0
 Robert Rose,2020-Q4,0,0,0
@@ -51407,8 +44981,6 @@ Robert Rose,2018-Q4,0,0,0
 Robert Rose,2018-Q3,0,0,0
 Robert Rose,2018-Q2,0,0,0
 Robert Rose,2018-Q1,0,0,0
-Waleed,2021-Q4,0,0,0
-Waleed,2021-Q3,0,0,0
 Waleed,2021-Q2,0,0,0
 Waleed,2021-Q1,0,0,0
 Waleed,2020-Q4,0,0,0
@@ -51423,8 +44995,6 @@ Waleed,2018-Q4,0,0,0
 Waleed,2018-Q3,0,0,0
 Waleed,2018-Q2,0,0,0
 Waleed,2018-Q1,0,0,0
-Snake Charmer,2021-Q4,0,0,0
-Snake Charmer,2021-Q3,0,0,0
 Snake Charmer,2021-Q2,0,0,0
 Snake Charmer,2021-Q1,0,0,0
 Snake Charmer,2020-Q4,0,0,0
@@ -51439,8 +45009,6 @@ Snake Charmer,2018-Q4,0,0,0
 Snake Charmer,2018-Q3,0,0,0
 Snake Charmer,2018-Q2,0,0,0
 Snake Charmer,2018-Q1,0,0,0
-Yeison Rodriguez,2021-Q4,0,0,0
-Yeison Rodriguez,2021-Q3,0,0,0
 Yeison Rodriguez,2021-Q2,0,0,0
 Yeison Rodriguez,2021-Q1,0,0,0
 Yeison Rodriguez,2020-Q4,0,0,0
@@ -51455,8 +45023,6 @@ Yeison Rodriguez,2018-Q4,0,0,0
 Yeison Rodriguez,2018-Q3,0,0,0
 Yeison Rodriguez,2018-Q2,0,0,0
 Yeison Rodriguez,2018-Q1,0,0,0
-Aidan Dang,2021-Q4,0,0,0
-Aidan Dang,2021-Q3,0,0,0
 Aidan Dang,2021-Q2,0,0,0
 Aidan Dang,2021-Q1,0,0,0
 Aidan Dang,2020-Q4,0,0,0
@@ -51471,8 +45037,6 @@ Aidan Dang,2018-Q4,0,0,0
 Aidan Dang,2018-Q3,0,0,0
 Aidan Dang,2018-Q2,0,0,0
 Aidan Dang,2018-Q1,0,0,0
-Justin Harris,2021-Q4,0,0,0
-Justin Harris,2021-Q3,0,0,0
 Justin Harris,2021-Q2,0,0,0
 Justin Harris,2021-Q1,0,0,0
 Justin Harris,2020-Q4,0,0,0
@@ -51487,8 +45051,6 @@ Justin Harris,2018-Q4,0,0,0
 Justin Harris,2018-Q3,0,0,0
 Justin Harris,2018-Q2,0,0,0
 Justin Harris,2018-Q1,0,0,0
-Maxim Grechkin,2021-Q4,0,0,0
-Maxim Grechkin,2021-Q3,0,0,0
 Maxim Grechkin,2021-Q2,0,0,0
 Maxim Grechkin,2021-Q1,0,0,0
 Maxim Grechkin,2020-Q4,0,0,0
@@ -51503,8 +45065,6 @@ Maxim Grechkin,2018-Q4,0,0,0
 Maxim Grechkin,2018-Q3,0,0,0
 Maxim Grechkin,2018-Q2,0,0,0
 Maxim Grechkin,2018-Q1,0,0,0
-Felix Maximilian Möller,2021-Q4,0,0,0
-Felix Maximilian Möller,2021-Q3,0,0,0
 Felix Maximilian Möller,2021-Q2,0,0,0
 Felix Maximilian Möller,2021-Q1,0,0,0
 Felix Maximilian Möller,2020-Q4,0,0,0
@@ -51519,8 +45079,6 @@ Felix Maximilian Möller,2018-Q4,0,0,0
 Felix Maximilian Möller,2018-Q3,0,0,0
 Felix Maximilian Möller,2018-Q2,0,0,0
 Felix Maximilian Möller,2018-Q1,0,0,0
-Robert DiPietro,2021-Q4,0,0,0
-Robert DiPietro,2021-Q3,0,0,0
 Robert DiPietro,2021-Q2,0,0,0
 Robert DiPietro,2021-Q1,0,0,0
 Robert DiPietro,2020-Q4,0,0,0
@@ -51535,8 +45093,6 @@ Robert DiPietro,2018-Q4,0,0,0
 Robert DiPietro,2018-Q3,0,0,0
 Robert DiPietro,2018-Q2,0,0,0
 Robert DiPietro,2018-Q1,0,0,0
-Sung Kim,2021-Q4,0,0,0
-Sung Kim,2021-Q3,0,0,0
 Sung Kim,2021-Q2,0,0,0
 Sung Kim,2021-Q1,0,0,0
 Sung Kim,2020-Q4,0,0,0
@@ -51551,8 +45107,6 @@ Sung Kim,2018-Q4,0,0,0
 Sung Kim,2018-Q3,0,0,0
 Sung Kim,2018-Q2,0,0,0
 Sung Kim,2018-Q1,0,0,0
-Kristina,2021-Q4,0,0,0
-Kristina,2021-Q3,0,0,0
 Kristina,2021-Q2,0,0,0
 Kristina,2021-Q1,0,0,0
 Kristina,2020-Q4,0,0,0
@@ -51567,8 +45121,6 @@ Kristina,2018-Q4,0,0,0
 Kristina,2018-Q3,0,0,0
 Kristina,2018-Q2,0,0,0
 Kristina,2018-Q1,0,0,0
-Akihiko ITOH,2021-Q4,0,0,0
-Akihiko ITOH,2021-Q3,0,0,0
 Akihiko ITOH,2021-Q2,0,0,0
 Akihiko ITOH,2021-Q1,0,0,0
 Akihiko ITOH,2020-Q4,0,0,0
@@ -51583,8 +45135,6 @@ Akihiko ITOH,2018-Q4,0,0,0
 Akihiko ITOH,2018-Q3,0,0,0
 Akihiko ITOH,2018-Q2,0,0,0
 Akihiko ITOH,2018-Q1,0,0,0
-Kevin Robinson,2021-Q4,0,0,0
-Kevin Robinson,2021-Q3,0,0,0
 Kevin Robinson,2021-Q2,0,0,0
 Kevin Robinson,2021-Q1,0,0,0
 Kevin Robinson,2020-Q4,0,0,0
@@ -51599,8 +45149,6 @@ Kevin Robinson,2018-Q4,0,0,0
 Kevin Robinson,2018-Q3,0,0,0
 Kevin Robinson,2018-Q2,0,0,0
 Kevin Robinson,2018-Q1,0,0,0
-Clement Courbet,2021-Q4,0,0,0
-Clement Courbet,2021-Q3,0,0,0
 Clement Courbet,2021-Q2,0,0,0
 Clement Courbet,2021-Q1,0,0,0
 Clement Courbet,2020-Q4,0,0,0
@@ -51615,8 +45163,6 @@ Clement Courbet,2018-Q4,0,0,0
 Clement Courbet,2018-Q3,0,0,0
 Clement Courbet,2018-Q2,0,0,0
 Clement Courbet,2018-Q1,0,0,0
-Łukasz Bieniasz-Krzywiec,2021-Q4,0,0,0
-Łukasz Bieniasz-Krzywiec,2021-Q3,0,0,0
 Łukasz Bieniasz-Krzywiec,2021-Q2,0,0,0
 Łukasz Bieniasz-Krzywiec,2021-Q1,0,0,0
 Łukasz Bieniasz-Krzywiec,2020-Q4,0,0,0
@@ -51631,8 +45177,6 @@ Clement Courbet,2018-Q1,0,0,0
 Łukasz Bieniasz-Krzywiec,2018-Q3,0,0,0
 Łukasz Bieniasz-Krzywiec,2018-Q2,0,0,0
 Łukasz Bieniasz-Krzywiec,2018-Q1,0,0,0
-Victor Melo,2021-Q4,0,0,0
-Victor Melo,2021-Q3,0,0,0
 Victor Melo,2021-Q2,0,0,0
 Victor Melo,2021-Q1,0,0,0
 Victor Melo,2020-Q4,0,0,0
@@ -51647,8 +45191,6 @@ Victor Melo,2018-Q4,0,0,0
 Victor Melo,2018-Q3,0,0,0
 Victor Melo,2018-Q2,0,0,0
 Victor Melo,2018-Q1,0,0,0
-Mario Cho,2021-Q4,0,0,0
-Mario Cho,2021-Q3,0,0,0
 Mario Cho,2021-Q2,0,0,0
 Mario Cho,2021-Q1,0,0,0
 Mario Cho,2020-Q4,0,0,0
@@ -51663,8 +45205,6 @@ Mario Cho,2018-Q4,0,0,0
 Mario Cho,2018-Q3,0,0,0
 Mario Cho,2018-Q2,0,0,0
 Mario Cho,2018-Q1,0,0,0
-Arbit Chen,2021-Q4,0,0,0
-Arbit Chen,2021-Q3,0,0,0
 Arbit Chen,2021-Q2,0,0,0
 Arbit Chen,2021-Q1,0,0,0
 Arbit Chen,2020-Q4,0,0,0
@@ -51679,8 +45219,6 @@ Arbit Chen,2018-Q4,0,0,0
 Arbit Chen,2018-Q3,0,0,0
 Arbit Chen,2018-Q2,0,0,0
 Arbit Chen,2018-Q1,0,0,0
-Zohar Jackson,2021-Q4,0,0,0
-Zohar Jackson,2021-Q3,0,0,0
 Zohar Jackson,2021-Q2,0,0,0
 Zohar Jackson,2021-Q1,0,0,0
 Zohar Jackson,2020-Q4,0,0,0
@@ -51695,8 +45233,6 @@ Zohar Jackson,2018-Q4,0,0,0
 Zohar Jackson,2018-Q3,0,0,0
 Zohar Jackson,2018-Q2,0,0,0
 Zohar Jackson,2018-Q1,0,0,0
-Mostafa Rahmani,2021-Q4,0,0,0
-Mostafa Rahmani,2021-Q3,0,0,0
 Mostafa Rahmani,2021-Q2,0,0,0
 Mostafa Rahmani,2021-Q1,0,0,0
 Mostafa Rahmani,2020-Q4,0,0,0
@@ -51711,8 +45247,6 @@ Mostafa Rahmani,2018-Q4,0,0,0
 Mostafa Rahmani,2018-Q3,0,0,0
 Mostafa Rahmani,2018-Q2,0,0,0
 Mostafa Rahmani,2018-Q1,0,0,0
-hunkim,2021-Q4,0,0,0
-hunkim,2021-Q3,0,0,0
 hunkim,2021-Q2,0,0,0
 hunkim,2021-Q1,0,0,0
 hunkim,2020-Q4,0,0,0
@@ -51727,8 +45261,6 @@ hunkim,2018-Q4,0,0,0
 hunkim,2018-Q3,0,0,0
 hunkim,2018-Q2,0,0,0
 hunkim,2018-Q1,0,0,0
-Stephen Roller,2021-Q4,0,0,0
-Stephen Roller,2021-Q3,0,0,0
 Stephen Roller,2021-Q2,0,0,0
 Stephen Roller,2021-Q1,0,0,0
 Stephen Roller,2020-Q4,0,0,0
@@ -51743,8 +45275,6 @@ Stephen Roller,2018-Q4,0,0,0
 Stephen Roller,2018-Q3,0,0,0
 Stephen Roller,2018-Q2,0,0,0
 Stephen Roller,2018-Q1,0,0,0
-Michael Heilman,2021-Q4,0,0,0
-Michael Heilman,2021-Q3,0,0,0
 Michael Heilman,2021-Q2,0,0,0
 Michael Heilman,2021-Q1,0,0,0
 Michael Heilman,2020-Q4,0,0,0
@@ -51759,8 +45289,6 @@ Michael Heilman,2018-Q4,0,0,0
 Michael Heilman,2018-Q3,0,0,0
 Michael Heilman,2018-Q2,0,0,0
 Michael Heilman,2018-Q1,0,0,0
-Paul Tucker,2021-Q4,0,0,0
-Paul Tucker,2021-Q3,0,0,0
 Paul Tucker,2021-Q2,0,0,0
 Paul Tucker,2021-Q1,0,0,0
 Paul Tucker,2020-Q4,0,0,0
@@ -51775,8 +45303,6 @@ Paul Tucker,2018-Q4,0,0,0
 Paul Tucker,2018-Q3,0,0,0
 Paul Tucker,2018-Q2,0,0,0
 Paul Tucker,2018-Q1,0,0,0
-Aziz Alto,2021-Q4,0,0,0
-Aziz Alto,2021-Q3,0,0,0
 Aziz Alto,2021-Q2,0,0,0
 Aziz Alto,2021-Q1,0,0,0
 Aziz Alto,2020-Q4,0,0,0
@@ -51791,8 +45317,6 @@ Aziz Alto,2018-Q4,0,0,0
 Aziz Alto,2018-Q3,0,0,0
 Aziz Alto,2018-Q2,0,0,0
 Aziz Alto,2018-Q1,0,0,0
-ninotoshi,2021-Q4,0,0,0
-ninotoshi,2021-Q3,0,0,0
 ninotoshi,2021-Q2,0,0,0
 ninotoshi,2021-Q1,0,0,0
 ninotoshi,2020-Q4,0,0,0
@@ -51807,8 +45331,6 @@ ninotoshi,2018-Q4,0,0,0
 ninotoshi,2018-Q3,0,0,0
 ninotoshi,2018-Q2,0,0,0
 ninotoshi,2018-Q1,0,0,0
-Ville Kallioniemi,2021-Q4,0,0,0
-Ville Kallioniemi,2021-Q3,0,0,0
 Ville Kallioniemi,2021-Q2,0,0,0
 Ville Kallioniemi,2021-Q1,0,0,0
 Ville Kallioniemi,2020-Q4,0,0,0
@@ -51823,8 +45345,6 @@ Ville Kallioniemi,2018-Q4,0,0,0
 Ville Kallioniemi,2018-Q3,0,0,0
 Ville Kallioniemi,2018-Q2,0,0,0
 Ville Kallioniemi,2018-Q1,0,0,0
-Lucas Moura,2021-Q4,0,0,0
-Lucas Moura,2021-Q3,0,0,0
 Lucas Moura,2021-Q2,0,0,0
 Lucas Moura,2021-Q1,0,0,0
 Lucas Moura,2020-Q4,0,0,0
@@ -51839,8 +45359,6 @@ Lucas Moura,2018-Q4,0,0,0
 Lucas Moura,2018-Q3,0,0,0
 Lucas Moura,2018-Q2,0,0,0
 Lucas Moura,2018-Q1,0,0,0
-Kannappan Sirchabesan,2021-Q4,0,0,0
-Kannappan Sirchabesan,2021-Q3,0,0,0
 Kannappan Sirchabesan,2021-Q2,0,0,0
 Kannappan Sirchabesan,2021-Q1,0,0,0
 Kannappan Sirchabesan,2020-Q4,0,0,0
@@ -51855,8 +45373,6 @@ Kannappan Sirchabesan,2018-Q4,0,0,0
 Kannappan Sirchabesan,2018-Q3,0,0,0
 Kannappan Sirchabesan,2018-Q2,0,0,0
 Kannappan Sirchabesan,2018-Q1,0,0,0
-ry,2021-Q4,0,0,0
-ry,2021-Q3,0,0,0
 ry,2021-Q2,0,0,0
 ry,2021-Q1,0,0,0
 ry,2020-Q4,0,0,0
@@ -51871,8 +45387,6 @@ ry,2018-Q4,0,0,0
 ry,2018-Q3,0,0,0
 ry,2018-Q2,0,0,0
 ry,2018-Q1,0,0,0
-Fabien Benureau,2021-Q4,0,0,0
-Fabien Benureau,2021-Q3,0,0,0
 Fabien Benureau,2021-Q2,0,0,0
 Fabien Benureau,2021-Q1,0,0,0
 Fabien Benureau,2020-Q4,0,0,0
@@ -51887,8 +45401,6 @@ Fabien Benureau,2018-Q4,0,0,0
 Fabien Benureau,2018-Q3,0,0,0
 Fabien Benureau,2018-Q2,0,0,0
 Fabien Benureau,2018-Q1,0,0,0
-Vladislav,2021-Q4,0,0,0
-Vladislav,2021-Q3,0,0,0
 Vladislav,2021-Q2,0,0,0
 Vladislav,2021-Q1,0,0,0
 Vladislav,2020-Q4,0,0,0
@@ -51903,8 +45415,6 @@ Vladislav,2018-Q4,0,0,0
 Vladislav,2018-Q3,0,0,0
 Vladislav,2018-Q2,0,0,0
 Vladislav,2018-Q1,0,0,0
-SeongJae Park,2021-Q4,0,0,0
-SeongJae Park,2021-Q3,0,0,0
 SeongJae Park,2021-Q2,0,0,0
 SeongJae Park,2021-Q1,0,0,0
 SeongJae Park,2020-Q4,0,0,0
@@ -51919,8 +45429,6 @@ SeongJae Park,2018-Q4,0,0,0
 SeongJae Park,2018-Q3,0,0,0
 SeongJae Park,2018-Q2,0,0,0
 SeongJae Park,2018-Q1,0,0,0
-Dan Aloni,2021-Q4,0,0,0
-Dan Aloni,2021-Q3,0,0,0
 Dan Aloni,2021-Q2,0,0,0
 Dan Aloni,2021-Q1,0,0,0
 Dan Aloni,2020-Q4,0,0,0
@@ -51935,8 +45443,6 @@ Dan Aloni,2018-Q4,0,0,0
 Dan Aloni,2018-Q3,0,0,0
 Dan Aloni,2018-Q2,0,0,0
 Dan Aloni,2018-Q1,0,0,0
-ross,2021-Q4,0,0,0
-ross,2021-Q3,0,0,0
 ross,2021-Q2,0,0,0
 ross,2021-Q1,0,0,0
 ross,2020-Q4,0,0,0
@@ -51951,8 +45457,6 @@ ross,2018-Q4,0,0,0
 ross,2018-Q3,0,0,0
 ross,2018-Q2,0,0,0
 ross,2018-Q1,0,0,0
-Fred Bertsch,2021-Q4,0,0,0
-Fred Bertsch,2021-Q3,0,0,0
 Fred Bertsch,2021-Q2,0,0,0
 Fred Bertsch,2021-Q1,0,0,0
 Fred Bertsch,2020-Q4,0,0,0
@@ -51967,8 +45471,6 @@ Fred Bertsch,2018-Q4,0,0,0
 Fred Bertsch,2018-Q3,0,0,0
 Fred Bertsch,2018-Q2,0,0,0
 Fred Bertsch,2018-Q1,0,0,0
-kchen92,2021-Q4,0,0,0
-kchen92,2021-Q3,0,0,0
 kchen92,2021-Q2,0,0,0
 kchen92,2021-Q1,0,0,0
 kchen92,2020-Q4,0,0,0
@@ -51983,8 +45485,6 @@ kchen92,2018-Q4,0,0,0
 kchen92,2018-Q3,0,0,0
 kchen92,2018-Q2,0,0,0
 kchen92,2018-Q1,0,0,0
-e-lin,2021-Q4,0,0,0
-e-lin,2021-Q3,0,0,0
 e-lin,2021-Q2,0,0,0
 e-lin,2021-Q1,0,0,0
 e-lin,2020-Q4,0,0,0
@@ -51999,8 +45499,6 @@ e-lin,2018-Q4,0,0,0
 e-lin,2018-Q3,0,0,0
 e-lin,2018-Q2,0,0,0
 e-lin,2018-Q1,0,0,0
-Jeongkyu Shin,2021-Q4,0,0,0
-Jeongkyu Shin,2021-Q3,0,0,0
 Jeongkyu Shin,2021-Q2,0,0,0
 Jeongkyu Shin,2021-Q1,0,0,0
 Jeongkyu Shin,2020-Q4,0,0,0
@@ -52015,8 +45513,6 @@ Jeongkyu Shin,2018-Q4,0,0,0
 Jeongkyu Shin,2018-Q3,0,0,0
 Jeongkyu Shin,2018-Q2,0,0,0
 Jeongkyu Shin,2018-Q1,0,0,0
-Kai Curtis,2021-Q4,0,0,0
-Kai Curtis,2021-Q3,0,0,0
 Kai Curtis,2021-Q2,0,0,0
 Kai Curtis,2021-Q1,0,0,0
 Kai Curtis,2020-Q4,0,0,0
@@ -52031,8 +45527,6 @@ Kai Curtis,2018-Q4,0,0,0
 Kai Curtis,2018-Q3,0,0,0
 Kai Curtis,2018-Q2,0,0,0
 Kai Curtis,2018-Q1,0,0,0
-Shan Carter,2021-Q4,0,0,0
-Shan Carter,2021-Q3,0,0,0
 Shan Carter,2021-Q2,0,0,0
 Shan Carter,2021-Q1,0,0,0
 Shan Carter,2020-Q4,0,0,0
@@ -52047,8 +45541,6 @@ Shan Carter,2018-Q4,0,0,0
 Shan Carter,2018-Q3,0,0,0
 Shan Carter,2018-Q2,0,0,0
 Shan Carter,2018-Q1,0,0,0
-lahwran,2021-Q4,0,0,0
-lahwran,2021-Q3,0,0,0
 lahwran,2021-Q2,0,0,0
 lahwran,2021-Q1,0,0,0
 lahwran,2020-Q4,0,0,0
@@ -52063,8 +45555,6 @@ lahwran,2018-Q4,0,0,0
 lahwran,2018-Q3,0,0,0
 lahwran,2018-Q2,0,0,0
 lahwran,2018-Q1,0,0,0
-fredbertsch,2021-Q4,0,0,0
-fredbertsch,2021-Q3,0,0,0
 fredbertsch,2021-Q2,0,0,0
 fredbertsch,2021-Q1,0,0,0
 fredbertsch,2020-Q4,0,0,0
@@ -52079,8 +45569,6 @@ fredbertsch,2018-Q4,0,0,0
 fredbertsch,2018-Q3,0,0,0
 fredbertsch,2018-Q2,0,0,0
 fredbertsch,2018-Q1,0,0,0
-Jonas Meinertz Hansen,2021-Q4,0,0,0
-Jonas Meinertz Hansen,2021-Q3,0,0,0
 Jonas Meinertz Hansen,2021-Q2,0,0,0
 Jonas Meinertz Hansen,2021-Q1,0,0,0
 Jonas Meinertz Hansen,2020-Q4,0,0,0
@@ -52095,8 +45583,6 @@ Jonas Meinertz Hansen,2018-Q4,0,0,0
 Jonas Meinertz Hansen,2018-Q3,0,0,0
 Jonas Meinertz Hansen,2018-Q2,0,0,0
 Jonas Meinertz Hansen,2018-Q1,0,0,0
-Bas Veeling,2021-Q4,0,0,0
-Bas Veeling,2021-Q3,0,0,0
 Bas Veeling,2021-Q2,0,0,0
 Bas Veeling,2021-Q1,0,0,0
 Bas Veeling,2020-Q4,0,0,0
@@ -52111,8 +45597,6 @@ Bas Veeling,2018-Q4,0,0,0
 Bas Veeling,2018-Q3,0,0,0
 Bas Veeling,2018-Q2,0,0,0
 Bas Veeling,2018-Q1,0,0,0
-Alexander G. de G. Matthews,2021-Q4,0,0,0
-Alexander G. de G. Matthews,2021-Q3,0,0,0
 Alexander G. de G. Matthews,2021-Q2,0,0,0
 Alexander G. de G. Matthews,2021-Q1,0,0,0
 Alexander G. de G. Matthews,2020-Q4,0,0,0
@@ -52127,8 +45611,6 @@ Alexander G. de G. Matthews,2018-Q4,0,0,0
 Alexander G. de G. Matthews,2018-Q3,0,0,0
 Alexander G. de G. Matthews,2018-Q2,0,0,0
 Alexander G. de G. Matthews,2018-Q1,0,0,0
-David Dao,2021-Q4,0,0,0
-David Dao,2021-Q3,0,0,0
 David Dao,2021-Q2,0,0,0
 David Dao,2021-Q1,0,0,0
 David Dao,2020-Q4,0,0,0
@@ -52143,8 +45625,6 @@ David Dao,2018-Q4,0,0,0
 David Dao,2018-Q3,0,0,0
 David Dao,2018-Q2,0,0,0
 David Dao,2018-Q1,0,0,0
-Cheng-Lung Sung,2021-Q4,0,0,0
-Cheng-Lung Sung,2021-Q3,0,0,0
 Cheng-Lung Sung,2021-Q2,0,0,0
 Cheng-Lung Sung,2021-Q1,0,0,0
 Cheng-Lung Sung,2020-Q4,0,0,0
@@ -52159,8 +45639,6 @@ Cheng-Lung Sung,2018-Q4,0,0,0
 Cheng-Lung Sung,2018-Q3,0,0,0
 Cheng-Lung Sung,2018-Q2,0,0,0
 Cheng-Lung Sung,2018-Q1,0,0,0
-Awni Hannun,2021-Q4,0,0,0
-Awni Hannun,2021-Q3,0,0,0
 Awni Hannun,2021-Q2,0,0,0
 Awni Hannun,2021-Q1,0,0,0
 Awni Hannun,2020-Q4,0,0,0
@@ -52175,8 +45653,6 @@ Awni Hannun,2018-Q4,0,0,0
 Awni Hannun,2018-Q3,0,0,0
 Awni Hannun,2018-Q2,0,0,0
 Awni Hannun,2018-Q1,0,0,0
-Rob Culliton,2021-Q4,0,0,0
-Rob Culliton,2021-Q3,0,0,0
 Rob Culliton,2021-Q2,0,0,0
 Rob Culliton,2021-Q1,0,0,0
 Rob Culliton,2020-Q4,0,0,0
@@ -52191,8 +45667,6 @@ Rob Culliton,2018-Q4,0,0,0
 Rob Culliton,2018-Q3,0,0,0
 Rob Culliton,2018-Q2,0,0,0
 Rob Culliton,2018-Q1,0,0,0
-amchercashin,2021-Q4,0,0,0
-amchercashin,2021-Q3,0,0,0
 amchercashin,2021-Q2,0,0,0
 amchercashin,2021-Q1,0,0,0
 amchercashin,2020-Q4,0,0,0
@@ -52207,8 +45681,6 @@ amchercashin,2018-Q4,0,0,0
 amchercashin,2018-Q3,0,0,0
 amchercashin,2018-Q2,0,0,0
 amchercashin,2018-Q1,0,0,0
-Yuwen Yan,2021-Q4,0,0,0
-Yuwen Yan,2021-Q3,0,0,0
 Yuwen Yan,2021-Q2,0,0,0
 Yuwen Yan,2021-Q1,0,0,0
 Yuwen Yan,2020-Q4,0,0,0
@@ -52223,8 +45695,6 @@ Yuwen Yan,2018-Q4,0,0,0
 Yuwen Yan,2018-Q3,0,0,0
 Yuwen Yan,2018-Q2,0,0,0
 Yuwen Yan,2018-Q1,0,0,0
-ExplodingCabbage,2021-Q4,0,0,0
-ExplodingCabbage,2021-Q3,0,0,0
 ExplodingCabbage,2021-Q2,0,0,0
 ExplodingCabbage,2021-Q1,0,0,0
 ExplodingCabbage,2020-Q4,0,0,0
@@ -52239,8 +45709,6 @@ ExplodingCabbage,2018-Q4,0,0,0
 ExplodingCabbage,2018-Q3,0,0,0
 ExplodingCabbage,2018-Q2,0,0,0
 ExplodingCabbage,2018-Q1,0,0,0
-gaohuazuo,2021-Q4,0,0,0
-gaohuazuo,2021-Q3,0,0,0
 gaohuazuo,2021-Q2,0,0,0
 gaohuazuo,2021-Q1,0,0,0
 gaohuazuo,2020-Q4,0,0,0
@@ -52255,8 +45723,6 @@ gaohuazuo,2018-Q4,0,0,0
 gaohuazuo,2018-Q3,0,0,0
 gaohuazuo,2018-Q2,0,0,0
 gaohuazuo,2018-Q1,0,0,0
-Olav Nymoen,2021-Q4,0,0,0
-Olav Nymoen,2021-Q3,0,0,0
 Olav Nymoen,2021-Q2,0,0,0
 Olav Nymoen,2021-Q1,0,0,0
 Olav Nymoen,2020-Q4,0,0,0
@@ -52271,8 +45737,6 @@ Olav Nymoen,2018-Q4,0,0,0
 Olav Nymoen,2018-Q3,0,0,0
 Olav Nymoen,2018-Q2,0,0,0
 Olav Nymoen,2018-Q1,0,0,0
-Daniel Smilkov,2021-Q4,0,0,0
-Daniel Smilkov,2021-Q3,0,0,0
 Daniel Smilkov,2021-Q2,0,0,0
 Daniel Smilkov,2021-Q1,0,0,0
 Daniel Smilkov,2020-Q4,0,0,0
@@ -52287,8 +45751,6 @@ Daniel Smilkov,2018-Q4,0,0,0
 Daniel Smilkov,2018-Q3,0,0,0
 Daniel Smilkov,2018-Q2,0,0,0
 Daniel Smilkov,2018-Q1,0,0,0
-Dongjoon Hyun,2021-Q4,0,0,0
-Dongjoon Hyun,2021-Q3,0,0,0
 Dongjoon Hyun,2021-Q2,0,0,0
 Dongjoon Hyun,2021-Q1,0,0,0
 Dongjoon Hyun,2020-Q4,0,0,0
@@ -52303,8 +45765,6 @@ Dongjoon Hyun,2018-Q4,0,0,0
 Dongjoon Hyun,2018-Q3,0,0,0
 Dongjoon Hyun,2018-Q2,0,0,0
 Dongjoon Hyun,2018-Q1,0,0,0
-Kanit Wongsuphasawat,2021-Q4,0,0,0
-Kanit Wongsuphasawat,2021-Q3,0,0,0
 Kanit Wongsuphasawat,2021-Q2,0,0,0
 Kanit Wongsuphasawat,2021-Q1,0,0,0
 Kanit Wongsuphasawat,2020-Q4,0,0,0
@@ -52319,8 +45779,6 @@ Kanit Wongsuphasawat,2018-Q4,0,0,0
 Kanit Wongsuphasawat,2018-Q3,0,0,0
 Kanit Wongsuphasawat,2018-Q2,0,0,0
 Kanit Wongsuphasawat,2018-Q1,0,0,0
-Andy Kitchen,2021-Q4,0,0,0
-Andy Kitchen,2021-Q3,0,0,0
 Andy Kitchen,2021-Q2,0,0,0
 Andy Kitchen,2021-Q1,0,0,0
 Andy Kitchen,2020-Q4,0,0,0
@@ -52335,8 +45793,6 @@ Andy Kitchen,2018-Q4,0,0,0
 Andy Kitchen,2018-Q3,0,0,0
 Andy Kitchen,2018-Q2,0,0,0
 Andy Kitchen,2018-Q1,0,0,0
-Jeff Hodges,2021-Q4,0,0,0
-Jeff Hodges,2021-Q3,0,0,0
 Jeff Hodges,2021-Q2,0,0,0
 Jeff Hodges,2021-Q1,0,0,0
 Jeff Hodges,2020-Q4,0,0,0
@@ -52351,8 +45807,6 @@ Jeff Hodges,2018-Q4,0,0,0
 Jeff Hodges,2018-Q3,0,0,0
 Jeff Hodges,2018-Q2,0,0,0
 Jeff Hodges,2018-Q1,0,0,0
-znah,2021-Q4,0,0,0
-znah,2021-Q3,0,0,0
 znah,2021-Q2,0,0,0
 znah,2021-Q1,0,0,0
 znah,2020-Q4,0,0,0
@@ -52367,8 +45821,6 @@ znah,2018-Q4,0,0,0
 znah,2018-Q3,0,0,0
 znah,2018-Q2,0,0,0
 znah,2018-Q1,0,0,0
-lekaha,2021-Q4,0,0,0
-lekaha,2021-Q3,0,0,0
 lekaha,2021-Q2,0,0,0
 lekaha,2021-Q1,0,0,0
 lekaha,2020-Q4,0,0,0
@@ -52383,8 +45835,6 @@ lekaha,2018-Q4,0,0,0
 lekaha,2018-Q3,0,0,0
 lekaha,2018-Q2,0,0,0
 lekaha,2018-Q1,0,0,0
-Pedro Lopes,2021-Q4,0,0,0
-Pedro Lopes,2021-Q3,0,0,0
 Pedro Lopes,2021-Q2,0,0,0
 Pedro Lopes,2021-Q1,0,0,0
 Pedro Lopes,2020-Q4,0,0,0
@@ -52399,8 +45849,6 @@ Pedro Lopes,2018-Q4,0,0,0
 Pedro Lopes,2018-Q3,0,0,0
 Pedro Lopes,2018-Q2,0,0,0
 Pedro Lopes,2018-Q1,0,0,0
-Alexander Mordvintsev,2021-Q4,0,0,0
-Alexander Mordvintsev,2021-Q3,0,0,0
 Alexander Mordvintsev,2021-Q2,0,0,0
 Alexander Mordvintsev,2021-Q1,0,0,0
 Alexander Mordvintsev,2020-Q4,0,0,0
@@ -52415,8 +45863,6 @@ Alexander Mordvintsev,2018-Q4,0,0,0
 Alexander Mordvintsev,2018-Q3,0,0,0
 Alexander Mordvintsev,2018-Q2,0,0,0
 Alexander Mordvintsev,2018-Q1,0,0,0
-David Kretch,2021-Q4,0,0,0
-David Kretch,2021-Q3,0,0,0
 David Kretch,2021-Q2,0,0,0
 David Kretch,2021-Q1,0,0,0
 David Kretch,2020-Q4,0,0,0
@@ -52431,8 +45877,6 @@ David Kretch,2018-Q4,0,0,0
 David Kretch,2018-Q3,0,0,0
 David Kretch,2018-Q2,0,0,0
 David Kretch,2018-Q1,0,0,0
-ronrest,2021-Q4,0,0,0
-ronrest,2021-Q3,0,0,0
 ronrest,2021-Q2,0,0,0
 ronrest,2021-Q1,0,0,0
 ronrest,2020-Q4,0,0,0
@@ -52447,8 +45891,6 @@ ronrest,2018-Q4,0,0,0
 ronrest,2018-Q3,0,0,0
 ronrest,2018-Q2,0,0,0
 ronrest,2018-Q1,0,0,0
-Alan Wu,2021-Q4,0,0,0
-Alan Wu,2021-Q3,0,0,0
 Alan Wu,2021-Q2,0,0,0
 Alan Wu,2021-Q1,0,0,0
 Alan Wu,2020-Q4,0,0,0
@@ -52463,8 +45905,6 @@ Alan Wu,2018-Q4,0,0,0
 Alan Wu,2018-Q3,0,0,0
 Alan Wu,2018-Q2,0,0,0
 Alan Wu,2018-Q1,0,0,0
-panmari,2021-Q4,0,0,0
-panmari,2021-Q3,0,0,0
 panmari,2021-Q2,0,0,0
 panmari,2021-Q1,0,0,0
 panmari,2020-Q4,0,0,0
@@ -52479,8 +45919,6 @@ panmari,2018-Q4,0,0,0
 panmari,2018-Q3,0,0,0
 panmari,2018-Q2,0,0,0
 panmari,2018-Q1,0,0,0
-Jack Zhang,2021-Q4,0,0,0
-Jack Zhang,2021-Q3,0,0,0
 Jack Zhang,2021-Q2,0,0,0
 Jack Zhang,2021-Q1,0,0,0
 Jack Zhang,2020-Q4,0,0,0
@@ -52495,8 +45933,6 @@ Jack Zhang,2018-Q4,0,0,0
 Jack Zhang,2018-Q3,0,0,0
 Jack Zhang,2018-Q2,0,0,0
 Jack Zhang,2018-Q1,0,0,0
-Iblis Lin,2021-Q4,0,0,0
-Iblis Lin,2021-Q3,0,0,0
 Iblis Lin,2021-Q2,0,0,0
 Iblis Lin,2021-Q1,0,0,0
 Iblis Lin,2020-Q4,0,0,0
@@ -52511,8 +45947,6 @@ Iblis Lin,2018-Q4,0,0,0
 Iblis Lin,2018-Q3,0,0,0
 Iblis Lin,2018-Q2,0,0,0
 Iblis Lin,2018-Q1,0,0,0
-Sarath Shekkizhar,2021-Q4,0,0,0
-Sarath Shekkizhar,2021-Q3,0,0,0
 Sarath Shekkizhar,2021-Q2,0,0,0
 Sarath Shekkizhar,2021-Q1,0,0,0
 Sarath Shekkizhar,2020-Q4,0,0,0
@@ -52527,8 +45961,6 @@ Sarath Shekkizhar,2018-Q4,0,0,0
 Sarath Shekkizhar,2018-Q3,0,0,0
 Sarath Shekkizhar,2018-Q2,0,0,0
 Sarath Shekkizhar,2018-Q1,0,0,0
-papelita1234,2021-Q4,0,0,0
-papelita1234,2021-Q3,0,0,0
 papelita1234,2021-Q2,0,0,0
 papelita1234,2021-Q1,0,0,0
 papelita1234,2020-Q4,0,0,0
@@ -52543,8 +45975,6 @@ papelita1234,2018-Q4,0,0,0
 papelita1234,2018-Q3,0,0,0
 papelita1234,2018-Q2,0,0,0
 papelita1234,2018-Q1,0,0,0
-Dustin Dorroh,2021-Q4,0,0,0
-Dustin Dorroh,2021-Q3,0,0,0
 Dustin Dorroh,2021-Q2,0,0,0
 Dustin Dorroh,2021-Q1,0,0,0
 Dustin Dorroh,2020-Q4,0,0,0
@@ -52559,8 +45989,6 @@ Dustin Dorroh,2018-Q4,0,0,0
 Dustin Dorroh,2018-Q3,0,0,0
 Dustin Dorroh,2018-Q2,0,0,0
 Dustin Dorroh,2018-Q1,0,0,0
-Cameron Chen,2021-Q4,0,0,0
-Cameron Chen,2021-Q3,0,0,0
 Cameron Chen,2021-Q2,0,0,0
 Cameron Chen,2021-Q1,0,0,0
 Cameron Chen,2020-Q4,0,0,0
@@ -52575,8 +46003,6 @@ Cameron Chen,2018-Q4,0,0,0
 Cameron Chen,2018-Q3,0,0,0
 Cameron Chen,2018-Q2,0,0,0
 Cameron Chen,2018-Q1,0,0,0
-Syed Ahmed,2021-Q4,0,0,0
-Syed Ahmed,2021-Q3,0,0,0
 Syed Ahmed,2021-Q2,0,0,0
 Syed Ahmed,2021-Q1,0,0,0
 Syed Ahmed,2020-Q4,0,0,0
@@ -52591,8 +46017,6 @@ Syed Ahmed,2018-Q4,0,0,0
 Syed Ahmed,2018-Q3,0,0,0
 Syed Ahmed,2018-Q2,0,0,0
 Syed Ahmed,2018-Q1,0,0,0
-BanditCat,2021-Q4,0,0,0
-BanditCat,2021-Q3,0,0,0
 BanditCat,2021-Q2,0,0,0
 BanditCat,2021-Q1,0,0,0
 BanditCat,2020-Q4,0,0,0
@@ -52607,8 +46031,6 @@ BanditCat,2018-Q4,0,0,0
 BanditCat,2018-Q3,0,0,0
 BanditCat,2018-Q2,0,0,0
 BanditCat,2018-Q1,0,0,0
-Kenneth Mitchner,2021-Q4,0,0,0
-Kenneth Mitchner,2021-Q3,0,0,0
 Kenneth Mitchner,2021-Q2,0,0,0
 Kenneth Mitchner,2021-Q1,0,0,0
 Kenneth Mitchner,2020-Q4,0,0,0
@@ -52623,8 +46045,6 @@ Kenneth Mitchner,2018-Q4,0,0,0
 Kenneth Mitchner,2018-Q3,0,0,0
 Kenneth Mitchner,2018-Q2,0,0,0
 Kenneth Mitchner,2018-Q1,0,0,0
-Daniel Golden,2021-Q4,0,0,0
-Daniel Golden,2021-Q3,0,0,0
 Daniel Golden,2021-Q2,0,0,0
 Daniel Golden,2021-Q1,0,0,0
 Daniel Golden,2020-Q4,0,0,0
@@ -52639,8 +46059,6 @@ Daniel Golden,2018-Q4,0,0,0
 Daniel Golden,2018-Q3,0,0,0
 Daniel Golden,2018-Q2,0,0,0
 Daniel Golden,2018-Q1,0,0,0
-Vlad Zagorodniy,2021-Q4,0,0,0
-Vlad Zagorodniy,2021-Q3,0,0,0
 Vlad Zagorodniy,2021-Q2,0,0,0
 Vlad Zagorodniy,2021-Q1,0,0,0
 Vlad Zagorodniy,2020-Q4,0,0,0
@@ -52655,8 +46073,6 @@ Vlad Zagorodniy,2018-Q4,0,0,0
 Vlad Zagorodniy,2018-Q3,0,0,0
 Vlad Zagorodniy,2018-Q2,0,0,0
 Vlad Zagorodniy,2018-Q1,0,0,0
-Lucas Adams,2021-Q4,0,0,0
-Lucas Adams,2021-Q3,0,0,0
 Lucas Adams,2021-Q2,0,0,0
 Lucas Adams,2021-Q1,0,0,0
 Lucas Adams,2020-Q4,0,0,0
@@ -52671,8 +46087,6 @@ Lucas Adams,2018-Q4,0,0,0
 Lucas Adams,2018-Q3,0,0,0
 Lucas Adams,2018-Q2,0,0,0
 Lucas Adams,2018-Q1,0,0,0
-e3,2021-Q4,0,0,0
-e3,2021-Q3,0,0,0
 e3,2021-Q2,0,0,0
 e3,2021-Q1,0,0,0
 e3,2020-Q4,0,0,0
@@ -52687,8 +46101,6 @@ e3,2018-Q4,0,0,0
 e3,2018-Q3,0,0,0
 e3,2018-Q2,0,0,0
 e3,2018-Q1,0,0,0
-Yuya Kusakabe,2021-Q4,0,0,0
-Yuya Kusakabe,2021-Q3,0,0,0
 Yuya Kusakabe,2021-Q2,0,0,0
 Yuya Kusakabe,2021-Q1,0,0,0
 Yuya Kusakabe,2020-Q4,0,0,0
@@ -52703,8 +46115,6 @@ Yuya Kusakabe,2018-Q4,0,0,0
 Yuya Kusakabe,2018-Q3,0,0,0
 Yuya Kusakabe,2018-Q2,0,0,0
 Yuya Kusakabe,2018-Q1,0,0,0
-timsl,2021-Q4,0,0,0
-timsl,2021-Q3,0,0,0
 timsl,2021-Q2,0,0,0
 timsl,2021-Q1,0,0,0
 timsl,2020-Q4,0,0,0
@@ -52719,8 +46129,6 @@ timsl,2018-Q4,0,0,0
 timsl,2018-Q3,0,0,0
 timsl,2018-Q2,0,0,0
 timsl,2018-Q1,0,0,0
-Aggelos Avgerinos,2021-Q4,0,0,0
-Aggelos Avgerinos,2021-Q3,0,0,0
 Aggelos Avgerinos,2021-Q2,0,0,0
 Aggelos Avgerinos,2021-Q1,0,0,0
 Aggelos Avgerinos,2020-Q4,0,0,0
@@ -52735,8 +46143,6 @@ Aggelos Avgerinos,2018-Q4,0,0,0
 Aggelos Avgerinos,2018-Q3,0,0,0
 Aggelos Avgerinos,2018-Q2,0,0,0
 Aggelos Avgerinos,2018-Q1,0,0,0
-Pranav Sailesh Mani,2021-Q4,0,0,0
-Pranav Sailesh Mani,2021-Q3,0,0,0
 Pranav Sailesh Mani,2021-Q2,0,0,0
 Pranav Sailesh Mani,2021-Q1,0,0,0
 Pranav Sailesh Mani,2020-Q4,0,0,0
@@ -52751,8 +46157,6 @@ Pranav Sailesh Mani,2018-Q4,0,0,0
 Pranav Sailesh Mani,2018-Q3,0,0,0
 Pranav Sailesh Mani,2018-Q2,0,0,0
 Pranav Sailesh Mani,2018-Q1,0,0,0
-Isaac Hodes,2021-Q4,0,0,0
-Isaac Hodes,2021-Q3,0,0,0
 Isaac Hodes,2021-Q2,0,0,0
 Isaac Hodes,2021-Q1,0,0,0
 Isaac Hodes,2020-Q4,0,0,0
@@ -52767,8 +46171,6 @@ Isaac Hodes,2018-Q4,0,0,0
 Isaac Hodes,2018-Q3,0,0,0
 Isaac Hodes,2018-Q2,0,0,0
 Isaac Hodes,2018-Q1,0,0,0
-Michael Peteuil,2021-Q4,0,0,0
-Michael Peteuil,2021-Q3,0,0,0
 Michael Peteuil,2021-Q2,0,0,0
 Michael Peteuil,2021-Q1,0,0,0
 Michael Peteuil,2020-Q4,0,0,0
@@ -52783,8 +46185,6 @@ Michael Peteuil,2018-Q4,0,0,0
 Michael Peteuil,2018-Q3,0,0,0
 Michael Peteuil,2018-Q2,0,0,0
 Michael Peteuil,2018-Q1,0,0,0
-J Yegerlehner,2021-Q4,0,0,0
-J Yegerlehner,2021-Q3,0,0,0
 J Yegerlehner,2021-Q2,0,0,0
 J Yegerlehner,2021-Q1,0,0,0
 J Yegerlehner,2020-Q4,0,0,0
@@ -52799,8 +46199,6 @@ J Yegerlehner,2018-Q4,0,0,0
 J Yegerlehner,2018-Q3,0,0,0
 J Yegerlehner,2018-Q2,0,0,0
 J Yegerlehner,2018-Q1,0,0,0
-Konrad Magnusson,2021-Q4,0,0,0
-Konrad Magnusson,2021-Q3,0,0,0
 Konrad Magnusson,2021-Q2,0,0,0
 Konrad Magnusson,2021-Q1,0,0,0
 Konrad Magnusson,2020-Q4,0,0,0
@@ -52815,8 +46213,6 @@ Konrad Magnusson,2018-Q4,0,0,0
 Konrad Magnusson,2018-Q3,0,0,0
 Konrad Magnusson,2018-Q2,0,0,0
 Konrad Magnusson,2018-Q1,0,0,0
-Dan Van Boxel,2021-Q4,0,0,0
-Dan Van Boxel,2021-Q3,0,0,0
 Dan Van Boxel,2021-Q2,0,0,0
 Dan Van Boxel,2021-Q1,0,0,0
 Dan Van Boxel,2020-Q4,0,0,0
@@ -52831,8 +46227,6 @@ Dan Van Boxel,2018-Q4,0,0,0
 Dan Van Boxel,2018-Q3,0,0,0
 Dan Van Boxel,2018-Q2,0,0,0
 Dan Van Boxel,2018-Q1,0,0,0
-Ali Elqursh,2021-Q4,0,0,0
-Ali Elqursh,2021-Q3,0,0,0
 Ali Elqursh,2021-Q2,0,0,0
 Ali Elqursh,2021-Q1,0,0,0
 Ali Elqursh,2020-Q4,0,0,0
@@ -52847,8 +46241,6 @@ Ali Elqursh,2018-Q4,0,0,0
 Ali Elqursh,2018-Q3,0,0,0
 Ali Elqursh,2018-Q2,0,0,0
 Ali Elqursh,2018-Q1,0,0,0
-urimend,2021-Q4,0,0,0
-urimend,2021-Q3,0,0,0
 urimend,2021-Q2,0,0,0
 urimend,2021-Q1,0,0,0
 urimend,2020-Q4,0,0,0
@@ -52863,8 +46255,6 @@ urimend,2018-Q4,0,0,0
 urimend,2018-Q3,0,0,0
 urimend,2018-Q2,0,0,0
 urimend,2018-Q1,0,0,0
-liyongsea,2021-Q4,0,0,0
-liyongsea,2021-Q3,0,0,0
 liyongsea,2021-Q2,0,0,0
 liyongsea,2021-Q1,0,0,0
 liyongsea,2020-Q4,0,0,0
@@ -52879,8 +46269,6 @@ liyongsea,2018-Q4,0,0,0
 liyongsea,2018-Q3,0,0,0
 liyongsea,2018-Q2,0,0,0
 liyongsea,2018-Q1,0,0,0
-Jarek Wilkiewicz,2021-Q4,0,0,0
-Jarek Wilkiewicz,2021-Q3,0,0,0
 Jarek Wilkiewicz,2021-Q2,0,0,0
 Jarek Wilkiewicz,2021-Q1,0,0,0
 Jarek Wilkiewicz,2020-Q4,0,0,0
@@ -52895,8 +46283,6 @@ Jarek Wilkiewicz,2018-Q4,0,0,0
 Jarek Wilkiewicz,2018-Q3,0,0,0
 Jarek Wilkiewicz,2018-Q2,0,0,0
 Jarek Wilkiewicz,2018-Q1,0,0,0
-Nathan Daly,2021-Q4,0,0,0
-Nathan Daly,2021-Q3,0,0,0
 Nathan Daly,2021-Q2,0,0,0
 Nathan Daly,2021-Q1,0,0,0
 Nathan Daly,2020-Q4,0,0,0
@@ -52911,8 +46297,6 @@ Nathan Daly,2018-Q4,0,0,0
 Nathan Daly,2018-Q3,0,0,0
 Nathan Daly,2018-Q2,0,0,0
 Nathan Daly,2018-Q1,0,0,0
-Scott Graham,2021-Q4,0,0,0
-Scott Graham,2021-Q3,0,0,0
 Scott Graham,2021-Q2,0,0,0
 Scott Graham,2021-Q1,0,0,0
 Scott Graham,2020-Q4,0,0,0
@@ -52927,8 +46311,6 @@ Scott Graham,2018-Q4,0,0,0
 Scott Graham,2018-Q3,0,0,0
 Scott Graham,2018-Q2,0,0,0
 Scott Graham,2018-Q1,0,0,0
-Vesnica,2021-Q4,0,0,0
-Vesnica,2021-Q3,0,0,0
 Vesnica,2021-Q2,0,0,0
 Vesnica,2021-Q1,0,0,0
 Vesnica,2020-Q4,0,0,0
@@ -52943,8 +46325,6 @@ Vesnica,2018-Q4,0,0,0
 Vesnica,2018-Q3,0,0,0
 Vesnica,2018-Q2,0,0,0
 Vesnica,2018-Q1,0,0,0
-Wladimir Schmidt,2021-Q4,0,0,0
-Wladimir Schmidt,2021-Q3,0,0,0
 Wladimir Schmidt,2021-Q2,0,0,0
 Wladimir Schmidt,2021-Q1,0,0,0
 Wladimir Schmidt,2020-Q4,0,0,0
@@ -52959,8 +46339,6 @@ Wladimir Schmidt,2018-Q4,0,0,0
 Wladimir Schmidt,2018-Q3,0,0,0
 Wladimir Schmidt,2018-Q2,0,0,0
 Wladimir Schmidt,2018-Q1,0,0,0
-cg,2021-Q4,0,0,0
-cg,2021-Q3,0,0,0
 cg,2021-Q2,0,0,0
 cg,2021-Q1,0,0,0
 cg,2020-Q4,0,0,0
@@ -52975,8 +46353,6 @@ cg,2018-Q4,0,0,0
 cg,2018-Q3,0,0,0
 cg,2018-Q2,0,0,0
 cg,2018-Q1,0,0,0
-Singlet,2021-Q4,0,0,0
-Singlet,2021-Q3,0,0,0
 Singlet,2021-Q2,0,0,0
 Singlet,2021-Q1,0,0,0
 Singlet,2020-Q4,0,0,0
@@ -52991,8 +46367,6 @@ Singlet,2018-Q4,0,0,0
 Singlet,2018-Q3,0,0,0
 Singlet,2018-Q2,0,0,0
 Singlet,2018-Q1,0,0,0
-Isaac Turner,2021-Q4,0,0,0
-Isaac Turner,2021-Q3,0,0,0
 Isaac Turner,2021-Q2,0,0,0
 Isaac Turner,2021-Q1,0,0,0
 Isaac Turner,2020-Q4,0,0,0
@@ -53007,8 +46381,6 @@ Isaac Turner,2018-Q4,0,0,0
 Isaac Turner,2018-Q3,0,0,0
 Isaac Turner,2018-Q2,0,0,0
 Isaac Turner,2018-Q1,0,0,0
-Kenta Yonekura,2021-Q4,0,0,0
-Kenta Yonekura,2021-Q3,0,0,0
 Kenta Yonekura,2021-Q2,0,0,0
 Kenta Yonekura,2021-Q1,0,0,0
 Kenta Yonekura,2020-Q4,0,0,0
@@ -53023,8 +46395,6 @@ Kenta Yonekura,2018-Q4,0,0,0
 Kenta Yonekura,2018-Q3,0,0,0
 Kenta Yonekura,2018-Q2,0,0,0
 Kenta Yonekura,2018-Q1,0,0,0
-rizzomichaelg,2021-Q4,0,0,0
-rizzomichaelg,2021-Q3,0,0,0
 rizzomichaelg,2021-Q2,0,0,0
 rizzomichaelg,2021-Q1,0,0,0
 rizzomichaelg,2020-Q4,0,0,0
@@ -53039,8 +46409,6 @@ rizzomichaelg,2018-Q4,0,0,0
 rizzomichaelg,2018-Q3,0,0,0
 rizzomichaelg,2018-Q2,0,0,0
 rizzomichaelg,2018-Q1,0,0,0
-Frank Chu,2021-Q4,0,0,0
-Frank Chu,2021-Q3,0,0,0
 Frank Chu,2021-Q2,0,0,0
 Frank Chu,2021-Q1,0,0,0
 Frank Chu,2020-Q4,0,0,0
@@ -53055,8 +46423,6 @@ Frank Chu,2018-Q4,0,0,0
 Frank Chu,2018-Q3,0,0,0
 Frank Chu,2018-Q2,0,0,0
 Frank Chu,2018-Q1,0,0,0
-Povilas Liubauskas,2021-Q4,0,0,0
-Povilas Liubauskas,2021-Q3,0,0,0
 Povilas Liubauskas,2021-Q2,0,0,0
 Povilas Liubauskas,2021-Q1,0,0,0
 Povilas Liubauskas,2020-Q4,0,0,0
@@ -53071,8 +46437,6 @@ Povilas Liubauskas,2018-Q4,0,0,0
 Povilas Liubauskas,2018-Q3,0,0,0
 Povilas Liubauskas,2018-Q2,0,0,0
 Povilas Liubauskas,2018-Q1,0,0,0
-Mandar,2021-Q4,0,0,0
-Mandar,2021-Q3,0,0,0
 Mandar,2021-Q2,0,0,0
 Mandar,2021-Q1,0,0,0
 Mandar,2020-Q4,0,0,0
@@ -53087,8 +46451,6 @@ Mandar,2018-Q4,0,0,0
 Mandar,2018-Q3,0,0,0
 Mandar,2018-Q2,0,0,0
 Mandar,2018-Q1,0,0,0
-Moussa Taifi,2021-Q4,0,0,0
-Moussa Taifi,2021-Q3,0,0,0
 Moussa Taifi,2021-Q2,0,0,0
 Moussa Taifi,2021-Q1,0,0,0
 Moussa Taifi,2020-Q4,0,0,0
@@ -53103,8 +46465,6 @@ Moussa Taifi,2018-Q4,0,0,0
 Moussa Taifi,2018-Q3,0,0,0
 Moussa Taifi,2018-Q2,0,0,0
 Moussa Taifi,2018-Q1,0,0,0
-Lukas Krecan,2021-Q4,0,0,0
-Lukas Krecan,2021-Q3,0,0,0
 Lukas Krecan,2021-Q2,0,0,0
 Lukas Krecan,2021-Q1,0,0,0
 Lukas Krecan,2020-Q4,0,0,0
@@ -53119,8 +46479,6 @@ Lukas Krecan,2018-Q4,0,0,0
 Lukas Krecan,2018-Q3,0,0,0
 Lukas Krecan,2018-Q2,0,0,0
 Lukas Krecan,2018-Q1,0,0,0
-Chen Yu,2021-Q4,0,0,0
-Chen Yu,2021-Q3,0,0,0
 Chen Yu,2021-Q2,0,0,0
 Chen Yu,2021-Q1,0,0,0
 Chen Yu,2020-Q4,0,0,0
@@ -53135,8 +46493,6 @@ Chen Yu,2018-Q4,0,0,0
 Chen Yu,2018-Q3,0,0,0
 Chen Yu,2018-Q2,0,0,0
 Chen Yu,2018-Q1,0,0,0
-Zero Chen,2021-Q4,0,0,0
-Zero Chen,2021-Q3,0,0,0
 Zero Chen,2021-Q2,0,0,0
 Zero Chen,2021-Q1,0,0,0
 Zero Chen,2020-Q4,0,0,0
@@ -53151,8 +46507,6 @@ Zero Chen,2018-Q4,0,0,0
 Zero Chen,2018-Q3,0,0,0
 Zero Chen,2018-Q2,0,0,0
 Zero Chen,2018-Q1,0,0,0
-Takeshi Hagikura,2021-Q4,0,0,0
-Takeshi Hagikura,2021-Q3,0,0,0
 Takeshi Hagikura,2021-Q2,0,0,0
 Takeshi Hagikura,2021-Q1,0,0,0
 Takeshi Hagikura,2020-Q4,0,0,0
@@ -53167,8 +46521,6 @@ Takeshi Hagikura,2018-Q4,0,0,0
 Takeshi Hagikura,2018-Q3,0,0,0
 Takeshi Hagikura,2018-Q2,0,0,0
 Takeshi Hagikura,2018-Q1,0,0,0
-Konstantin Lopuhin,2021-Q4,0,0,0
-Konstantin Lopuhin,2021-Q3,0,0,0
 Konstantin Lopuhin,2021-Q2,0,0,0
 Konstantin Lopuhin,2021-Q1,0,0,0
 Konstantin Lopuhin,2020-Q4,0,0,0
@@ -53183,8 +46535,6 @@ Konstantin Lopuhin,2018-Q4,0,0,0
 Konstantin Lopuhin,2018-Q3,0,0,0
 Konstantin Lopuhin,2018-Q2,0,0,0
 Konstantin Lopuhin,2018-Q1,0,0,0
-Taehoon Kim,2021-Q4,0,0,0
-Taehoon Kim,2021-Q3,0,0,0
 Taehoon Kim,2021-Q2,0,0,0
 Taehoon Kim,2021-Q1,0,0,0
 Taehoon Kim,2020-Q4,0,0,0
@@ -53199,8 +46549,6 @@ Taehoon Kim,2018-Q4,0,0,0
 Taehoon Kim,2018-Q3,0,0,0
 Taehoon Kim,2018-Q2,0,0,0
 Taehoon Kim,2018-Q1,0,0,0
-Christian Jauvin,2021-Q4,0,0,0
-Christian Jauvin,2021-Q3,0,0,0
 Christian Jauvin,2021-Q2,0,0,0
 Christian Jauvin,2021-Q1,0,0,0
 Christian Jauvin,2020-Q4,0,0,0
@@ -53215,8 +46563,6 @@ Christian Jauvin,2018-Q4,0,0,0
 Christian Jauvin,2018-Q3,0,0,0
 Christian Jauvin,2018-Q2,0,0,0
 Christian Jauvin,2018-Q1,0,0,0
-jmtatsch,2021-Q4,0,0,0
-jmtatsch,2021-Q3,0,0,0
 jmtatsch,2021-Q2,0,0,0
 jmtatsch,2021-Q1,0,0,0
 jmtatsch,2020-Q4,0,0,0
@@ -53231,8 +46577,6 @@ jmtatsch,2018-Q4,0,0,0
 jmtatsch,2018-Q3,0,0,0
 jmtatsch,2018-Q2,0,0,0
 jmtatsch,2018-Q1,0,0,0
-Sagan Bolliger,2021-Q4,0,0,0
-Sagan Bolliger,2021-Q3,0,0,0
 Sagan Bolliger,2021-Q2,0,0,0
 Sagan Bolliger,2021-Q1,0,0,0
 Sagan Bolliger,2020-Q4,0,0,0
@@ -53247,8 +46591,6 @@ Sagan Bolliger,2018-Q4,0,0,0
 Sagan Bolliger,2018-Q3,0,0,0
 Sagan Bolliger,2018-Q2,0,0,0
 Sagan Bolliger,2018-Q1,0,0,0
-Andrew Dai,2021-Q4,0,0,0
-Andrew Dai,2021-Q3,0,0,0
 Andrew Dai,2021-Q2,0,0,0
 Andrew Dai,2021-Q1,0,0,0
 Andrew Dai,2020-Q4,0,0,0
@@ -53263,8 +46605,6 @@ Andrew Dai,2018-Q4,0,0,0
 Andrew Dai,2018-Q3,0,0,0
 Andrew Dai,2018-Q2,0,0,0
 Andrew Dai,2018-Q1,0,0,0
-Timothy J Laurent,2021-Q4,0,0,0
-Timothy J Laurent,2021-Q3,0,0,0
 Timothy J Laurent,2021-Q2,0,0,0
 Timothy J Laurent,2021-Q1,0,0,0
 Timothy J Laurent,2020-Q4,0,0,0
@@ -53279,8 +46619,6 @@ Timothy J Laurent,2018-Q4,0,0,0
 Timothy J Laurent,2018-Q3,0,0,0
 Timothy J Laurent,2018-Q2,0,0,0
 Timothy J Laurent,2018-Q1,0,0,0
-Andre Cruz,2021-Q4,0,0,0
-Andre Cruz,2021-Q3,0,0,0
 Andre Cruz,2021-Q2,0,0,0
 Andre Cruz,2021-Q1,0,0,0
 Andre Cruz,2020-Q4,0,0,0
@@ -53295,8 +46633,6 @@ Andre Cruz,2018-Q4,0,0,0
 Andre Cruz,2018-Q3,0,0,0
 Andre Cruz,2018-Q2,0,0,0
 Andre Cruz,2018-Q1,0,0,0
-emmjaykay,2021-Q4,0,0,0
-emmjaykay,2021-Q3,0,0,0
 emmjaykay,2021-Q2,0,0,0
 emmjaykay,2021-Q1,0,0,0
 emmjaykay,2020-Q4,0,0,0
@@ -53311,8 +46647,6 @@ emmjaykay,2018-Q4,0,0,0
 emmjaykay,2018-Q3,0,0,0
 emmjaykay,2018-Q2,0,0,0
 emmjaykay,2018-Q1,0,0,0
-nick,2021-Q4,0,0,0
-nick,2021-Q3,0,0,0
 nick,2021-Q2,0,0,0
 nick,2021-Q1,0,0,0
 nick,2020-Q4,0,0,0
@@ -53327,8 +46661,6 @@ nick,2018-Q4,0,0,0
 nick,2018-Q3,0,0,0
 nick,2018-Q2,0,0,0
 nick,2018-Q1,0,0,0
-Krishna Sankar,2021-Q4,0,0,0
-Krishna Sankar,2021-Q3,0,0,0
 Krishna Sankar,2021-Q2,0,0,0
 Krishna Sankar,2021-Q1,0,0,0
 Krishna Sankar,2020-Q4,0,0,0
@@ -53343,8 +46675,6 @@ Krishna Sankar,2018-Q4,0,0,0
 Krishna Sankar,2018-Q3,0,0,0
 Krishna Sankar,2018-Q2,0,0,0
 Krishna Sankar,2018-Q1,0,0,0
-Niklas Riekenbrauck,2021-Q4,0,0,0
-Niklas Riekenbrauck,2021-Q3,0,0,0
 Niklas Riekenbrauck,2021-Q2,0,0,0
 Niklas Riekenbrauck,2021-Q1,0,0,0
 Niklas Riekenbrauck,2020-Q4,0,0,0
@@ -53359,8 +46689,6 @@ Niklas Riekenbrauck,2018-Q4,0,0,0
 Niklas Riekenbrauck,2018-Q3,0,0,0
 Niklas Riekenbrauck,2018-Q2,0,0,0
 Niklas Riekenbrauck,2018-Q1,0,0,0
-Zhifeng Chen,2021-Q4,0,0,0
-Zhifeng Chen,2021-Q3,0,0,0
 Zhifeng Chen,2021-Q2,0,0,0
 Zhifeng Chen,2021-Q1,0,0,0
 Zhifeng Chen,2020-Q4,0,0,0
@@ -53375,8 +46703,6 @@ Zhifeng Chen,2018-Q4,0,0,0
 Zhifeng Chen,2018-Q3,0,0,0
 Zhifeng Chen,2018-Q2,0,0,0
 Zhifeng Chen,2018-Q1,0,0,0
-Eren Güven,2021-Q4,0,0,0
-Eren Güven,2021-Q3,0,0,0
 Eren Güven,2021-Q2,0,0,0
 Eren Güven,2021-Q1,0,0,0
 Eren Güven,2020-Q4,0,0,0
@@ -53391,8 +46717,6 @@ Eren Güven,2018-Q4,0,0,0
 Eren Güven,2018-Q3,0,0,0
 Eren Güven,2018-Q2,0,0,0
 Eren Güven,2018-Q1,0,0,0
-RainerWasserfuhr,2021-Q4,0,0,0
-RainerWasserfuhr,2021-Q3,0,0,0
 RainerWasserfuhr,2021-Q2,0,0,0
 RainerWasserfuhr,2021-Q1,0,0,0
 RainerWasserfuhr,2020-Q4,0,0,0
@@ -53407,8 +46731,6 @@ RainerWasserfuhr,2018-Q4,0,0,0
 RainerWasserfuhr,2018-Q3,0,0,0
 RainerWasserfuhr,2018-Q2,0,0,0
 RainerWasserfuhr,2018-Q1,0,0,0
-Naveen Sundar G,2021-Q4,0,0,0
-Naveen Sundar G,2021-Q3,0,0,0
 Naveen Sundar G,2021-Q2,0,0,0
 Naveen Sundar G,2021-Q1,0,0,0
 Naveen Sundar G,2020-Q4,0,0,0
@@ -53423,8 +46745,6 @@ Naveen Sundar G,2018-Q4,0,0,0
 Naveen Sundar G,2018-Q3,0,0,0
 Naveen Sundar G,2018-Q2,0,0,0
 Naveen Sundar G,2018-Q1,0,0,0
-Cesar Salgado,2021-Q4,0,0,0
-Cesar Salgado,2021-Q3,0,0,0
 Cesar Salgado,2021-Q2,0,0,0
 Cesar Salgado,2021-Q1,0,0,0
 Cesar Salgado,2020-Q4,0,0,0
@@ -53439,8 +46759,6 @@ Cesar Salgado,2018-Q4,0,0,0
 Cesar Salgado,2018-Q3,0,0,0
 Cesar Salgado,2018-Q2,0,0,0
 Cesar Salgado,2018-Q1,0,0,0
-Linchao Zhu,2021-Q4,0,0,0
-Linchao Zhu,2021-Q3,0,0,0
 Linchao Zhu,2021-Q2,0,0,0
 Linchao Zhu,2021-Q1,0,0,0
 Linchao Zhu,2020-Q4,0,0,0
@@ -53455,8 +46773,6 @@ Linchao Zhu,2018-Q4,0,0,0
 Linchao Zhu,2018-Q3,0,0,0
 Linchao Zhu,2018-Q2,0,0,0
 Linchao Zhu,2018-Q1,0,0,0
-Kenton Lee,2021-Q4,0,0,0
-Kenton Lee,2021-Q3,0,0,0
 Kenton Lee,2021-Q2,0,0,0
 Kenton Lee,2021-Q1,0,0,0
 Kenton Lee,2020-Q4,0,0,0
@@ -53471,8 +46787,6 @@ Kenton Lee,2018-Q4,0,0,0
 Kenton Lee,2018-Q3,0,0,0
 Kenton Lee,2018-Q2,0,0,0
 Kenton Lee,2018-Q1,0,0,0
-makseq-ubnt,2021-Q4,0,0,0
-makseq-ubnt,2021-Q3,0,0,0
 makseq-ubnt,2021-Q2,0,0,0
 makseq-ubnt,2021-Q1,0,0,0
 makseq-ubnt,2020-Q4,0,0,0
@@ -53487,8 +46801,6 @@ makseq-ubnt,2018-Q4,0,0,0
 makseq-ubnt,2018-Q3,0,0,0
 makseq-ubnt,2018-Q2,0,0,0
 makseq-ubnt,2018-Q1,0,0,0
-okoriko,2021-Q4,0,0,0
-okoriko,2021-Q3,0,0,0
 okoriko,2021-Q2,0,0,0
 okoriko,2021-Q1,0,0,0
 okoriko,2020-Q4,0,0,0
@@ -53503,8 +46815,6 @@ okoriko,2018-Q4,0,0,0
 okoriko,2018-Q3,0,0,0
 okoriko,2018-Q2,0,0,0
 okoriko,2018-Q1,0,0,0
-Yi-Lin Juang,2021-Q4,0,0,0
-Yi-Lin Juang,2021-Q3,0,0,0
 Yi-Lin Juang,2021-Q2,0,0,0
 Yi-Lin Juang,2021-Q1,0,0,0
 Yi-Lin Juang,2020-Q4,0,0,0
@@ -53519,8 +46829,6 @@ Yi-Lin Juang,2018-Q4,0,0,0
 Yi-Lin Juang,2018-Q3,0,0,0
 Yi-Lin Juang,2018-Q2,0,0,0
 Yi-Lin Juang,2018-Q1,0,0,0
-Joao Felipe Santos,2021-Q4,0,0,0
-Joao Felipe Santos,2021-Q3,0,0,0
 Joao Felipe Santos,2021-Q2,0,0,0
 Joao Felipe Santos,2021-Q1,0,0,0
 Joao Felipe Santos,2020-Q4,0,0,0
@@ -53535,8 +46843,6 @@ Joao Felipe Santos,2018-Q4,0,0,0
 Joao Felipe Santos,2018-Q3,0,0,0
 Joao Felipe Santos,2018-Q2,0,0,0
 Joao Felipe Santos,2018-Q1,0,0,0
-Carl Vondrick,2021-Q4,0,0,0
-Carl Vondrick,2021-Q3,0,0,0
 Carl Vondrick,2021-Q2,0,0,0
 Carl Vondrick,2021-Q1,0,0,0
 Carl Vondrick,2020-Q4,0,0,0
@@ -53551,8 +46857,6 @@ Carl Vondrick,2018-Q4,0,0,0
 Carl Vondrick,2018-Q3,0,0,0
 Carl Vondrick,2018-Q2,0,0,0
 Carl Vondrick,2018-Q1,0,0,0
-Nicolas Fauchereau,2021-Q4,0,0,0
-Nicolas Fauchereau,2021-Q3,0,0,0
 Nicolas Fauchereau,2021-Q2,0,0,0
 Nicolas Fauchereau,2021-Q1,0,0,0
 Nicolas Fauchereau,2020-Q4,0,0,0
@@ -53567,8 +46871,6 @@ Nicolas Fauchereau,2018-Q4,0,0,0
 Nicolas Fauchereau,2018-Q3,0,0,0
 Nicolas Fauchereau,2018-Q2,0,0,0
 Nicolas Fauchereau,2018-Q1,0,0,0
-Yangqing Jia,2021-Q4,0,0,0
-Yangqing Jia,2021-Q3,0,0,0
 Yangqing Jia,2021-Q2,0,0,0
 Yangqing Jia,2021-Q1,0,0,0
 Yangqing Jia,2020-Q4,0,0,0
@@ -53583,8 +46885,6 @@ Yangqing Jia,2018-Q4,0,0,0
 Yangqing Jia,2018-Q3,0,0,0
 Yangqing Jia,2018-Q2,0,0,0
 Yangqing Jia,2018-Q1,0,0,0
-Bart Coppens,2021-Q4,0,0,0
-Bart Coppens,2021-Q3,0,0,0
 Bart Coppens,2021-Q2,0,0,0
 Bart Coppens,2021-Q1,0,0,0
 Bart Coppens,2020-Q4,0,0,0
@@ -53599,8 +46899,6 @@ Bart Coppens,2018-Q4,0,0,0
 Bart Coppens,2018-Q3,0,0,0
 Bart Coppens,2018-Q2,0,0,0
 Bart Coppens,2018-Q1,0,0,0
-Dan Vanderkam,2021-Q4,0,0,0
-Dan Vanderkam,2021-Q3,0,0,0
 Dan Vanderkam,2021-Q2,0,0,0
 Dan Vanderkam,2021-Q1,0,0,0
 Dan Vanderkam,2020-Q4,0,0,0
@@ -53615,8 +46913,6 @@ Dan Vanderkam,2018-Q4,0,0,0
 Dan Vanderkam,2018-Q3,0,0,0
 Dan Vanderkam,2018-Q2,0,0,0
 Dan Vanderkam,2018-Q1,0,0,0
-MarkDaoust,2021-Q4,0,0,0
-MarkDaoust,2021-Q3,0,0,0
 MarkDaoust,2021-Q2,0,0,0
 MarkDaoust,2021-Q1,0,0,0
 MarkDaoust,2020-Q4,0,0,0
@@ -53631,8 +46927,6 @@ MarkDaoust,2018-Q4,0,0,0
 MarkDaoust,2018-Q3,0,0,0
 MarkDaoust,2018-Q2,0,0,0
 MarkDaoust,2018-Q1,0,0,0
-Jim Fleming,2021-Q4,0,0,0
-Jim Fleming,2021-Q3,0,0,0
 Jim Fleming,2021-Q2,0,0,0
 Jim Fleming,2021-Q1,0,0,0
 Jim Fleming,2020-Q4,0,0,0
@@ -53647,8 +46941,6 @@ Jim Fleming,2018-Q4,0,0,0
 Jim Fleming,2018-Q3,0,0,0
 Jim Fleming,2018-Q2,0,0,0
 Jim Fleming,2018-Q1,0,0,0
-Zachary Lipton,2021-Q4,0,0,0
-Zachary Lipton,2021-Q3,0,0,0
 Zachary Lipton,2021-Q2,0,0,0
 Zachary Lipton,2021-Q1,0,0,0
 Zachary Lipton,2020-Q4,0,0,0
@@ -53663,8 +46955,6 @@ Zachary Lipton,2018-Q4,0,0,0
 Zachary Lipton,2018-Q3,0,0,0
 Zachary Lipton,2018-Q2,0,0,0
 Zachary Lipton,2018-Q1,0,0,0
-Olivier Grisel,2021-Q4,0,0,0
-Olivier Grisel,2021-Q3,0,0,0
 Olivier Grisel,2021-Q2,0,0,0
 Olivier Grisel,2021-Q1,0,0,0
 Olivier Grisel,2020-Q4,0,0,0
@@ -53679,8 +46969,6 @@ Olivier Grisel,2018-Q4,0,0,0
 Olivier Grisel,2018-Q3,0,0,0
 Olivier Grisel,2018-Q2,0,0,0
 Olivier Grisel,2018-Q1,0,0,0
-jalammar,2021-Q4,0,0,0
-jalammar,2021-Q3,0,0,0
 jalammar,2021-Q2,0,0,0
 jalammar,2021-Q1,0,0,0
 jalammar,2020-Q4,0,0,0
@@ -53695,8 +46983,6 @@ jalammar,2018-Q4,0,0,0
 jalammar,2018-Q3,0,0,0
 jalammar,2018-Q2,0,0,0
 jalammar,2018-Q1,0,0,0
-aymericdamien,2021-Q4,0,0,0
-aymericdamien,2021-Q3,0,0,0
 aymericdamien,2021-Q2,0,0,0
 aymericdamien,2021-Q1,0,0,0
 aymericdamien,2020-Q4,0,0,0
@@ -53711,8 +46997,6 @@ aymericdamien,2018-Q4,0,0,0
 aymericdamien,2018-Q3,0,0,0
 aymericdamien,2018-Q2,0,0,0
 aymericdamien,2018-Q1,0,0,0
-Vlad Zavidovych,2021-Q4,0,0,0
-Vlad Zavidovych,2021-Q3,0,0,0
 Vlad Zavidovych,2021-Q2,0,0,0
 Vlad Zavidovych,2021-Q1,0,0,0
 Vlad Zavidovych,2020-Q4,0,0,0
@@ -53727,8 +47011,6 @@ Vlad Zavidovych,2018-Q4,0,0,0
 Vlad Zavidovych,2018-Q3,0,0,0
 Vlad Zavidovych,2018-Q2,0,0,0
 Vlad Zavidovych,2018-Q1,0,0,0
-Joshi,2021-Q4,0,0,0
-Joshi,2021-Q3,0,0,0
 Joshi,2021-Q2,0,0,0
 Joshi,2021-Q1,0,0,0
 Joshi,2020-Q4,0,0,0
@@ -53743,8 +47025,6 @@ Joshi,2018-Q4,0,0,0
 Joshi,2018-Q3,0,0,0
 Joshi,2018-Q2,0,0,0
 Joshi,2018-Q1,0,0,0
-Akiomi KAMAKURA,2021-Q4,0,0,0
-Akiomi KAMAKURA,2021-Q3,0,0,0
 Akiomi KAMAKURA,2021-Q2,0,0,0
 Akiomi KAMAKURA,2021-Q1,0,0,0
 Akiomi KAMAKURA,2020-Q4,0,0,0
@@ -53759,8 +47039,6 @@ Akiomi KAMAKURA,2018-Q4,0,0,0
 Akiomi KAMAKURA,2018-Q3,0,0,0
 Akiomi KAMAKURA,2018-Q2,0,0,0
 Akiomi KAMAKURA,2018-Q1,0,0,0
-Nick Sweeting,2021-Q4,0,0,0
-Nick Sweeting,2021-Q3,0,0,0
 Nick Sweeting,2021-Q2,0,0,0
 Nick Sweeting,2021-Q1,0,0,0
 Nick Sweeting,2020-Q4,0,0,0
@@ -53775,8 +47053,6 @@ Nick Sweeting,2018-Q4,0,0,0
 Nick Sweeting,2018-Q3,0,0,0
 Nick Sweeting,2018-Q2,0,0,0
 Nick Sweeting,2018-Q1,0,0,0
-Vlad Frolov,2021-Q4,0,0,0
-Vlad Frolov,2021-Q3,0,0,0
 Vlad Frolov,2021-Q2,0,0,0
 Vlad Frolov,2021-Q1,0,0,0
 Vlad Frolov,2020-Q4,0,0,0
@@ -53791,8 +47067,6 @@ Vlad Frolov,2018-Q4,0,0,0
 Vlad Frolov,2018-Q3,0,0,0
 Vlad Frolov,2018-Q2,0,0,0
 Vlad Frolov,2018-Q1,0,0,0
-Bernardo Pires,2021-Q4,0,0,0
-Bernardo Pires,2021-Q3,0,0,0
 Bernardo Pires,2021-Q2,0,0,0
 Bernardo Pires,2021-Q1,0,0,0
 Bernardo Pires,2020-Q4,0,0,0
@@ -53807,8 +47081,6 @@ Bernardo Pires,2018-Q4,0,0,0
 Bernardo Pires,2018-Q3,0,0,0
 Bernardo Pires,2018-Q2,0,0,0
 Bernardo Pires,2018-Q1,0,0,0
-Denny Britz,2021-Q4,0,0,0
-Denny Britz,2021-Q3,0,0,0
 Denny Britz,2021-Q2,0,0,0
 Denny Britz,2021-Q1,0,0,0
 Denny Britz,2020-Q4,0,0,0
@@ -53823,8 +47095,6 @@ Denny Britz,2018-Q4,0,0,0
 Denny Britz,2018-Q3,0,0,0
 Denny Britz,2018-Q2,0,0,0
 Denny Britz,2018-Q1,0,0,0
-prolearner,2021-Q4,0,0,0
-prolearner,2021-Q3,0,0,0
 prolearner,2021-Q2,0,0,0
 prolearner,2021-Q1,0,0,0
 prolearner,2020-Q4,0,0,0
@@ -53839,8 +47109,6 @@ prolearner,2018-Q4,0,0,0
 prolearner,2018-Q3,0,0,0
 prolearner,2018-Q2,0,0,0
 prolearner,2018-Q1,0,0,0
-ivallesp,2021-Q4,0,0,0
-ivallesp,2021-Q3,0,0,0
 ivallesp,2021-Q2,0,0,0
 ivallesp,2021-Q1,0,0,0
 ivallesp,2020-Q4,0,0,0
@@ -53855,8 +47123,6 @@ ivallesp,2018-Q4,0,0,0
 ivallesp,2018-Q3,0,0,0
 ivallesp,2018-Q2,0,0,0
 ivallesp,2018-Q1,0,0,0
-Alex Vig,2021-Q4,0,0,0
-Alex Vig,2021-Q3,0,0,0
 Alex Vig,2021-Q2,0,0,0
 Alex Vig,2021-Q1,0,0,0
 Alex Vig,2020-Q4,0,0,0
@@ -53871,8 +47137,6 @@ Alex Vig,2018-Q4,0,0,0
 Alex Vig,2018-Q3,0,0,0
 Alex Vig,2018-Q2,0,0,0
 Alex Vig,2018-Q1,0,0,0
-Mark Borgerding,2021-Q4,0,0,0
-Mark Borgerding,2021-Q3,0,0,0
 Mark Borgerding,2021-Q2,0,0,0
 Mark Borgerding,2021-Q1,0,0,0
 Mark Borgerding,2020-Q4,0,0,0
@@ -53887,8 +47151,6 @@ Mark Borgerding,2018-Q4,0,0,0
 Mark Borgerding,2018-Q3,0,0,0
 Mark Borgerding,2018-Q2,0,0,0
 Mark Borgerding,2018-Q1,0,0,0
-arahuja,2021-Q4,0,0,0
-arahuja,2021-Q3,0,0,0
 arahuja,2021-Q2,0,0,0
 arahuja,2021-Q1,0,0,0
 arahuja,2020-Q4,0,0,0
@@ -53903,8 +47165,6 @@ arahuja,2018-Q4,0,0,0
 arahuja,2018-Q3,0,0,0
 arahuja,2018-Q2,0,0,0
 arahuja,2018-Q1,0,0,0
-Jeff Hammerbacher,2021-Q4,0,0,0
-Jeff Hammerbacher,2021-Q3,0,0,0
 Jeff Hammerbacher,2021-Q2,0,0,0
 Jeff Hammerbacher,2021-Q1,0,0,0
 Jeff Hammerbacher,2020-Q4,0,0,0
@@ -53919,8 +47179,6 @@ Jeff Hammerbacher,2018-Q4,0,0,0
 Jeff Hammerbacher,2018-Q3,0,0,0
 Jeff Hammerbacher,2018-Q2,0,0,0
 Jeff Hammerbacher,2018-Q1,0,0,0
-dresimpelo,2021-Q4,0,0,0
-dresimpelo,2021-Q3,0,0,0
 dresimpelo,2021-Q2,0,0,0
 dresimpelo,2021-Q1,0,0,0
 dresimpelo,2020-Q4,0,0,0
@@ -53935,8 +47193,6 @@ dresimpelo,2018-Q4,0,0,0
 dresimpelo,2018-Q3,0,0,0
 dresimpelo,2018-Q2,0,0,0
 dresimpelo,2018-Q1,0,0,0
-William Dmitri Breaden Madden,2021-Q4,0,0,0
-William Dmitri Breaden Madden,2021-Q3,0,0,0
 William Dmitri Breaden Madden,2021-Q2,0,0,0
 William Dmitri Breaden Madden,2021-Q1,0,0,0
 William Dmitri Breaden Madden,2020-Q4,0,0,0
@@ -53951,8 +47207,6 @@ William Dmitri Breaden Madden,2018-Q4,0,0,0
 William Dmitri Breaden Madden,2018-Q3,0,0,0
 William Dmitri Breaden Madden,2018-Q2,0,0,0
 William Dmitri Breaden Madden,2018-Q1,0,0,0
-Dave Decker,2021-Q4,0,0,0
-Dave Decker,2021-Q3,0,0,0
 Dave Decker,2021-Q2,0,0,0
 Dave Decker,2021-Q1,0,0,0
 Dave Decker,2020-Q4,0,0,0
@@ -53967,8 +47221,6 @@ Dave Decker,2018-Q4,0,0,0
 Dave Decker,2018-Q3,0,0,0
 Dave Decker,2018-Q2,0,0,0
 Dave Decker,2018-Q1,0,0,0
-Boris Daskalov,2021-Q4,0,0,0
-Boris Daskalov,2021-Q3,0,0,0
 Boris Daskalov,2021-Q2,0,0,0
 Boris Daskalov,2021-Q1,0,0,0
 Boris Daskalov,2020-Q4,0,0,0
@@ -53983,8 +47235,6 @@ Boris Daskalov,2018-Q4,0,0,0
 Boris Daskalov,2018-Q3,0,0,0
 Boris Daskalov,2018-Q2,0,0,0
 Boris Daskalov,2018-Q1,0,0,0
-Christopher Bonnett,2021-Q4,0,0,0
-Christopher Bonnett,2021-Q3,0,0,0
 Christopher Bonnett,2021-Q2,0,0,0
 Christopher Bonnett,2021-Q1,0,0,0
 Christopher Bonnett,2020-Q4,0,0,0

--- a/js/js_bumpchart.js
+++ b/js/js_bumpchart.js
@@ -9,8 +9,6 @@ function bumpchart() {
     // margin = Object {left: 105, right: 105, top: 20, bottom: 50}
     margin = ({left: 150, right: 150, top: 20, bottom: 50});
 
-    //const compact = drawingStyle === "compact";
-
     data = [];
     d3.csv("../data/git-log-tensorflow-stat-v2.csv", function(row){
         data.push({
@@ -100,12 +98,7 @@ function bumpchart() {
 
         // title = f(g)
         title = g => g.append("title")
-            .text((g, i) => `${d.Name} - ${Quarters[i]}\nRank: ${d.File_Changed.rank + 1}\nFile_Changed: ${d.File_Changed}`);
-
-        // strokeWidth = f(i)
-        strokeWidth = d3.scaleOrdinal()
-            .domain(["default", "transit", "compact"])
-            .range([5, bumpRadius * 2 + 2, 2]);
+            .text((d, i) => `${d.Name} - ${Quarters[i]}\nRank: ${d.File_Changed.rank + 1}\nFile_Changed: ${d.File_Changed.File_Changed}`);
 
         // seq = f(start, length)
         seq = (start, length) => Array.apply(null, {length: length}).map((d, i) => i + start);
@@ -146,7 +139,6 @@ function bumpchart() {
             .domain(seq(0, ranking.length));
 
         const svg = d3.select("div#bump-chart")
-            //.create("svg")
             .append("svg")
             .attr("cursor", "default")
             .attr("viewBox", [0, 0, width, height]);
@@ -183,7 +175,6 @@ function bumpchart() {
         series.selectAll("path")
             .data(d => d)
             .join("path")
-            //.attr("stroke-width", strokeWidth(drawingStyle))
             .attr("d", (d, i) => {
                 if ((d) && (d.next))
                     return d3.line()([[bx(i), by(d.rank)], [bx(i + 1), by(d.next.rank)]]);
@@ -202,25 +193,19 @@ function bumpchart() {
                     return `translate(${bx(i)}, ${by(d.File_Changed.rank)})`
                 }
             })
-            //.call(g => g.append("title").text((d, i) => `${d.Name} - ${Quarters[i]}\n${d.File_Changed}`));
-            //.call("title");
+            .call(title);
 
         bumps.append("circle")
-            //.attr("r", compact ? 5 : bumpRadius);
             .attr("r", bumpRadius);
 
         bumps.append("text")
-            //.attr("dy", compact ? "-0.75em" : "0.35em")
-            //.attr("fill", compact ? null : "white")
+            .attr("dy", "0.35em")
+            .attr("fill", "white")
             .attr("stroke", "none")
             .attr("text-anchor", "middle")
             .style("font-weight", "bold")
             .style("font-size", "14px")
-            .text(d => {
-                if (d.File_Changed) {
-                    return d.File_Changed.rank + 1;
-                }
-            });
+            .text(d => d.File_Changed.rank + 1);
 
         svg.append("g")
             .call(g => drawAxis(g, 0, height - margin.top - margin.bottom + padding, d3.axisBottom(ax), true));


### PR DESCRIPTION
2021年的Q3和Q4因為還沒到所以內容都是0，而且排序也會跟2021的Q2一樣，所以我把這兩個也刪掉了